### PR TITLE
Add top-level "check-deps" script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+BasedOnStyle: Google
+AlignAfterOpenBracket: AlwaysBreak
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+# This breaks async functions sometimes, see
+#     https://github.com/Polymer/polymer-analyzer/pull/393
+# BinPackParameters: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /packages/*/node_modules
 /node_modules
+/scripts/**/*.js
 lerna-debug.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,18 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@types/node": {
+      "version": "7.0.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.60.tgz",
+      "integrity": "sha512-ZfCUDgCOPBDn0aAsyBOcNh1nLksuGp3LAL+8GULccZN2IkMBG2KfiwFIRrIuQkLKg1W1dIB9kQZ9MIF3IgAqlw==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -211,6 +223,17 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
       "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
       "dev": true
+    },
+    "clang-format": {
+      "version": "1.0.41-c",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.41-c.tgz",
+      "integrity": "sha512-yhp8mKiXt/wxQ2VmH1BJu5EZ9XnMGKOOE2EJFg0VAjL0J+4+kVZnuO+t619S1r3fyQjKMXNpsRclJSoe+qDbEg==",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.2",
+        "resolve": "1.7.0"
+      }
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -865,17 +888,6 @@
         "locate-path": "2.0.0"
       }
     },
-    "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1501,6 +1513,19 @@
         "write-json-file": "2.3.0",
         "write-pkg": "3.1.0",
         "yargs": "8.0.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -1894,6 +1919,12 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -2154,6 +2185,15 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -2518,6 +2558,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typescript": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2562,7 +2562,8 @@
     "typescript": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
-      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg=="
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,20 @@
     "test": "lerna run test",
     "test:windows": "lerna run test --ignore polyserve",
     "test:integration": "lerna run test:integration",
-    "test:integration:windows": "lerna run test:integration --ignore polymer-linter"
+    "test:integration:windows": "lerna run test:integration --ignore polymer-linter",
+    "check-deps": "tsc && node scripts/check-deps.js"
   },
   "devDependencies": {
-    "lerna": "^2.9.1"
+    "@types/node": "^7.0.60",
+    "@types/semver": "^5.5.0",
+    "clang-format": "^1.0.41-c",
+    "lerna": "^2.9.1",
+    "semver": "^5.5.0"
   },
   "engines": {
     "node": ">=6"
+  },
+  "dependencies": {
+    "typescript": "^2.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,12 +22,10 @@
     "@types/semver": "^5.5.0",
     "clang-format": "^1.0.41-c",
     "lerna": "^2.9.1",
-    "semver": "^5.5.0"
+    "semver": "^5.5.0",
+    "typescript": "^2.8.1"
   },
   "engines": {
     "node": ">=6"
-  },
-  "dependencies": {
-    "typescript": "^2.8.1"
   }
 }

--- a/scripts/check-deps.ts
+++ b/scripts/check-deps.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ *
+ * This program analyzes the dependencies of all packages in the monorepo, and
+ * reports any incompatible semver ranges.
+ *
+ * Conflicts reported here do not indicate an error. Keeping our dependency
+ * ranges compatible when possible simply helps to optimize the combined install
+ * footprint of our tools.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as semver from 'semver';
+
+const packagesDir = path.join(__dirname, '..', 'packages');
+
+const ansi = {
+  reset: '\x1b[0m',
+  yellow: '\x1b[33m',
+}
+
+interface PackageJson {
+  dependencies?: {[name: string]: string};
+  devDependencies?: {[name: string]: string};
+}
+
+function main() {
+  const deps = new Map<string, Map<string, string>>();
+  let maxPackageNameLength = 0;
+
+  for (const packageName of fs.readdirSync(packagesDir)) {
+    let packageJsonStr;
+    try {
+      packageJsonStr = fs.readFileSync(
+          path.join(packagesDir, packageName, 'package.json'), 'utf-8');
+    } catch (err) {
+      if (err.code === 'ENOTDIR' || err.code === 'ENOENT') {
+        continue;
+      }
+      throw err;
+    }
+    const packageJson = JSON.parse(packageJsonStr) as PackageJson;
+
+    for (const [dep, semver] of
+             [...Object.entries(packageJson.dependencies || {}),
+              ...Object.entries(packageJson.devDependencies || {})]) {
+      let semvers = deps.get(dep);
+      if (semvers === undefined) {
+        semvers = new Map();
+        deps.set(dep, semvers);
+      }
+      semvers.set(packageName, semver);
+    }
+
+    maxPackageNameLength = Math.max(maxPackageNameLength, packageName.length);
+  }
+
+  for (const dep of [...deps.keys()].sort()) {
+    const semvers = deps.get(dep) !;
+    const conflicts = new Set<string>();
+    const entries = [...semvers.entries()];
+    for (let a = 0; a < entries.length; a++) {
+      for (let b = a + 1; b < entries.length; b++) {
+        const [aName, aSemver] = entries[a];
+        const [bName, bSemver] = entries[b];
+        if (!semver.intersects(aSemver, bSemver)) {
+          conflicts.add(aName);
+          conflicts.add(bName);
+        }
+      }
+    }
+
+    if (conflicts.size > 0) {
+      console.log(`\n${ansi.yellow}${dep}${ansi.reset}`);
+      console.log('-'.repeat(dep.length));
+
+      for (const packageName of [...conflicts].sort()) {
+        const spaces =
+            ' '.repeat(maxPackageNameLength - packageName.length + 1);
+        console.log(`${packageName}${spaces}${semvers.get(packageName)}`);
+      }
+    }
+  }
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "pretty": true,
+    "lib": [
+      "es2017"
+    ]
+  },
+  "include": [
+    "./scripts/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Adds `npm run check-deps` script.

Analyzes the dependencies of all packages in the monorepo, and reports any incompatible semver ranges.

Conflicts reported here do not indicate an error. Keeping our dependency ranges compatible when possible simply helps to optimize the combined install footprint of our tools.

<details><summary>Here's what it outputs right now (click).</summary>

```
@polymer/tools-common
---------------------
cli            ^1.0.1
linter         ^2.0.0

@types/chai
-----------
analyzer       ^4.0.10
build          ^3.4.34
bundler        ^3.4.30
linter         ^3.4.34
polyserve      ^3.4.34

@types/chai-as-promised
-----------------------
analyzer       ^7.1.0
polyserve      0.0.29

@types/fs-extra
---------------
build          0.0.37
cli            ^5.0.1

@types/mz
---------
build          0.0.31
cli            ^0.0.31
polyserve      0.0.29

@types/node
-----------
analyzer       ^6.0.0
build          ^6.0.77
bundler        ^6.0.33
cli            =6.0.65
linter         ^6.0.100
polyserve      ^8.0.0
project-config ^6.0.41

@types/resolve
--------------
analyzer       0.0.6
build          0.0.7
cli            0.0.4
polyserve      0.0.6

@types/sinon
------------
build          ^1.16.33
cli            ^4.0.0
polyserve      ^1.16.31

@types/tmp
----------
cli            ^0.0.33
polyserve      0.0.31

@types/vinyl-fs
---------------
build          ^2.4.8
cli            0.0.28

chai
----
analyzer       ^4.1.2
build          ^4.1.2
bundler        ^3.5.0
cli            ^3.5.0
linter         ^3.5.0
polyserve      ^3.5.0
project-config ^3.5.0

chai-as-promised
----------------
analyzer       ^7.1.1
polyserve      ^6.0.0

clang-format
------------
analyzer       =1.1.1
build          ^1.0.52
bundler        =1.0.49
cli            =1.1.0
linter         1.0.48
polyserve      1.0.52
project-config 1.0.49

dom5
----
analyzer       ^3.0.0
build          ^3.0.0
bundler        ^2.2.0
linter         ^3.0.0

fs-extra
--------
analyzer       ^0.30.0
build          ^5.0.0
cli            ^5.0.0

gulp-sourcemaps
---------------
analyzer       ^1.6.0
build          ^2.6.4

gulp-typescript
---------------
analyzer       ^2.13.4
build          ^3.1.4
cli            ^3.0.0

mocha
-----
analyzer       ^5.0.5
build          ^3.2.0
bundler        ^2.2.4
cli            ^3.0
linter         ^3.1.0
polyserve      ^3.1.0
project-config ^3.0.2

parse5
------
analyzer       ^4.0.0
build          ^4.0.0
bundler        ^2.2.2
linter         ^4.0.0

plylog
------
build          ^0.5.0
cli            ^0.4.0
project-config ^0.5.0

polymer-analyzer
----------------
build          3.0.0-pre.22
bundler        ^3.0.0-pre.18
cli            3.0.0-pre.22
linter         3.0.0-pre.21
project-config ^3.0.0-pre.17 || ^3.0.0

polymer-build
-------------
cli            3.0.0-pre.10
polyserve      =3.0.0-pre.7

source-map-support
------------------
analyzer       ^0.4.2
build          ^0.5.4
bundler        ^0.4.2
cli            ^0.5.4
linter         ^0.4.3
polyserve      ^0.4.6

tmp
---
cli            0.0.31
polyserve      0.0.28

tslint
------
analyzer       ^4.1.1
build          ^5.2.0
bundler        ^3.15.1
cli            ^4.0.2
linter         ^4.1.1
polyserve      ^4.0.2

typescript-json-schema
----------------------
analyzer       ^0.21.0
project-config ^0.9.0
```
</details>