### PR TITLE
jsTransform now inlines Babel helpers by default.

### DIFF
--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-* [breaking] The `jsTransform` function will now inline any required Babel helper functions by default. Previously they were always omitted. Added `omitInlineHelpers` option to disable inlining. Note that the behavior of the build transformers from `getOptimizeStreams` continue to never inline the Babel helpers.
+* [breaking] The `jsTransform` function will now inline any required Babel helper functions by default. Previously they were always omitted. Added `externalHelpers` option to disable inlining. Note that the behavior of the build transformers from `getOptimizeStreams` continue to never inline the Babel helpers.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.9] - 2018-04-05

--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* [breaking] The `jsTransform` function will now inline any required Babel helper functions by default. Previously they were always omitted. Added `omitInlineHelpers` option to disable inlining. Note that the behavior of the build transformers from `getOptimizeStreams` continue to never inline the Babel helpers.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.9] - 2018-04-05

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -620,85 +620,15 @@
         "through2": "2.0.3"
       }
     },
-    "@types/acorn": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.3.tgz",
-      "integrity": "sha512-gou/kWQkGPMZjdCKNZGDpqxLm9+ErG/pFZKPX4tvCjr0Xf4FCYYX3nAsu7aDVKJV3KUe27+mvqqyWT/9VZoM/A==",
-      "requires": {
-        "@types/estree": "0.0.38"
-      }
-    },
-    "@types/babel-generator": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.1.tgz",
-      "integrity": "sha512-nKNz9Ch4WP2TFZjQROhxqqS2SCk0OoDzGazJI6S+2sGgW9P7N4o3vluZAXFuPEnRqtz2A0vrrkK3tjQktxIlRw==",
-      "requires": {
-        "@types/babel-types": "6.25.2"
-      }
-    },
-    "@types/babel-traverse": {
-      "version": "6.25.3",
-      "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.3.tgz",
-      "integrity": "sha512-4FaulWyA7nrXPkzoukL2VmSpxCnBZwc+MgwZqO30gtHCrtaUXnoxymdYfxzf3CZN80zjtrVzKfLlZ7FPYvrhQQ==",
-      "requires": {
-        "@types/babel-types": "6.25.2"
-      }
-    },
-    "@types/babel-types": {
-      "version": "6.25.2",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
-      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA=="
-    },
-    "@types/babylon": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
-      "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
-      "requires": {
-        "@types/babel-types": "6.25.2"
-      }
-    },
     "@types/chai": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
       "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4="
     },
-    "@types/chai-subset": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
-      "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
-      "requires": {
-        "@types/chai": "3.5.2"
-      }
-    },
-    "@types/chalk": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
-      "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk="
-    },
     "@types/clean-css": {
       "version": "3.4.30",
       "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-3.4.30.tgz",
       "integrity": "sha1-AFLBNvUkgAJCjjY4s33ko5gYZB0="
-    },
-    "@types/clone": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
-      "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
-    },
-    "@types/cssbeautify": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
-      "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8="
-    },
-    "@types/doctrine": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
-      "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
-    },
-    "@types/estree": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
-      "integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA=="
     },
     "@types/events": {
       "version": "1.2.0",
@@ -787,11 +717,6 @@
         "@types/node": "6.0.103"
       }
     },
-    "@types/path-is-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
-      "integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw=="
-    },
     "@types/relateurl": {
       "version": "0.2.28",
       "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
@@ -803,14 +728,6 @@
       "integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
       "requires": {
         "@types/node": "6.0.103"
-      }
-    },
-    "@types/rollup": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@types/rollup/-/rollup-0.54.0.tgz",
-      "integrity": "sha512-oeYztLHhQ98jnr+u2cs1c3tHOGtpzrm9DJlIdEjznwoXWidUbrI+X6ib7zCkPIbB7eJ7VbbKNQ5n/bPnSg6Naw==",
-      "requires": {
-        "rollup": "0.56.5"
       }
     },
     "@types/sinon": {
@@ -859,14 +776,6 @@
         "@types/vinyl": "2.0.2"
       }
     },
-    "@types/whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
-      "requires": {
-        "@types/node": "6.0.103"
-      }
-    },
     "@types/winston": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
@@ -884,21 +793,6 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
       "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-        }
-      }
     },
     "agent-base": {
       "version": "2.1.1",
@@ -1076,44 +970,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
       "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
-    },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.5",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.5",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-        }
-      }
     },
     "babel-helper-evaluate-path": {
       "version": "0.4.0-alpha.f95869d4",
@@ -1485,21 +1341,6 @@
       "requires": {
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
-      }
-    },
-    "cancel-token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
-      "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
-      "requires": {
-        "@types/node": "4.2.23"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "4.2.23",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
-          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w=="
-        }
       }
     },
     "capture-stack-trace": {
@@ -1901,11 +1742,6 @@
         "shady-css-parser": "0.1.0"
       }
     },
-    "cssbeautify": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
-      "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2154,14 +1990,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
     },
-    "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "requires": {
-        "esutils": "2.0.2"
-      }
-    },
     "dom-urls": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
@@ -2309,15 +2137,6 @@
             "amdefine": "1.0.1"
           }
         }
-      }
-    },
-    "espree": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-      "requires": {
-        "acorn": "5.5.3",
-        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -3775,11 +3594,6 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
-    "indent": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
-      "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
-    },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -4226,11 +4040,6 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
-    "jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4458,11 +4267,6 @@
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-    },
     "lodash.template": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
@@ -4532,14 +4336,6 @@
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
         "es5-ext": "0.10.42"
-      }
-    },
-    "magic-string": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
-      "requires": {
-        "vlq": "0.2.3"
       }
     },
     "make-dir": {
@@ -5393,209 +5189,6 @@
         }
       }
     },
-    "polymer-analyzer": {
-      "version": "3.0.0-pre.21",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.21.tgz",
-      "integrity": "sha512-fi3m7EvXHBF/CazUpBeA9RG07iG4bmdIgJ3l/EPrYI/0kgntR5ot6fgLF2UzDFjrrGHEiGl+ABPrhqqdcLyM8A==",
-      "requires": {
-        "@babel/generator": "7.0.0-beta.42",
-        "@babel/traverse": "7.0.0-beta.42",
-        "@babel/types": "7.0.0-beta.42",
-        "@types/babel-generator": "6.25.1",
-        "@types/babel-traverse": "6.25.3",
-        "@types/babel-types": "6.25.2",
-        "@types/babylon": "6.16.2",
-        "@types/chai-subset": "1.3.1",
-        "@types/chalk": "0.4.31",
-        "@types/clone": "0.1.30",
-        "@types/cssbeautify": "0.3.1",
-        "@types/doctrine": "0.0.1",
-        "@types/is-windows": "0.2.0",
-        "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.103",
-        "@types/parse5": "2.2.34",
-        "@types/path-is-inside": "1.0.0",
-        "@types/resolve": "0.0.6",
-        "@types/whatwg-url": "6.4.0",
-        "babylon": "7.0.0-beta.42",
-        "cancel-token": "0.1.1",
-        "chalk": "1.1.3",
-        "clone": "2.1.2",
-        "cssbeautify": "0.3.1",
-        "doctrine": "2.1.0",
-        "dom5": "3.0.0",
-        "indent": "0.0.2",
-        "is-windows": "1.0.2",
-        "jsonschema": "1.2.2",
-        "minimatch": "3.0.4",
-        "parse5": "4.0.0",
-        "path-is-inside": "1.0.2",
-        "resolve": "1.6.0",
-        "shady-css-parser": "0.1.0",
-        "stable": "0.1.6",
-        "strip-indent": "2.0.0",
-        "vscode-uri": "1.0.3",
-        "whatwg-url": "6.4.0"
-      },
-      "dependencies": {
-        "@types/resolve": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
-          "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
-          "requires": {
-            "@types/node": "6.0.103"
-          }
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
-    "polymer-bundler": {
-      "version": "4.0.0-pre.4",
-      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.0-pre.4.tgz",
-      "integrity": "sha512-+xTbJUPrn9Ns5su8W6knfRzqNncJXVncxkjFf0aGCh6vMHFq/Nh+URIAXQnGLJMjkfvUz9qpjp+hDS0oqb4WRg==",
-      "requires": {
-        "@types/acorn": "4.0.3",
-        "@types/babel-generator": "6.25.1",
-        "@types/babel-traverse": "6.25.3",
-        "@types/rollup": "0.54.0",
-        "babel-generator": "6.26.1",
-        "babel-traverse": "6.26.0",
-        "clone": "2.1.2",
-        "command-line-args": "3.0.5",
-        "command-line-usage": "3.0.8",
-        "dom5": "2.3.0",
-        "espree": "3.5.4",
-        "magic-string": "0.22.5",
-        "mkdirp": "0.5.1",
-        "parse5": "2.2.3",
-        "polymer-analyzer": "3.0.0-pre.21",
-        "rollup": "0.56.5",
-        "source-map": "0.5.7",
-        "vscode-uri": "1.0.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.5"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.5",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "dom5": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
-          "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
-          "requires": {
-            "@types/clone": "0.1.30",
-            "@types/node": "6.0.103",
-            "@types/parse5": "2.2.34",
-            "clone": "2.1.2",
-            "parse5": "2.2.3"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "parse5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY="
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-        }
-      }
-    },
     "popsicle": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-8.2.0.tgz",
@@ -5691,11 +5284,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -6025,11 +5613,6 @@
       "requires": {
         "glob": "7.1.2"
       }
-    },
-    "rollup": {
-      "version": "0.56.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.5.tgz",
-      "integrity": "sha512-IGPk5vdWrsc4vkiW9XMeXr5QMtxmvATTttTi59w2jBQWe9G/MMQtn8teIBAj+DdK51TrpVT6P0aQUaQUlUYCJA=="
     },
     "run-sequence": {
       "version": "1.2.2",
@@ -6367,11 +5950,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "stable": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-      "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -6809,14 +6387,6 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
-      }
-    },
-    "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "requires": {
-        "punycode": "2.1.0"
       }
     },
     "trim-newlines": {
@@ -7507,35 +7077,10 @@
         }
       }
     },
-    "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
-    },
-    "vscode-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
-      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
-    },
     "walkdir": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
-    "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
-      "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
-      }
     },
     "which": {
       "version": "1.3.0",

--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -36,8 +36,6 @@ const babelPresetEs2015NoModules =
 // are small, and we have to list syntax plugins separately anyway (see below),
 // just enumerate the transform plugins here instead of merging the 3 presets.
 const babelTransformPlugins = [
-  // Don't emit helpers inline.
-  require('@babel/plugin-external-helpers'),
   // ES2016
   require('@babel/plugin-transform-exponentiation-operator'),
   // ES2017
@@ -46,6 +44,9 @@ const babelTransformPlugins = [
   require('@babel/plugin-proposal-object-rest-spread'),
   require('@babel/plugin-proposal-async-generator-functions'),
 ];
+
+// Loading this plugin removes inlined Babel helpers.
+const babelExternalHelpersPlugin = require('@babel/plugin-external-helpers');
 
 const babelTransformModulesAmd = [
   dynamicImportAmd,
@@ -75,10 +76,14 @@ const babelPresetMinify =
  */
 export interface JsTransformOptions {
   // Whether to compile JavaScript to ES5.
-  //
-  // Note that some JavaScript features may require the Babel helper polyfills,
-  // which this function will not insert and must be loaded separately.
   compileToEs5?: boolean;
+
+  // If true, do not include Babel helper functions in the output. Otherwise,
+  // any Babel helper functions that were required by this transform (e.g. ES5
+  // compilation or AMD module transformation) will be automatically included
+  // inline with this output. If you set this option, you must provide those
+  // required Babel helpers by some other means.
+  omitInlineHelpers?: boolean;
 
   // Whether to minify JavaScript.
   minify?: boolean;
@@ -142,6 +147,9 @@ export function jsTransform(js: string, options: JsTransformOptions): string {
   const plugins = [...babelSyntaxPlugins];
   const presets = [];
 
+  if (options.omitInlineHelpers) {
+    plugins.push(babelExternalHelpersPlugin);
+  }
   if (options.minify) {
     doBabel = true;
     // Minify last, so push first.

--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -83,7 +83,7 @@ export interface JsTransformOptions {
   // compilation or AMD module transformation) will be automatically included
   // inline with this output. If you set this option, you must provide those
   // required Babel helpers by some other means.
-  omitInlineHelpers?: boolean;
+  externalHelpers?: boolean;
 
   // Whether to minify JavaScript.
   minify?: boolean;
@@ -147,7 +147,7 @@ export function jsTransform(js: string, options: JsTransformOptions): string {
   const plugins = [...babelSyntaxPlugins];
   const presets = [];
 
-  if (options.omitInlineHelpers) {
+  if (options.externalHelpers) {
     plugins.push(babelExternalHelpersPlugin);
   }
   if (options.minify) {

--- a/packages/build/src/optimize-streams.ts
+++ b/packages/build/src/optimize-streams.ts
@@ -115,7 +115,7 @@ export class JsTransform extends GenericOptimizeTransform {
     const transformer = (content: string, file: File) => {
       return jsTransform(content, {
         compileToEs5: shouldCompileFile(file),
-        omitInlineHelpers: true,
+        externalHelpers: true,
         minify: shouldMinifyFile(file),
         moduleResolution: jsOptions.moduleResolution,
         filePath: file.path,
@@ -151,7 +151,7 @@ export class HtmlTransform extends GenericOptimizeTransform {
         js: {
           transformModulesToAmd,
           transformImportMeta: options.js && options.js.transformImportMeta,
-          omitInlineHelpers: true,
+          externalHelpers: true,
           // Note we don't do any other JS transforms here (like compilation),
           // because we're assuming that HtmlSplitter has run and any inline
           // scripts will be compiled in their own stream.

--- a/packages/build/src/optimize-streams.ts
+++ b/packages/build/src/optimize-streams.ts
@@ -115,6 +115,7 @@ export class JsTransform extends GenericOptimizeTransform {
     const transformer = (content: string, file: File) => {
       return jsTransform(content, {
         compileToEs5: shouldCompileFile(file),
+        omitInlineHelpers: true,
         minify: shouldMinifyFile(file),
         moduleResolution: jsOptions.moduleResolution,
         filePath: file.path,
@@ -150,6 +151,7 @@ export class HtmlTransform extends GenericOptimizeTransform {
         js: {
           transformModulesToAmd,
           transformImportMeta: options.js && options.js.transformImportMeta,
+          omitInlineHelpers: true,
           // Note we don't do any other JS transforms here (like compilation),
           // because we're assuming that HtmlSplitter has run and any inline
           // scripts will be compiled in their own stream.

--- a/packages/build/src/test/js-transform_test.ts
+++ b/packages/build/src/test/js-transform_test.ts
@@ -46,6 +46,17 @@ suite('jsTransform', () => {
     assert.equal(jsTransform('const foo = 3;\n', {}), 'const foo = 3;\n');
   });
 
+  test('includes babel helpers by default', () => {
+    const result = jsTransform('class Foo {}', {compileToEs5: true});
+    assert.include(result, 'function _classCallCheck(');
+  });
+
+  test('omits babel helpers when omitInlineHelpers is true', () => {
+    const result = jsTransform(
+        'class Foo {}', {compileToEs5: true, omitInlineHelpers: true});
+    assert.notInclude(result, 'function _classCallCheck(');
+  });
+
   suite('parse errors', () => {
     const invalidJs = ';var{';
 
@@ -88,7 +99,7 @@ suite('jsTransform', () => {
           jsTransform(js, {compileToEs5: true}),
           // Some compiled features are very verbose. Just look for the Babel
           // helper call so we know the plugin ran.
-          'babelHelpers.objectWithoutProperties');
+          'objectWithoutProperties');
     });
   });
 
@@ -100,8 +111,7 @@ suite('jsTransform', () => {
     });
 
     test('compiles to ES5', () => {
-      assert.include(
-          jsTransform(js, {compileToEs5: true}), 'babelHelpers.objectSpread');
+      assert.include(jsTransform(js, {compileToEs5: true}), 'objectSpread');
     });
   });
 
@@ -114,9 +124,7 @@ suite('jsTransform', () => {
     });
 
     test('compiles to ES5', () => {
-      assert.include(
-          jsTransform(js, {compileToEs5: true}),
-          'babelHelpers.asyncToGenerator');
+      assert.include(jsTransform(js, {compileToEs5: true}), 'asyncToGenerator');
     });
   });
 
@@ -130,8 +138,7 @@ suite('jsTransform', () => {
 
     test('compiles to ES5', () => {
       assert.include(
-          jsTransform(js, {compileToEs5: true}),
-          'babelHelpers.wrapAsyncGenerator');
+          jsTransform(js, {compileToEs5: true}), 'wrapAsyncGenerator');
     });
   });
 

--- a/packages/build/src/test/js-transform_test.ts
+++ b/packages/build/src/test/js-transform_test.ts
@@ -51,9 +51,9 @@ suite('jsTransform', () => {
     assert.include(result, 'function _classCallCheck(');
   });
 
-  test('omits babel helpers when omitInlineHelpers is true', () => {
+  test('omits babel helpers when externalHelpers is true', () => {
     const result = jsTransform(
-        'class Foo {}', {compileToEs5: true, omitInlineHelpers: true});
+        'class Foo {}', {compileToEs5: true, externalHelpers: true});
     assert.notInclude(result, 'function _classCallCheck(');
   });
 


### PR DESCRIPTION
Previously they never did. Added the `omitInlineHelpers` option to optionally disable inlining.

Addresses #987