### PR TITLE
Remove `sudo: false` from the sample Travis files?

### DIFF
--- a/travis/sample-travis-with-sauce.yml
+++ b/travis/sample-travis-with-sauce.yml
@@ -1,5 +1,4 @@
 language: node_js
-sudo: false
 node_js: stable
 addons:
   firefox: latest

--- a/travis/sample-travis-without-sauce.yml
+++ b/travis/sample-travis-without-sauce.yml
@@ -1,5 +1,4 @@
 language: node_js
-sudo: false
 node_js: stable
 addons:
   firefox: latest


### PR DESCRIPTION
Since the Travis sample code will [most probably](https://www.youtube.com/watch?v=afy_EEq_4Go&t=4m26s) end up in repositories recognize on or after 2015-01-01, there is no need to include `sudo: false` as that is now the default.

---

From http://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure:

> The default behavior, when no sudo usage is detected in any customizable build phases, depends on the date when the repository is first recognized by Travis CI:
>
>    * For repos we recognize before 2015-01-01, linux builds are sent to our standard infrastructure.
>    * __For repos we recognize on or after 2015-01-01, linux builds are sent to our container-based infrastructure__