### PR TITLE
Update polylint execution in travis.yml files 

### DIFF
--- a/travis/sample-travis-with-sauce.yml
+++ b/travis/sample-travis-with-sauce.yml
@@ -13,7 +13,7 @@ addons:
 before_script:
 - npm install -g bower polylint web-component-tester
 - bower install
-- polylint
 script:
+- polylint
 - xvfb-run wct
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'default'; fi

--- a/travis/sample-travis-without-sauce.yml
+++ b/travis/sample-travis-without-sauce.yml
@@ -12,5 +12,6 @@ addons:
 before_script:
 - npm install -g bower polylint web-component-tester
 - bower install
+script: 
 - polylint
-script: xvfb-run wct
+- xvfb-run wct


### PR DESCRIPTION
I moved the polylint command in both travis.yml files from the `before_script` section to the `script` section, as I suggested in my Issue #62 
