### PR TITLE
Add core-component-page when pushing to gh-pages

### DIFF
--- a/bin/gp.sh
+++ b/bin/gp.sh
@@ -33,6 +33,14 @@ echo "{
 " > .bowerrc
 bower install --save $org/$repo#$branch
 
+# add core-component-page
+echo "Adding core-component-page..."
+cd components
+mkdir core-component-page && cd core-component-page
+wget https://raw.githubusercontent.com/Polymer/core-component-page/master/core-component-page.html
+cd ..
+cd ..
+
 # redirect by default to the component folder
 echo "<META http-equiv="refresh" content=\"0;URL=components/$repo/\">" >index.html
 


### PR DESCRIPTION
Currently the core-component-page is not loaded in components
and thus page gets a "Failed to fetch resource" error. Adding it
to bower is not an option as it would polute the dependencies.
Cloning the entire repository wasn't a good idea either because
it would have to be registerd as a git submodule -
https://help.github.com/articles/page-build-failed-missing-submodule
