### PR TITLE
Bump cli caret dep on polyserve in prep for 1.7.0-pre.7

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "polymer-bundler": "^4.0.0-pre.4",
     "polymer-linter": "^3.0.0-pre.5",
     "polymer-project-config": "^3.13.0",
-    "polyserve": "^0.27.1",
+    "polyserve": "^0.27.2",
     "request": "^2.72.0",
     "rimraf": "^2.6.1",
     "semver": "^5.3.0",


### PR DESCRIPTION
This might not technically be necessary, but it is what lerna would have
done if we had published the two packages together. And it ensures users
get the recent fix to polyserve despite their package lock or whatever,
which is the main reason for this release.