### PR TITLE
Fix tests.

### DIFF
--- a/packages/cli/npm-shrinkwrap.json
+++ b/packages/cli/npm-shrinkwrap.json
@@ -1,8 +1,6 @@
 {
-  "name": "polymer-cli",
-  "version": "1.7.0-pre.4",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0-beta.44",
@@ -708,7 +706,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@polymer/tools-common/-/tools-common-1.0.2.tgz",
       "integrity": "sha1-CLSlF/DgGEJFxdbBVxZc97d+He0=",
-      "dev": true,
       "requires": {
         "depcheck": "0.6.9",
         "fs-extra": "2.1.2",
@@ -726,7 +723,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0"
@@ -736,7 +732,6 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
           }
@@ -823,7 +818,6 @@
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-1.7.5.tgz",
       "integrity": "sha512-PDkSRY7KltW3M60hSBlerxI8SFPXsO3AL/aRVsO4Kh9IHRW74Ih75gUuTd/aE4LSSFqypb10UIX3QzOJwBQMGQ==",
-      "dev": true,
       "requires": {
         "@types/events": "1.2.0",
         "@types/node": "6.0.65"
@@ -911,11 +905,6 @@
         }
       }
     },
-    "@types/fast-levenshtein": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.1.tgz",
-      "integrity": "sha1-OjYVzxc2Rcj8pY0FHk4ygk5L0oY="
-    },
     "@types/findup-sync": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@types/findup-sync/-/findup-sync-0.3.29.tgz",
@@ -949,7 +938,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
       "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
-      "dev": true,
       "requires": {
         "@types/node": "6.0.65"
       }
@@ -1062,8 +1050,7 @@
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
-      "dev": true
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw=="
     },
     "@types/mz": {
       "version": "0.0.31",
@@ -1297,8 +1284,7 @@
     "@types/sinon": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.3.0.tgz",
-      "integrity": "sha512-rvgY5bK5ZBRJPuJF0vJI+NC2gt+lakobTa8pnDS/oRH2gk/tooeDEel8piZA8Ng6pxq0A5QGzilIFSyashP6jw==",
-      "dev": true
+      "integrity": "sha512-rvgY5bK5ZBRJPuJF0vJI+NC2gt+lakobTa8pnDS/oRH2gk/tooeDEel8piZA8Ng6pxq0A5QGzilIFSyashP6jw=="
     },
     "@types/spdy": {
       "version": "3.4.4",
@@ -1341,8 +1327,7 @@
     "@types/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
-      "dev": true
+      "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0="
     },
     "@types/ua-parser-js": {
       "version": "0.7.32",
@@ -1450,7 +1435,6 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@types/yeoman-test/-/yeoman-test-1.7.4.tgz",
       "integrity": "sha512-nppkWxmwWX2yuvuHqWjYZOxMuhjeKJ0CK6IONDBzYiLEC7l5dQR9RMTyBqtIXKrzX7PDMQmZDsKHfWds7anI7Q==",
-      "dev": true,
       "requires": {
         "@types/events": "1.2.0",
         "@types/yeoman-generator": "1.0.4"
@@ -1464,8 +1448,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.5",
@@ -1542,14 +1525,12 @@
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
     },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -1559,8 +1540,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -1616,7 +1596,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
       "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "dev": true,
       "requires": {
         "ansi-wrap": "0.1.0"
       }
@@ -1634,8 +1613,7 @@
     "ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-      "dev": true
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
     },
     "any-promise": {
       "version": "1.3.0",
@@ -1698,14 +1676,12 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-      "dev": true
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
     },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       },
@@ -1713,8 +1689,7 @@
         "sprintf-js": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-          "dev": true
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         }
       }
     },
@@ -1752,8 +1727,7 @@
     "array-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
-      "dev": true
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -1768,8 +1742,7 @@
     "array-slice": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
-      "dev": true
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
     },
     "array-union": {
       "version": "1.0.2",
@@ -2309,8 +2282,7 @@
     "beeper": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-      "dev": true
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
     },
     "better-assert": {
       "version": "1.0.2",
@@ -2540,7 +2512,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.3.tgz",
       "integrity": "sha512-HaJnVuslRF4g2kSDeyl++AaVizoitCpL9PglzCYwy0uHHyvWerfvEb8jWmYbF1z4kiVFolGomnxSGl+GUQp2jg==",
-      "dev": true,
       "requires": {
         "readable-stream": "2.3.5"
       }
@@ -2619,7 +2590,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
       "requires": {
         "callsites": "0.2.0"
       }
@@ -2632,8 +2602,7 @@
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
     "camel-case": {
       "version": "3.0.0",
@@ -2687,7 +2656,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4",
@@ -2698,7 +2666,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true,
       "requires": {
         "assertion-error": "1.1.0",
         "deep-eql": "0.1.3",
@@ -2709,7 +2676,6 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-          "dev": true,
           "requires": {
             "type-detect": "0.1.1"
           },
@@ -2717,16 +2683,14 @@
             "type-detect": {
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-              "dev": true
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
             }
           }
         },
         "type-detect": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-          "dev": true
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
         }
       }
     },
@@ -2745,8 +2709,7 @@
     "chardet": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "charenc": {
       "version": "0.0.2",
@@ -2787,14 +2750,12 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
     },
     "clang-format": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.1.0.tgz",
       "integrity": "sha512-0Aru49uTLoROl4sPTyO3fvF/NZ+fnGEy5i7bsRwA/bAYT+eWaAxK3sDxRvm/AW7Nwq83BvARH/npeF8OIAaGVQ==",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "glob": "7.1.2",
@@ -2804,8 +2765,7 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
     },
@@ -2944,7 +2904,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
@@ -3011,8 +2970,7 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colors": {
       "version": "1.0.3",
@@ -3265,11 +3223,6 @@
         "shady-css-parser": "0.1.0"
       }
     },
-    "css-what": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
-    },
     "cssbeautify": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
@@ -3292,7 +3245,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
       "requires": {
         "es5-ext": "0.10.42"
       }
@@ -3349,14 +3301,12 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true,
       "requires": {
         "clone": "1.0.4"
       },
@@ -3364,8 +3314,7 @@
         "clone": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-          "dev": true
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         }
       }
     },
@@ -3433,7 +3382,6 @@
       "version": "0.6.9",
       "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.6.9.tgz",
       "integrity": "sha1-7+b99c8AwhcoEbwqJAPVnlNB5Rk=",
-      "dev": true,
       "requires": {
         "babel-traverse": "6.26.0",
         "babylon": "6.18.0",
@@ -3452,7 +3400,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "esutils": "2.0.2",
@@ -3463,7 +3410,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "6.23.0",
@@ -3480,7 +3426,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
@@ -3491,14 +3436,12 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
         }
       }
     },
@@ -3510,20 +3453,17 @@
     "deprecate": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
-      "integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg=",
-      "dev": true
+      "integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg="
     },
     "deprecated": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-      "dev": true
+      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
     },
     "deps-regex": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
-      "integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=",
-      "dev": true
+      "integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ="
     },
     "destroy": {
       "version": "1.0.4",
@@ -3807,7 +3747,6 @@
       "version": "0.10.42",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
       "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
-      "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
@@ -3818,7 +3757,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.42",
@@ -3829,7 +3767,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.42",
@@ -3848,7 +3785,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.42",
@@ -3861,7 +3797,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.42"
@@ -3871,7 +3806,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.42",
@@ -3893,7 +3827,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-      "dev": true,
       "requires": {
         "esprima": "2.7.3",
         "estraverse": "1.9.3",
@@ -3905,20 +3838,17 @@
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
         },
         "estraverse": {
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-          "dev": true
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
         },
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
           "optional": true,
           "requires": {
             "amdefine": "1.0.1"
@@ -3930,7 +3860,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
       "requires": {
         "es6-map": "0.1.5",
         "es6-weak-map": "2.0.2",
@@ -3942,7 +3871,6 @@
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "chalk": "1.1.3",
@@ -3985,7 +3913,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "esutils": "2.0.2",
@@ -3995,14 +3922,12 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
         },
         "inquirer": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "dev": true,
           "requires": {
             "ansi-escapes": "1.4.0",
             "ansi-regex": "2.1.1",
@@ -4022,14 +3947,12 @@
         "progress": {
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
         },
         "run-async": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
           "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-          "dev": true,
           "requires": {
             "once": "1.4.0"
           }
@@ -4037,8 +3960,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
@@ -4054,14 +3976,12 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true,
       "requires": {
         "estraverse": "4.2.0"
       }
@@ -4070,7 +3990,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "dev": true,
       "requires": {
         "estraverse": "4.2.0"
       }
@@ -4078,8 +3997,7 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
@@ -4095,7 +4013,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.42"
@@ -4303,7 +4220,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-      "dev": true,
       "requires": {
         "ansi-gray": "0.1.1",
         "color-support": "1.1.3",
@@ -4633,7 +4549,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
       "requires": {
         "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
@@ -4678,8 +4593,7 @@
     "find-index": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-      "dev": true
+      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
     },
     "find-port": {
       "version": "1.0.1",
@@ -4729,7 +4643,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
-      "dev": true,
       "requires": {
         "expand-tilde": "2.0.2",
         "is-plain-object": "2.0.4",
@@ -4742,7 +4655,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "dev": true,
           "requires": {
             "homedir-polyfill": "1.0.1"
           }
@@ -4757,14 +4669,12 @@
     "flagged-respawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
-      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
-      "dev": true
+      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c="
     },
     "flat-cache": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
       "requires": {
         "circular-json": "0.3.3",
         "del": "2.2.2",
@@ -4776,7 +4686,6 @@
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-          "dev": true,
           "requires": {
             "globby": "5.0.0",
             "is-path-cwd": "1.0.0",
@@ -4791,7 +4700,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true,
           "requires": {
             "array-union": "1.0.2",
             "arrify": "1.0.1",
@@ -4886,7 +4794,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
@@ -5690,14 +5597,12 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gaze": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "dev": true,
       "requires": {
         "globule": "0.1.0"
       }
@@ -5718,8 +5623,7 @@
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-      "dev": true
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -5897,7 +5801,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-      "dev": true,
       "requires": {
         "gaze": "0.5.2"
       }
@@ -5906,7 +5809,6 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "dev": true,
       "requires": {
         "find-index": "0.1.1"
       }
@@ -5969,7 +5871,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-      "dev": true,
       "requires": {
         "glob": "3.1.21",
         "lodash": "1.0.2",
@@ -5980,7 +5881,6 @@
           "version": "3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true,
           "requires": {
             "graceful-fs": "1.2.3",
             "inherits": "1.0.2",
@@ -5990,32 +5890,27 @@
         "graceful-fs": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-          "dev": true
+          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
         },
         "inherits": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-          "dev": true
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
         },
         "lodash": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-          "dev": true
+          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
         },
         "lru-cache": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-          "dev": true
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
         },
         "minimatch": {
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
           "requires": {
             "lru-cache": "2.7.3",
             "sigmund": "1.0.1"
@@ -6027,7 +5922,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
-      "dev": true,
       "requires": {
         "sparkles": "1.0.0"
       }
@@ -6077,7 +5971,6 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
-      "dev": true,
       "requires": {
         "archy": "1.0.0",
         "chalk": "1.1.3",
@@ -6097,14 +5990,12 @@
         "clone": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
         },
         "glob": {
           "version": "4.5.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
           "requires": {
             "inflight": "1.0.6",
             "inherits": "2.0.3",
@@ -6116,7 +6007,6 @@
           "version": "3.1.18",
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
           "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-          "dev": true,
           "requires": {
             "glob": "4.5.3",
             "glob2base": "0.0.12",
@@ -6130,7 +6020,6 @@
           "version": "3.0.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true,
           "requires": {
             "natives": "1.1.2"
           }
@@ -6138,14 +6027,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -6153,14 +6040,12 @@
         "ordered-read-streams": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-          "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-          "dev": true
+          "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -6171,20 +6056,17 @@
         "semver": {
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-          "dev": true
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
         },
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "strip-bom": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-          "dev": true,
           "requires": {
             "first-chunk-stream": "1.0.0",
             "is-utf8": "0.2.1"
@@ -6194,7 +6076,6 @@
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
           "requires": {
             "readable-stream": "1.0.34",
             "xtend": "4.0.1"
@@ -6203,14 +6084,12 @@
         "unique-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-          "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-          "dev": true
+          "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
         },
         "vinyl": {
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
           "requires": {
             "clone": "0.2.0",
             "clone-stats": "0.0.1"
@@ -6220,7 +6099,6 @@
           "version": "0.3.14",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
           "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
-          "dev": true,
           "requires": {
             "defaults": "1.0.3",
             "glob-stream": "3.1.18",
@@ -6238,7 +6116,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-3.0.1.tgz",
       "integrity": "sha1-BOV+PhjGl0JnwSz2hV3HF9SjE70=",
-      "dev": true,
       "requires": {
         "bufferstreams": "1.1.3",
         "eslint": "3.19.0",
@@ -6267,7 +6144,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-3.0.1.tgz",
       "integrity": "sha1-qwyiw5QDcYF03drXUOY6Yb4X4EE=",
-      "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
         "mocha": "3.5.3",
@@ -6293,7 +6169,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/gulp-spawn-mocha/-/gulp-spawn-mocha-3.3.1.tgz",
       "integrity": "sha512-0DoyYQ4+MmARhs6N0Yr5+Sm8K8aN0SwJoxpRl6YfWPP2nZhMLHtDx7grm7Bw5cr0VR2urkG/p36rRAbCqzaP2A==",
-      "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
         "lodash": "4.17.5",
@@ -6304,7 +6179,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/gulp-tslint/-/gulp-tslint-7.1.0.tgz",
       "integrity": "sha1-m9P/T7wW1MvZq7CP94bbibVj6T0=",
-      "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
         "map-stream": "0.1.0",
@@ -6315,7 +6189,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.4.tgz",
       "integrity": "sha512-bZosNvbUGzFA4bjjWoUPyjU5vfgJSzlYKkU0Jutbsrj+td8yvtqxethhqfzB9MwyamaUODIuidj5gIytZ523Bw==",
-      "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
         "source-map": "0.5.7",
@@ -6327,7 +6200,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/gulp-typings/-/gulp-typings-2.0.4.tgz",
       "integrity": "sha1-z7/yMGfR8sRlWqKM87g/QJMQFY8=",
-      "dev": true,
       "requires": {
         "through2": "2.0.3",
         "typings-core": "1.6.1",
@@ -6338,7 +6210,6 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-      "dev": true,
       "requires": {
         "array-differ": "1.0.0",
         "array-uniq": "1.0.3",
@@ -6363,14 +6234,12 @@
         "clone": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-          "dev": true
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         },
         "duplexer2": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
           "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-          "dev": true,
           "requires": {
             "readable-stream": "1.1.14"
           }
@@ -6378,14 +6247,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "lodash.template": {
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-          "dev": true,
           "requires": {
             "lodash._basecopy": "3.0.1",
             "lodash._basetostring": "3.0.1",
@@ -6402,7 +6269,6 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
           "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-          "dev": true,
           "requires": {
             "lodash._reinterpolate": "3.0.0",
             "lodash.escape": "3.2.0"
@@ -6412,7 +6278,6 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
           "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-          "dev": true,
           "requires": {
             "duplexer2": "0.0.2"
           }
@@ -6420,14 +6285,12 @@
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "dev": true
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -6438,14 +6301,12 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "vinyl": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-          "dev": true,
           "requires": {
             "clone": "1.0.4",
             "clone-stats": "0.0.1",
@@ -6458,7 +6319,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true,
       "requires": {
         "glogg": "1.0.1"
       }
@@ -6485,7 +6345,6 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -6496,21 +6355,18 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
           "optional": true
         },
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
           "optional": true,
           "requires": {
             "center-align": "0.1.3",
@@ -6522,7 +6378,6 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -6531,7 +6386,6 @@
           "version": "2.8.29",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
           "optional": true,
           "requires": {
             "source-map": "0.5.7",
@@ -6543,7 +6397,6 @@
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
               "optional": true
             }
           }
@@ -6552,14 +6405,12 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
           "optional": true
         },
         "yargs": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "1.2.1",
@@ -6588,7 +6439,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
       "requires": {
         "function-bind": "1.1.1"
       }
@@ -6635,7 +6485,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true,
       "requires": {
         "sparkles": "1.0.0"
       }
@@ -6794,7 +6643,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
-      "dev": true,
       "requires": {
         "agent-base": "2.1.1",
         "debug": "2.6.9",
@@ -6946,8 +6794,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ipaddr.js": {
       "version": "1.6.0",
@@ -6957,14 +6804,12 @@
     "irregular-plurals": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
-      "dev": true
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
     },
     "is-absolute": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-      "dev": true,
       "requires": {
         "is-relative": "0.2.1",
         "is-windows": "0.2.0"
@@ -7242,7 +7087,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-      "dev": true,
       "requires": {
         "is-unc-path": "0.1.2"
       }
@@ -7250,8 +7094,7 @@
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -7262,7 +7105,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
-      "dev": true,
       "requires": {
         "scoped-regex": "1.0.0"
       }
@@ -7281,7 +7123,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-      "dev": true,
       "requires": {
         "unc-path-regex": "0.1.2"
       }
@@ -7328,7 +7169,6 @@
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-      "dev": true,
       "requires": {
         "abbrev": "1.0.9",
         "async": "1.0.0",
@@ -7349,20 +7189,17 @@
         "abbrev": {
           "version": "1.0.9",
           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true
+          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
         },
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
         },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
           "requires": {
             "inflight": "1.0.6",
             "inherits": "2.0.3",
@@ -7374,14 +7211,12 @@
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
           "requires": {
             "abbrev": "1.0.9"
           }
@@ -7389,14 +7224,12 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
           "requires": {
             "has-flag": "1.0.0"
           }
@@ -7404,8 +7237,7 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
@@ -7428,7 +7260,6 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-      "dev": true,
       "requires": {
         "argparse": "1.0.10",
         "esprima": "4.0.0"
@@ -7482,7 +7313,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -7564,7 +7394,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
       "optional": true
     },
     "lazy-req": {
@@ -7584,7 +7413,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
       "requires": {
         "invert-kv": "1.0.0"
       }
@@ -7593,7 +7421,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
@@ -7603,7 +7430,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
-      "dev": true,
       "requires": {
         "extend": "3.0.1",
         "findup-sync": "2.0.0",
@@ -7618,20 +7444,17 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-          "dev": true
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "braces": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
           "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
-          "dev": true,
           "requires": {
             "arr-flatten": "1.1.0",
             "array-unique": "0.3.2",
@@ -7651,7 +7474,6 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
               }
@@ -7660,7 +7482,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -7670,14 +7491,12 @@
         "detect-file": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-          "dev": true
+          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
         },
         "expand-brackets": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-          "dev": true,
           "requires": {
             "debug": "2.6.9",
             "define-property": "0.2.5",
@@ -7692,7 +7511,6 @@
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
               }
@@ -7701,7 +7519,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -7710,7 +7527,6 @@
               "version": "0.1.6",
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "0.1.6",
                 "is-data-descriptor": "0.1.4",
@@ -7720,8 +7536,7 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             }
           }
         },
@@ -7729,7 +7544,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "dev": true,
           "requires": {
             "homedir-polyfill": "1.0.1"
           }
@@ -7738,7 +7552,6 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
           "requires": {
             "array-unique": "0.3.2",
             "define-property": "1.0.0",
@@ -7754,7 +7567,6 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
               "requires": {
                 "is-descriptor": "1.0.2"
               }
@@ -7763,7 +7575,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -7774,7 +7585,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
           "requires": {
             "extend-shallow": "2.0.1",
             "is-number": "3.0.0",
@@ -7786,7 +7596,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
               "requires": {
                 "is-extendable": "0.1.1"
               }
@@ -7797,7 +7606,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
-          "dev": true,
           "requires": {
             "detect-file": "1.0.0",
             "is-glob": "3.1.0",
@@ -7809,7 +7617,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-          "dev": true,
           "requires": {
             "global-prefix": "1.0.2",
             "is-windows": "1.0.2",
@@ -7820,7 +7627,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
           "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-          "dev": true,
           "requires": {
             "expand-tilde": "2.0.2",
             "homedir-polyfill": "1.0.1",
@@ -7833,7 +7639,6 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -7842,7 +7647,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
               }
@@ -7853,7 +7657,6 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -7862,7 +7665,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
               }
@@ -7872,14 +7674,12 @@
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-glob": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
           "requires": {
             "is-extglob": "2.1.1"
           }
@@ -7888,7 +7688,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -7897,7 +7696,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
               }
@@ -7907,26 +7705,22 @@
         "is-windows": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-          "dev": true
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
             "array-unique": "0.3.2",
@@ -7947,7 +7741,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-          "dev": true,
           "requires": {
             "expand-tilde": "2.0.2",
             "global-modules": "1.0.0"
@@ -7958,8 +7751,7 @@
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
-      "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
-      "dev": true
+      "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM="
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -7992,8 +7784,7 @@
     "lockfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
-      "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
-      "dev": true
+      "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
     },
     "lodash": {
       "version": "4.17.5",
@@ -8022,14 +7813,12 @@
     "lodash._basetostring": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-      "dev": true
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
     },
     "lodash._basevalues": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "dev": true
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -8044,14 +7833,12 @@
     "lodash._reescape": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-      "dev": true
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-      "dev": true
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -8061,8 +7848,7 @@
     "lodash._root": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-      "dev": true
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
     },
     "lodash.create": {
       "version": "3.1.1",
@@ -8083,7 +7869,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true,
       "requires": {
         "lodash._root": "3.0.1"
       }
@@ -8121,8 +7906,7 @@
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "dev": true
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
     },
     "lodash.some": {
       "version": "4.6.0",
@@ -8167,8 +7951,7 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -8232,14 +8015,12 @@
     "make-error": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
-      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
-      "dev": true
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
     },
     "make-error-cause": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
-      "dev": true,
       "requires": {
         "make-error": "1.3.4"
       }
@@ -8248,7 +8029,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.0.tgz",
       "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -8266,8 +8046,7 @@
     "map-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-      "dev": true
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -8304,7 +8083,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.2.0"
       }
@@ -8377,7 +8155,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
       "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
-      "dev": true,
       "requires": {
         "readable-stream": "1.0.34"
       },
@@ -8385,14 +8162,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -8403,8 +8178,7 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -8489,8 +8263,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -8737,14 +8510,12 @@
     "natives": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.2.tgz",
-      "integrity": "sha512-5bRASydE1gu6zPOenLN043++J8xj1Ob7ArkfdYO3JN4DF5rDmG7bMoiybkTyD+GnXQEMixVeDHMzuqm6kpBmiA==",
-      "dev": true
+      "integrity": "sha512-5bRASydE1gu6zPOenLN043++J8xj1Ob7ArkfdYO3JN4DF5rDmG7bMoiybkTyD+GnXQEMixVeDHMzuqm6kpBmiA=="
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "negotiator": {
       "version": "0.6.1",
@@ -8759,8 +8530,7 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
       "version": "1.0.4",
@@ -8824,7 +8594,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
       "requires": {
         "abbrev": "1.1.1"
       }
@@ -8948,7 +8717,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
-      "dev": true,
       "requires": {
         "array-each": "1.0.1",
         "array-slice": "1.1.0",
@@ -8960,7 +8728,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-          "dev": true,
           "requires": {
             "for-in": "1.0.2"
           }
@@ -8968,8 +8735,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -8977,7 +8743,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
-      "dev": true,
       "requires": {
         "for-own": "1.0.0",
         "make-iterator": "1.0.0"
@@ -8987,7 +8752,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-          "dev": true,
           "requires": {
             "for-in": "1.0.2"
           }
@@ -9077,7 +8841,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
@@ -9090,8 +8853,7 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
@@ -9099,7 +8861,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-      "dev": true,
       "requires": {
         "end-of-stream": "0.1.5",
         "sequencify": "0.0.7",
@@ -9110,7 +8871,6 @@
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
           "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-          "dev": true,
           "requires": {
             "once": "1.3.3"
           }
@@ -9119,7 +8879,6 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -9144,7 +8903,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "dev": true,
       "requires": {
         "execa": "0.7.0",
         "lcid": "1.0.0",
@@ -9229,7 +8987,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
-      "dev": true,
       "requires": {
         "is-absolute": "1.0.0",
         "map-cache": "0.2.2",
@@ -9240,7 +8997,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
           "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-          "dev": true,
           "requires": {
             "is-relative": "1.0.0",
             "is-windows": "1.0.2"
@@ -9250,7 +9006,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
           "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-          "dev": true,
           "requires": {
             "is-unc-path": "1.0.0"
           }
@@ -9259,7 +9014,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
           "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-          "dev": true,
           "requires": {
             "unc-path-regex": "0.1.2"
           }
@@ -9267,8 +9021,7 @@
         "is-windows": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-          "dev": true
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         }
       }
     },
@@ -9364,7 +9117,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-      "dev": true,
       "requires": {
         "path-root-regex": "0.1.2"
       }
@@ -9372,8 +9124,7 @@
     "path-root-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
-      "dev": true
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -9470,7 +9221,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "dev": true,
       "requires": {
         "irregular-plurals": "1.4.0"
       }
@@ -9478,8 +9228,7 @@
     "pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-      "dev": true
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
     },
     "plylog": {
       "version": "0.4.0",
@@ -9804,80 +9553,6 @@
         }
       }
     },
-    "polymer-linter": {
-      "version": "3.0.0-pre.4",
-      "resolved": "https://registry.npmjs.org/polymer-linter/-/polymer-linter-3.0.0-pre.4.tgz",
-      "integrity": "sha512-TztEGDuGQgg7I9P80TobqziWrAm2u7EMEoaqry7f1L2Ti7oSzRZ820v4U/kTi9vaXNblSz/nSHw9d2D3/43Gcg==",
-      "requires": {
-        "@types/fast-levenshtein": "0.0.1",
-        "@types/parse5": "2.2.34",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "css-what": "2.1.0",
-        "dom5": "3.0.0",
-        "fast-levenshtein": "2.0.6",
-        "parse5": "4.0.0",
-        "polymer-analyzer": "3.0.0-pre.18",
-        "shady-css-parser": "0.1.0",
-        "stable": "0.1.6",
-        "strip-indent": "2.0.0",
-        "validate-element-name": "2.1.1"
-      },
-      "dependencies": {
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.5"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.5",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
-        },
-        "strip-indent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
-        }
-      }
-    },
     "polymer-project-config": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.13.0.tgz",
@@ -9908,82 +9583,10 @@
         }
       }
     },
-    "polyserve": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.27.0.tgz",
-      "integrity": "sha512-OqX/jbBks7M2qsFHAM8F3HdoN6Yu5Hgd4HhRcznJ8VpqHn/lRa0vBV9QiJvgDxBExgY40vdXW8aA5aIX7g6DYw==",
-      "requires": {
-        "@types/babylon": "6.16.2",
-        "@types/compression": "0.0.33",
-        "@types/content-type": "1.1.2",
-        "@types/escape-html": "0.0.20",
-        "@types/express": "4.11.1",
-        "@types/mime": "0.0.29",
-        "@types/mz": "0.0.29",
-        "@types/node": "8.10.2",
-        "@types/opn": "3.0.28",
-        "@types/parse5": "2.2.34",
-        "@types/pem": "1.9.3",
-        "@types/resolve": "0.0.6",
-        "@types/serve-static": "1.13.1",
-        "@types/spdy": "3.4.4",
-        "@types/ua-parser-js": "0.7.32",
-        "babylon": "6.18.0",
-        "bower-config": "1.4.1",
-        "browser-capabilities": "0.2.2",
-        "command-line-args": "3.0.5",
-        "command-line-usage": "3.0.8",
-        "compression": "1.7.2",
-        "content-type": "1.0.4",
-        "escape-html": "1.0.3",
-        "express": "4.16.3",
-        "find-port": "1.0.1",
-        "http-proxy-middleware": "0.17.4",
-        "lru-cache": "4.1.2",
-        "mime": "1.6.0",
-        "mz": "2.7.0",
-        "opn": "3.0.3",
-        "pem": "1.12.3",
-        "requirejs": "2.3.5",
-        "resolve": "1.6.0",
-        "send": "0.14.2",
-        "spdy": "3.4.7"
-      },
-      "dependencies": {
-        "@types/mz": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
-          "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
-          "requires": {
-            "@types/bluebird": "3.5.20",
-            "@types/node": "8.10.2"
-          }
-        },
-        "@types/node": {
-          "version": "8.10.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.2.tgz",
-          "integrity": "sha512-A6Uv1anbsCvrRDtaUXS2xZ5tlzD+Kg7yMRlSLFDy3z0r7KlGXDzL14vELXIAgpk2aJbU3XeZZQRcEkLkowT92g=="
-        },
-        "@types/resolve": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
-          "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
-          "requires": {
-            "@types/node": "8.10.2"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        }
-      }
-    },
     "popsicle": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-8.2.0.tgz",
       "integrity": "sha1-/0QBAFyrQ6lBipFBBhHAAZdxLSE=",
-      "dev": true,
       "requires": {
         "any-promise": "1.3.0",
         "arrify": "1.0.1",
@@ -9999,7 +9602,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-proxy-agent/-/popsicle-proxy-agent-3.0.0.tgz",
       "integrity": "sha1-uRM8VdlFdZq37mG3cRNkYg066tw=",
-      "dev": true,
       "requires": {
         "http-proxy-agent": "1.0.0",
         "https-proxy-agent": "1.0.0"
@@ -10009,7 +9611,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/popsicle-retry/-/popsicle-retry-3.2.1.tgz",
       "integrity": "sha1-4G6GZTO0KnoSPrMwy+Y6fOvLoQw=",
-      "dev": true,
       "requires": {
         "any-promise": "1.3.0",
         "xtend": "4.0.1"
@@ -10018,14 +9619,12 @@
     "popsicle-rewrite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-rewrite/-/popsicle-rewrite-1.0.0.tgz",
-      "integrity": "sha1-HdTo6pwxgjUfuCD4eTTZkvf7kAc=",
-      "dev": true
+      "integrity": "sha1-HdTo6pwxgjUfuCD4eTTZkvf7kAc="
     },
     "popsicle-status": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/popsicle-status/-/popsicle-status-2.0.1.tgz",
-      "integrity": "sha1-jdcMT+fGlBCa3XhP/oDqysHnso0=",
-      "dev": true
+      "integrity": "sha1-jdcMT+fGlBCa3XhP/oDqysHnso0="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -10035,8 +9634,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -10056,8 +9654,7 @@
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-      "dev": true
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
     "private": {
       "version": "0.1.8",
@@ -10079,7 +9676,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-2.2.1.tgz",
       "integrity": "sha1-ImFsS6kCkW6Yi9RsVNfKoIkQzXc=",
-      "dev": true,
       "requires": {
         "any-promise": "1.3.0"
       }
@@ -10279,7 +9875,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
@@ -10289,8 +9884,7 @@
         "mute-stream": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-          "dev": true
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
         }
       }
     },
@@ -10446,7 +10040,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
       "integrity": "sha1-DXOurpJm5penj3l2AZZ352rPD/8=",
-      "dev": true,
       "requires": {
         "req-from": "1.0.1"
       }
@@ -10455,7 +10048,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/req-from/-/req-from-1.0.1.tgz",
       "integrity": "sha1-v4HaUUeUfTLRO5R9wSpYrUWHNQ4=",
-      "dev": true,
       "requires": {
         "resolve-from": "2.0.0"
       },
@@ -10463,8 +10055,7 @@
         "resolve-from": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-          "dev": true
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
         }
       }
     },
@@ -10500,26 +10091,22 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "require-package-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
-      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
-      "dev": true
+      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk="
     },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
@@ -10555,8 +10142,7 @@
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -10581,7 +10167,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
@@ -10612,7 +10197,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
       "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "gulp-util": "3.0.8"
@@ -10626,14 +10210,12 @@
     "rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
       "requires": {
         "rx-lite": "3.1.2"
       }
@@ -10683,8 +10265,7 @@
     "scoped-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
-      "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
-      "dev": true
+      "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
     },
     "select-hose": {
       "version": "2.0.0",
@@ -10905,88 +10486,10 @@
         "semver": "5.5.0"
       }
     },
-    "send": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
-      "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
-      "requires": {
-        "debug": "2.2.0",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.7.0",
-        "fresh": "0.3.0",
-        "http-errors": "1.5.1",
-        "mime": "1.3.4",
-        "ms": "0.7.2",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-            }
-          }
-        },
-        "etag": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
-        },
-        "fresh": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
-        },
-        "http-errors": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-          "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-          "requires": {
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.2",
-            "statuses": "1.3.1"
-          }
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-        },
-        "setprototypeof": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-          "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-        }
-      }
-    },
     "sequencify": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-      "dev": true
+      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
     },
     "serve-static": {
       "version": "1.13.2",
@@ -11039,8 +10542,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -11104,8 +10606,7 @@
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -11116,7 +10617,6 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true,
       "requires": {
         "formatio": "1.1.1",
         "lolex": "1.3.2",
@@ -11128,7 +10628,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
           "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-          "dev": true,
           "requires": {
             "samsam": "1.1.2"
           }
@@ -11136,14 +10635,12 @@
         "lolex": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
-          "dev": true
+          "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE="
         },
         "samsam": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-          "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-          "dev": true
+          "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
         }
       }
     },
@@ -11160,8 +10657,7 @@
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
     "slide": {
       "version": "1.1.6",
@@ -11393,7 +10889,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
       "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
-      "dev": true,
       "requires": {
         "source-map": "0.6.1"
       },
@@ -11401,8 +10896,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -11414,8 +10908,7 @@
     "sparkles": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
-      "dev": true
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
     },
     "spawn-sync": {
       "version": "1.0.15",
@@ -11784,7 +11277,6 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-      "dev": true,
       "requires": {
         "ajv": "4.11.8",
         "ajv-keywords": "1.5.1",
@@ -11798,7 +11290,6 @@
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
@@ -11807,20 +11298,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -11830,7 +11318,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -11961,8 +11448,7 @@
     "throat": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
-      "dev": true
+      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
     },
     "through": {
       "version": "2.3.8",
@@ -11991,7 +11477,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/throwback/-/throwback-1.1.1.tgz",
       "integrity": "sha1-8AfnwXYEptFtegfEGqDo/txhhKQ=",
-      "dev": true,
       "requires": {
         "any-promise": "1.3.0"
       }
@@ -12000,7 +11485,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "dev": true,
       "requires": {
         "os-homedir": "1.0.2"
       }
@@ -12008,8 +11492,7 @@
     "time-stamp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-      "dev": true
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
     },
     "timed-out": {
       "version": "4.0.1",
@@ -12020,7 +11503,6 @@
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-      "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -12095,7 +11577,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
       "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
-      "dev": true,
       "requires": {
         "nopt": "1.0.10"
       }
@@ -12137,7 +11618,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tsc-then/-/tsc-then-1.1.0.tgz",
       "integrity": "sha512-830G8SK8tewOxfKVBC5YWqZ2C7wS1D4dh9267ebLxR7Gvh3UuI6aKU5Hxo+L3Kkcy6CuxZp4PMGl066DZ3Hlmw==",
-      "dev": true,
       "requires": {
         "@types/node": "8.10.1",
         "semver": "5.5.0"
@@ -12146,8 +11626,7 @@
         "@types/node": {
           "version": "8.10.1",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.1.tgz",
-          "integrity": "sha512-X/pIUOcgpX7xxKsmdPCMKeDBefsGH/4D/IuJ1gIHbqgWI0qEy/yMKeqaN/sT+rzV9UpAXAfd0kLOVExRmZrXIg==",
-          "dev": true
+          "integrity": "sha512-X/pIUOcgpX7xxKsmdPCMKeDBefsGH/4D/IuJ1gIHbqgWI0qEy/yMKeqaN/sT+rzV9UpAXAfd0kLOVExRmZrXIg=="
         }
       }
     },
@@ -12155,7 +11634,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
       "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "colors": "1.2.1",
@@ -12172,7 +11650,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -12181,7 +11658,6 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "esutils": "2.0.2",
@@ -12191,14 +11667,12 @@
         "colors": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-          "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
-          "dev": true
+          "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg=="
         },
         "findup-sync": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
           "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
-          "dev": true,
           "requires": {
             "glob": "5.0.15"
           },
@@ -12207,7 +11681,6 @@
               "version": "5.0.15",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-              "dev": true,
               "requires": {
                 "inflight": "1.0.6",
                 "inherits": "2.0.3",
@@ -12222,7 +11695,6 @@
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-          "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -12231,7 +11703,6 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
           "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
-          "dev": true,
           "requires": {
             "boxen": "1.3.0",
             "chalk": "2.3.2",
@@ -12249,7 +11720,6 @@
               "version": "2.3.2",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
               "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
@@ -12263,8 +11733,7 @@
     "tsutils": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
-      "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
-      "dev": true
+      "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -12284,7 +11753,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
       }
@@ -12311,8 +11779,7 @@
     "typescript": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
-      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
-      "dev": true
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg=="
     },
     "typical": {
       "version": "2.6.1",
@@ -12323,7 +11790,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-1.6.1.tgz",
       "integrity": "sha1-zkspMeovGbuPPay+xpmDrE6WSjc=",
-      "dev": true,
       "requires": {
         "any-promise": "1.3.0",
         "array-uniq": "1.0.3",
@@ -12363,7 +11829,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
           "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
-          "dev": true,
           "requires": {
             "dot-prop": "3.0.0",
             "graceful-fs": "4.1.11",
@@ -12380,7 +11845,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
           "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-          "dev": true,
           "requires": {
             "is-obj": "1.0.1"
           }
@@ -12388,20 +11852,17 @@
         "string-template": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
-          "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=",
-          "dev": true
+          "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y="
         },
         "uuid": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         },
         "write-file-atomic": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
@@ -12412,7 +11873,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
           "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-          "dev": true,
           "requires": {
             "os-homedir": "1.0.2"
           }
@@ -12422,8 +11882,7 @@
     "typings-global": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/typings-global/-/typings-global-1.0.28.tgz",
-      "integrity": "sha512-6VOwJWEY2971HOMHu/7sURzUXiD4/LiMJPsMAOqkHHAtS3MVpLFE5gzTiHilsH9KY5VE1mBQirWIgWFsDuo90A==",
-      "dev": true
+      "integrity": "sha512-6VOwJWEY2971HOMHu/7sURzUXiD4/LiMJPsMAOqkHHAtS3MVpLFE5gzTiHilsH9KY5VE1mBQirWIgWFsDuo90A=="
     },
     "ua-parser-js": {
       "version": "0.7.17",
@@ -12450,7 +11909,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
       "optional": true
     },
     "ultron": {
@@ -12461,8 +11919,7 @@
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-      "dev": true
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
     "underscore": {
       "version": "1.6.0",
@@ -12554,8 +12011,7 @@
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-      "dev": true
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -12813,7 +12269,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.1"
       },
@@ -12821,8 +12276,7 @@
         "inherits": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         }
       }
     },
@@ -12851,7 +12305,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true,
       "requires": {
         "user-home": "1.1.1"
       },
@@ -12859,8 +12312,7 @@
         "user-home": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-          "dev": true
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
         }
       }
     },
@@ -12985,7 +12437,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vinyl-fs-fake/-/vinyl-fs-fake-1.1.0.tgz",
       "integrity": "sha1-BfGxQrrKoUXDH6E4zi+gv9aLXwI=",
-      "dev": true,
       "requires": {
         "through2": "0.6.5",
         "vinyl": "0.4.6",
@@ -12995,14 +12446,12 @@
         "clone": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
         },
         "glob": {
           "version": "4.5.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
           "requires": {
             "inflight": "1.0.6",
             "inherits": "2.0.3",
@@ -13014,7 +12463,6 @@
           "version": "3.1.18",
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
           "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-          "dev": true,
           "requires": {
             "glob": "4.5.3",
             "glob2base": "0.0.12",
@@ -13028,7 +12476,6 @@
           "version": "3.0.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true,
           "requires": {
             "natives": "1.1.2"
           }
@@ -13036,14 +12483,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -13051,14 +12496,12 @@
         "ordered-read-streams": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-          "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-          "dev": true
+          "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -13069,14 +12512,12 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "strip-bom": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-          "dev": true,
           "requires": {
             "first-chunk-stream": "1.0.0",
             "is-utf8": "0.2.1"
@@ -13086,7 +12527,6 @@
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
           "requires": {
             "readable-stream": "1.0.34",
             "xtend": "4.0.1"
@@ -13095,14 +12535,12 @@
         "unique-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-          "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-          "dev": true
+          "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
         },
         "vinyl": {
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
           "requires": {
             "clone": "0.2.0",
             "clone-stats": "0.0.1"
@@ -13112,7 +12550,6 @@
           "version": "0.3.14",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
           "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
-          "dev": true,
           "requires": {
             "defaults": "1.0.3",
             "glob-stream": "3.1.18",
@@ -13861,8 +13298,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "widest-line": {
       "version": "2.0.0",
@@ -13905,7 +13341,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
       "optional": true
     },
     "winston": {
@@ -13941,7 +13376,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
@@ -13956,7 +13390,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
       }
@@ -14011,8 +13444,7 @@
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
       "version": "2.1.2",
@@ -14023,7 +13455,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-      "dev": true,
       "requires": {
         "camelcase": "4.1.0",
         "cliui": "3.2.0",
@@ -14043,20 +13474,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
           "requires": {
             "locate-path": "2.0.0"
           }
@@ -14064,14 +13492,12 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "parse-json": "2.2.0",
@@ -14083,7 +13509,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
           "requires": {
             "pify": "2.3.0"
           }
@@ -14092,7 +13517,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
           "requires": {
             "load-json-file": "2.0.0",
             "normalize-package-data": "2.4.0",
@@ -14103,7 +13527,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "2.0.0"
@@ -14113,7 +13536,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -14123,7 +13545,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -14131,8 +13552,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
@@ -14140,7 +13560,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-      "dev": true,
       "requires": {
         "camelcase": "4.1.0"
       },
@@ -14148,8 +13567,7 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         }
       }
     },
@@ -14171,8 +13589,7 @@
     "yeoman-assert": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-2.2.3.tgz",
-      "integrity": "sha1-pWgqg2MsUKwO6EFzpaEP1vMgZHQ=",
-      "dev": true
+      "integrity": "sha1-pWgqg2MsUKwO6EFzpaEP1vMgZHQ="
     },
     "yeoman-environment": {
       "version": "1.6.6",
@@ -14332,7 +13749,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-1.7.0.tgz",
       "integrity": "sha512-vJeg2gpWfhbq0HvQ7/yqmsQpYmADBfo9kaW+J6uJASkI7ChLBXNLIBQqaXCA65kWtHXOco+nBm0Km/O9YWk25Q==",
-      "dev": true,
       "requires": {
         "inquirer": "3.3.0",
         "lodash": "4.17.5",
@@ -14347,20 +13763,17 @@
         "ansi-escapes": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-          "dev": true
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -14369,7 +13782,6 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
@@ -14380,7 +13792,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "dev": true,
           "requires": {
             "restore-cursor": "2.0.0"
           }
@@ -14389,7 +13800,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -14398,7 +13808,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
           "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-          "dev": true,
           "requires": {
             "chardet": "0.4.2",
             "iconv-lite": "0.4.19",
@@ -14409,7 +13818,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "dev": true,
           "requires": {
             "escape-string-regexp": "1.0.5"
           }
@@ -14418,7 +13826,6 @@
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
           "requires": {
             "array-union": "1.0.2",
             "glob": "7.1.2",
@@ -14431,7 +13838,6 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
           "requires": {
             "ansi-escapes": "3.1.0",
             "chalk": "2.3.2",
@@ -14452,14 +13858,12 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "log-symbols": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-          "dev": true,
           "requires": {
             "chalk": "2.3.2"
           }
@@ -14467,14 +13871,12 @@
         "mute-stream": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
         },
         "onetime": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
           "requires": {
             "mimic-fn": "1.2.0"
           }
@@ -14483,7 +13885,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "dev": true,
           "requires": {
             "onetime": "2.0.1",
             "signal-exit": "3.0.2"
@@ -14492,14 +13893,12 @@
         "rx-lite": {
           "version": "4.0.8",
           "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-          "dev": true
+          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
         },
         "sinon": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
           "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
-          "dev": true,
           "requires": {
             "diff": "3.2.0",
             "formatio": "1.2.0",
@@ -14515,7 +13914,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -14525,7 +13923,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -14534,7 +13931,6 @@
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-          "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -14543,7 +13939,6 @@
           "version": "0.0.33",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-          "dev": true,
           "requires": {
             "os-tmpdir": "1.0.2"
           }
@@ -14551,14 +13946,12 @@
         "untildify": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
-          "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E=",
-          "dev": true
+          "integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
         },
         "yeoman-environment": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.5.tgz",
           "integrity": "sha512-6/W7/B54OPHJXob0n0+pmkwFsirC8cokuQkPSmT/D0lCcSxkKtg/BA6ZnjUBIwjuGqmw3DTrT4en++htaUju5g==",
-          "dev": true,
           "requires": {
             "chalk": "2.3.2",
             "debug": "3.1.0",
@@ -14578,8 +13971,7 @@
             "diff": {
               "version": "3.5.0",
               "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-              "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-              "dev": true
+              "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
             }
           }
         }
@@ -14588,8 +13980,7 @@
     "zip-object": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/zip-object/-/zip-object-0.1.0.tgz",
-      "integrity": "sha1-waDaBMiMg3dW4khoCgP/kC7D9To=",
-      "dev": true
+      "integrity": "sha1-waDaBMiMg3dW4khoCgP/kC7D9To="
     },
     "zip-stream": {
       "version": "1.2.0",

--- a/packages/linter/package-lock.json
+++ b/packages/linter/package-lock.json
@@ -2,6 +2,162 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.44"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.44",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.5",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "requires": {
+        "chalk": "2.3.2",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "debug": "3.1.0",
+        "globals": "11.4.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
+    },
     "@polymer/tools-common": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@polymer/tools-common/-/tools-common-2.0.0.tgz",
@@ -70,6 +226,14 @@
         }
       }
     },
+    "@types/babel-generator": {
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.1.tgz",
+      "integrity": "sha512-nKNz9Ch4WP2TFZjQROhxqqS2SCk0OoDzGazJI6S+2sGgW9P7N4o3vluZAXFuPEnRqtz2A0vrrkK3tjQktxIlRw==",
+      "requires": {
+        "@types/babel-types": "6.25.2"
+      }
+    },
     "@types/babel-traverse": {
       "version": "6.25.3",
       "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.3.tgz",
@@ -83,15 +247,46 @@
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
       "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA=="
     },
+    "@types/babylon": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
+      "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
+      "requires": {
+        "@types/babel-types": "6.25.2"
+      }
+    },
     "@types/chai": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
       "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4="
     },
+    "@types/chai-subset": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
+      "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
+      "requires": {
+        "@types/chai": "3.5.2"
+      }
+    },
+    "@types/chalk": {
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
+      "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk="
+    },
     "@types/clone": {
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
       "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
+    },
+    "@types/cssbeautify": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8="
+    },
+    "@types/doctrine": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
+      "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
     },
     "@types/fancy-log": {
       "version": "1.3.0",
@@ -102,6 +297,16 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.1.tgz",
       "integrity": "sha1-OjYVzxc2Rcj8pY0FHk4ygk5L0oY="
+    },
+    "@types/is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8="
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/mocha": {
       "version": "2.2.48",
@@ -126,6 +331,27 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.1.tgz",
           "integrity": "sha512-xwlHq5DXQFRpe+u6hmmNkzYk/3oxxqDp71a/AJMupOQYmxyaBetqrVMqdNlSQfbg7XTJYD8vARjf3Op06OzdtQ=="
         }
+      }
+    },
+    "@types/path-is-inside": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+      "integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw=="
+    },
+    "@types/resolve": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+      "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+      "requires": {
+        "@types/node": "6.0.103"
+      }
+    },
+    "@types/whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
+      "requires": {
+        "@types/node": "6.0.103"
       }
     },
     "acorn": {
@@ -685,6 +911,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
       "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+    },
+    "cssbeautify": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -1660,6 +1891,11 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
+    "indent": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
+      "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
+    },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -1944,6 +2180,11 @@
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1972,6 +2213,11 @@
         "argparse": "1.0.10",
         "esprima": "4.0.0"
       }
+    },
+    "jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -2008,6 +2254,11 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -2194,6 +2445,11 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.template": {
       "version": "3.6.2",
@@ -2751,6 +3007,58 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
     },
+    "polymer-analyzer": {
+      "version": "3.0.0-pre.21",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.21.tgz",
+      "integrity": "sha512-fi3m7EvXHBF/CazUpBeA9RG07iG4bmdIgJ3l/EPrYI/0kgntR5ot6fgLF2UzDFjrrGHEiGl+ABPrhqqdcLyM8A==",
+      "requires": {
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "@types/babel-generator": "6.25.1",
+        "@types/babel-traverse": "6.25.3",
+        "@types/babel-types": "6.25.2",
+        "@types/babylon": "6.16.2",
+        "@types/chai-subset": "1.3.1",
+        "@types/chalk": "0.4.31",
+        "@types/clone": "0.1.30",
+        "@types/cssbeautify": "0.3.1",
+        "@types/doctrine": "0.0.1",
+        "@types/is-windows": "0.2.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "6.0.103",
+        "@types/parse5": "2.2.34",
+        "@types/path-is-inside": "1.0.0",
+        "@types/resolve": "0.0.6",
+        "@types/whatwg-url": "6.4.0",
+        "babylon": "7.0.0-beta.44",
+        "cancel-token": "0.1.1",
+        "chalk": "1.1.3",
+        "clone": "2.1.2",
+        "cssbeautify": "0.3.1",
+        "doctrine": "2.1.0",
+        "dom5": "3.0.0",
+        "indent": "0.0.2",
+        "is-windows": "1.0.2",
+        "jsonschema": "1.2.4",
+        "minimatch": "3.0.4",
+        "parse5": "4.0.0",
+        "path-is-inside": "1.0.2",
+        "resolve": "1.6.0",
+        "shady-css-parser": "0.1.0",
+        "stable": "0.1.6",
+        "strip-indent": "2.0.0",
+        "vscode-uri": "1.0.3",
+        "whatwg-url": "6.4.0"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -2780,6 +3088,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -3355,10 +3668,23 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tsc-then": {
       "version": "1.1.0",
@@ -3607,10 +3933,30 @@
         }
       }
     },
+    "vscode-uri": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
+    },
     "walkdir": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI="
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+    },
+    "whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
     },
     "which": {
       "version": "1.3.0",

--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -14,7 +14,7 @@
     "dom5": "^3.0.0",
     "fast-levenshtein": "^2.0.6",
     "parse5": "^4.0.0",
-    "polymer-analyzer": "3.0.0-pre.21",
+    "polymer-analyzer": "^3.0.0-pre.22",
     "shady-css-parser": "^0.1.0",
     "stable": "^0.1.6",
     "strip-indent": "^2.0.0",

--- a/packages/polyserve/package-lock.json
+++ b/packages/polyserve/package-lock.json
@@ -1,8 +1,6 @@
 {
-  "name": "polyserve",
-  "version": "0.27.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0-beta.44",
@@ -792,14 +790,12 @@
     "@types/chai": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
-      "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
-      "dev": true
+      "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4="
     },
     "@types/chai-as-promised": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-0.0.29.tgz",
       "integrity": "sha1-Q9UokqqZjhhaPePiR37bhXO+HXc=",
-      "dev": true,
       "requires": {
         "@types/chai": "3.5.2",
         "@types/promises-a-plus": "0.0.27"
@@ -938,8 +934,7 @@
     "@types/lru-cache": {
       "version": "2.5.32",
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-2.5.32.tgz",
-      "integrity": "sha1-WZFZDVr0FA5V6qmmLgncf36a9hU=",
-      "dev": true
+      "integrity": "sha1-WZFZDVr0FA5V6qmmLgncf36a9hU="
     },
     "@types/mime": {
       "version": "0.0.29",
@@ -954,8 +949,7 @@
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
-      "dev": true
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw=="
     },
     "@types/mz": {
       "version": "0.0.29",
@@ -995,8 +989,7 @@
     "@types/promises-a-plus": {
       "version": "0.0.27",
       "resolved": "https://registry.npmjs.org/@types/promises-a-plus/-/promises-a-plus-0.0.27.tgz",
-      "integrity": "sha1-xkZRE0YUyEuPXXEUzokB02pgl4A=",
-      "dev": true
+      "integrity": "sha1-xkZRE0YUyEuPXXEUzokB02pgl4A="
     },
     "@types/relateurl": {
       "version": "0.2.28",
@@ -1031,8 +1024,7 @@
     "@types/sinon": {
       "version": "1.16.36",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-1.16.36.tgz",
-      "integrity": "sha1-dLtu15KFl8Gz+xsAkAXpTcbq41c=",
-      "dev": true
+      "integrity": "sha1-dLtu15KFl8Gz+xsAkAXpTcbq41c="
     },
     "@types/spdy": {
       "version": "3.4.4",
@@ -1046,7 +1038,6 @@
       "version": "3.5.7",
       "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.5.7.tgz",
       "integrity": "sha512-zvDPQHA/M8f8SqU3jgQ0PFgaO0FV+IarGwhRm8dy0CIPRi5on187IhkOJFTUT3O03C/vqjZ3jlhOichhw3RVng==",
-      "dev": true,
       "requires": {
         "@types/node": "8.10.0"
       }
@@ -1055,7 +1046,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.4.tgz",
       "integrity": "sha512-0TvOJ+6XVMSImgqc2ClNllfVffCxHQhFbsbwOGzGTjdFydoaG052LPqnP8SnmSlnokOcQiPPcbz+Yi30LxWPyA==",
-      "dev": true,
       "requires": {
         "@types/superagent": "3.5.7"
       }
@@ -1063,8 +1053,7 @@
     "@types/tmp": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-7446cypU5npyGzbzZFZwbBL/Qgs=",
-      "dev": true
+      "integrity": "sha1-7446cypU5npyGzbzZFZwbBL/Qgs="
     },
     "@types/ua-parser-js": {
       "version": "0.7.32",
@@ -1202,8 +1191,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "async": {
       "version": "0.2.10",
@@ -1408,8 +1396,7 @@
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-      "dev": true
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1468,7 +1455,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true,
       "requires": {
         "assertion-error": "1.1.0",
         "deep-eql": "0.1.3",
@@ -1479,7 +1465,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
       "integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
-      "dev": true,
       "requires": {
         "check-error": "1.0.2"
       }
@@ -1504,8 +1489,7 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "ci-info": {
       "version": "1.1.3",
@@ -1516,7 +1500,6 @@
       "version": "1.0.52",
       "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.52.tgz",
       "integrity": "sha1-3liozX6kQfGkpPl8k3BVGBa5C3Y=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "glob": "7.1.2",
@@ -1526,8 +1509,7 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
     },
@@ -1583,7 +1565,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -1619,8 +1600,7 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "compressible": {
       "version": "2.0.13",
@@ -1690,8 +1670,7 @@
     "cookiejar": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
-      "dev": true
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
     },
     "core-js": {
       "version": "2.5.3",
@@ -1795,7 +1774,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "dev": true,
       "requires": {
         "type-detect": "0.1.1"
       },
@@ -1803,8 +1781,7 @@
         "type-detect": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
         }
       }
     },
@@ -1816,8 +1793,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -1845,8 +1821,7 @@
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-      "dev": true
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
     },
     "doctrine": {
       "version": "2.1.0",
@@ -2162,7 +2137,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
-      "dev": true,
       "requires": {
         "glob": "5.0.15"
       },
@@ -2171,7 +2145,6 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
           "requires": {
             "inflight": "1.0.6",
             "inherits": "2.0.3",
@@ -2209,7 +2182,6 @@
       "version": "1.0.0-rc4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
       "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "combined-stream": "1.0.6",
@@ -2219,8 +2191,7 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
     },
@@ -2228,7 +2199,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true,
       "requires": {
         "samsam": "1.1.2"
       }
@@ -2236,8 +2206,7 @@
     "formidable": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
-      "dev": true
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -2431,14 +2400,12 @@
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growl": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-      "dev": true
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
     },
     "gulp-if": {
       "version": "2.0.2",
@@ -2623,7 +2590,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/intercept-stdout/-/intercept-stdout-0.1.2.tgz",
       "integrity": "sha1-Emq/H65sUJpCipjGGmMVWQQq6f0=",
-      "dev": true,
       "requires": {
         "lodash.toarray": "3.0.2"
       }
@@ -2830,8 +2796,7 @@
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
     },
     "json5": {
       "version": "0.5.1",
@@ -2892,14 +2857,12 @@
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
-      "dev": true
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
       "requires": {
         "lodash._basecopy": "3.0.1",
         "lodash.keys": "3.1.2"
@@ -2908,32 +2871,27 @@
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
     },
     "lodash._basecreate": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
     },
     "lodash._basevalues": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "dev": true
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -2944,7 +2902,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
       "requires": {
         "lodash._baseassign": "3.2.0",
         "lodash._basecreate": "3.0.3",
@@ -2959,14 +2916,12 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -2982,7 +2937,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
       "requires": {
         "lodash._getnative": "3.9.1",
         "lodash.isarguments": "3.1.0",
@@ -3020,7 +2974,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-3.0.2.tgz",
       "integrity": "sha1-KyBPD6T1HChcbwDIHRzqWiMEEXk=",
-      "dev": true,
       "requires": {
         "lodash._arraycopy": "3.0.0",
         "lodash._basevalues": "3.0.0",
@@ -3030,8 +2983,7 @@
     "lolex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
-      "dev": true
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -3260,7 +3212,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
       "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
-      "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.9.0",
@@ -3280,7 +3231,6 @@
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
           "requires": {
             "graceful-readlink": "1.0.1"
           }
@@ -3289,7 +3239,6 @@
           "version": "2.6.8",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -3298,7 +3247,6 @@
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -3311,14 +3259,12 @@
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "supports-color": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true,
           "requires": {
             "has-flag": "1.0.0"
           }
@@ -4505,7 +4451,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -4523,8 +4468,7 @@
     "samsam": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-      "dev": true
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
     },
     "select-hose": {
       "version": "2.0.0",
@@ -4696,7 +4640,6 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true,
       "requires": {
         "formatio": "1.1.1",
         "lolex": "1.3.2",
@@ -4713,7 +4656,6 @@
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
       "requires": {
         "source-map": "0.5.7"
       },
@@ -4721,8 +4663,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -4885,7 +4826,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
       "integrity": "sha1-cDUpoHFOV+EjlZ3e+84ZOy5Q0RU=",
-      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "cookiejar": "2.1.1",
@@ -4903,7 +4843,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-2.0.1.tgz",
       "integrity": "sha1-oFgIHXiPFRXUcA11Aogea3WeRM0=",
-      "dev": true,
       "requires": {
         "methods": "1.1.2",
         "superagent": "2.3.0"
@@ -5039,7 +4978,6 @@
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -5079,7 +5017,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tsc-then/-/tsc-then-1.1.0.tgz",
       "integrity": "sha512-830G8SK8tewOxfKVBC5YWqZ2C7wS1D4dh9267ebLxR7Gvh3UuI6aKU5Hxo+L3Kkcy6CuxZp4PMGl066DZ3Hlmw==",
-      "dev": true,
       "requires": {
         "@types/node": "8.10.0",
         "semver": "5.5.0"
@@ -5089,7 +5026,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
       "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "colors": "1.2.1",
@@ -5105,22 +5041,19 @@
         "colors": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-          "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
-          "dev": true
+          "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg=="
         }
       }
     },
     "tsutils": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
-      "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=",
-      "dev": true
+      "integrity": "sha1-ufmrROVa+WgYMdXyjQrur1x1DLA="
     },
     "type-detect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-      "dev": true
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
     },
     "type-is": {
       "version": "1.6.16",
@@ -5134,8 +5067,7 @@
     "typescript": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
-      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
-      "dev": true
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg=="
     },
     "typical": {
       "version": "2.6.1",
@@ -5282,7 +5214,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.1"
       },
@@ -5290,8 +5221,7 @@
         "inherits": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         }
       }
     },


### PR DESCRIPTION
Cross-package dependency versions need to match the current version exactly, or lerna won't create a symlink. This results in tsc finding typings from both the local node_modules folder, and the dependency package.

Passes locally. If it passes on CI I'll submit TBR.