### PR TITLE
Prepare linter 3.0.0-pre.6 release.

### DIFF
--- a/packages/linter/CHANGELOG.md
+++ b/packages/linter/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 
+## [3.0.0-pre.6] - 2018-04-11
+- Bump dependencies.
+
 ## [3.0.0-pre.5] - 2018-04-05
 - Accept AnalysisOptions as an argument to `Linter#lint` and
   `Linter#lintPackage`.


### PR DESCRIPTION
This is needed because the prior release of linter is pinned to an older version of analyzer, which means unless linked by lerna, the package will not build.