### PR TITLE
Prepare CLI 1.7.0-pre.8 release.

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,9 @@
 <!-- ## Unreleased -->
 <!-- Add new, unreleased items here. -->
 
+## v1.7.0-pre.8 [04-10-2018]
+* Fix broken release.
+
 ## v1.7.0-pre.7 [04-10-2018]
 * Update polyserve for latest changes.
 


### PR DESCRIPTION
The previous release was published totally unbuilt. Entirely my mistake, it's because I'm so used to using np which automatically runs "build", while "lerna publish" does not.

Maybe we should just put "build" in our prepublish (should be prepack actually) scripts. Or just not use "lerna publish".