### PR TITLE
Fix wrong AMD transform dependency/callback parameter ordering.

### DIFF
--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Fix AMD transform bug where if an HTML document had multiple type=module scripts, and any of them (apart from the first) had any kind of import, then that import was not accessible (because it was mapped to the wrong module callback function argument).
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.10] - 2018-04-09

--- a/packages/build/src/html-transform.ts
+++ b/packages/build/src/html-transform.ts
@@ -203,11 +203,11 @@ function transformEsModuleToAmd(
   const isExternal = dom5.hasAttribute(script, 'src');
   if (isExternal) {
     const deps = [];
+    const externalSrc = dom5.getAttribute(script, 'src');
+    deps.push(externalSrc);
     if (previousGeneratedModule !== undefined) {
       deps.push(previousGeneratedModule);
     }
-    const externalSrc = dom5.getAttribute(script, 'src');
-    deps.push(externalSrc);
     const depsStr = deps.map((dep) => `'${dep}'`).join(', ');
     dom5.removeAttribute(script, 'src');
     dom5.setTextContent(script, `define('${generatedModule}', [${depsStr}]);`);

--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -220,14 +220,21 @@ export function jsTransform(js: string, options: JsTransformOptions): string {
     const previousGeneratedModule = options.moduleScriptIdx === 0 ?
         undefined :
         generateModuleName(options.moduleScriptIdx - 1);
-    const depStr = previousGeneratedModule === undefined ?
-        '' :
-        `'${previousGeneratedModule}', `;
     // The AMD Babel plugin will produce a `define` call with no name argument,
     // since it assumes its name corresponds to its file name. This is an inline
-    // script, though, and we need a handle to it for chaining, so insert a name
-    // argument.
-    js = js.replace('define([', `define('${generatedModule}', [${depStr}`);
+    // script, though, and we need a handle to it for chaining, so insert a
+    // module name argument, plus a dependency on the previous module.
+    js = js.replace(/define\(\[([^\]]*)\]/, (_match, deps) => {
+      if (previousGeneratedModule !== undefined) {
+        // Note that existing dependencies must come before our generated one,
+        // becuase we are not updating the callback function parameters.
+        if (deps.length > 0) {
+          deps += ', ';
+        }
+        deps += `'${previousGeneratedModule}'`;
+      }
+      return `define('${generatedModule}', [${deps}]`;
+    });
   }
 
   js = replaceTemplateObjectNames(js);

--- a/packages/build/src/path-transformers.ts
+++ b/packages/build/src/path-transformers.ts
@@ -53,9 +53,13 @@
 import * as path from 'path';
 import {PackageRelativeUrl} from 'polymer-analyzer';
 
-export declare class LocalFsPathBrand { private LocalFsPathBrand: never; }
+export declare class LocalFsPathBrand {
+  private LocalFsPathBrand: never;
+}
 export type LocalFsPath = string&LocalFsPathBrand;
-export declare class PosixPathBrand { private PosixPathBrand: never; }
+export declare class PosixPathBrand {
+  private PosixPathBrand: never;
+}
 export type PosixPath = string&PosixPathBrand;
 
 /**

--- a/packages/build/src/test/babel-plugin-bare-specifiers_test.ts
+++ b/packages/build/src/test/babel-plugin-bare-specifiers_test.ts
@@ -20,7 +20,6 @@ import * as path from 'path';
 import {resolveBareSpecifiers} from '../babel-plugin-bare-specifiers';
 
 suite('babel-plugin-bare-specifiers', () => {
-
   const rootDir =
       path.join(__dirname, '..', '..', 'test-fixtures', 'npm-modules');
   const filePath = path.join(rootDir, 'foo.js');
@@ -39,5 +38,4 @@ suite('babel-plugin-bare-specifiers', () => {
             .code;
     assert.equal(result.trim(), expected.trim());
   });
-
 });

--- a/packages/build/src/test/babel-plugin-import-meta_test.ts
+++ b/packages/build/src/test/babel-plugin-import-meta_test.ts
@@ -19,7 +19,6 @@ import {assert} from 'chai';
 import {rewriteImportMeta} from '../babel-plugin-import-meta';
 
 suite('babel-plugin-import-meta', () => {
-
   test('transforms import.meta', () => {
     const input = stripIndent(`
       console.log(import.meta);
@@ -62,5 +61,4 @@ suite('babel-plugin-import-meta', () => {
     const result = babelCore.transform(input, {plugins: [plugin]}).code;
     assert.equal(result.trim(), expected.trim());
   });
-
 });

--- a/packages/build/src/test/bundle_test.ts
+++ b/packages/build/src/test/bundle_test.ts
@@ -529,10 +529,9 @@ suite('BuildBundler', () => {
             map.set(
                 urlResolver.resolve(
                     `bundled/${
-                                   [...bundle.entrypoints]
-                                       .map((u) => urlResolver.relative(u))
-                                       .join()
-                             }` as PackageRelativeUrl)!,
+                            [...bundle.entrypoints]
+                                .map((u) => urlResolver.relative(u))
+                                .join()}` as PackageRelativeUrl)!,
                 bundle);
           }
           return map;

--- a/packages/build/src/test/html-transform_test.ts
+++ b/packages/build/src/test/html-transform_test.ts
@@ -194,16 +194,18 @@ suite('htmlTransform', () => {
           <script type="module">import { depA } from './depA.js';</script>
           <script type="module" src="./depB.js"></script>
           <script type="module">import { depC } from './depC.js';</script>
+          <script type="module">'no imports';</script>
           <script type="module" src="./depD.js"></script>
         </body></html>`;
 
       const expected = `
       <html><head></head><body>
         <script>define('polymer-build-generated-module-0', ["./depA.js"], function (_depA) {"use strict";});</script>
-        <script>define('polymer-build-generated-module-1', ['polymer-build-generated-module-0', './depB.js']);</script>
-        <script>define('polymer-build-generated-module-2', ['polymer-build-generated-module-1', "./depC.js"], function (_depC) {"use strict";});</script>
-        <script>define('polymer-build-generated-module-3', ['polymer-build-generated-module-2', './depD.js']);</script>
-        <script>require(['polymer-build-generated-module-3']);</script>
+        <script>define('polymer-build-generated-module-1', ['./depB.js', 'polymer-build-generated-module-0']);</script>
+        <script>define('polymer-build-generated-module-2', ["./depC.js", 'polymer-build-generated-module-1'], function (_depC) {"use strict";});</script>
+        <script>define('polymer-build-generated-module-3', ['polymer-build-generated-module-2'], function () {"use strict";'no imports';});</script>
+        <script>define('polymer-build-generated-module-4', ['./depD.js', 'polymer-build-generated-module-3']);</script>
+        <script>require(['polymer-build-generated-module-4']);</script>
       </body></html>`;
 
       assertEqualIgnoringWhitespace(

--- a/packages/build/src/test/optimize-streams_test.ts
+++ b/packages/build/src/test/optimize-streams_test.ts
@@ -158,8 +158,8 @@ suite('optimize-streams', () => {
           expected: `
             <html><head></head><body>
               <script>define('polymer-build-generated-module-0', ["./depA.js"], function (_depA) {"use strict";});</script>
-              <script>define('polymer-build-generated-module-1', ['polymer-build-generated-module-0', './depB.js']);</script>
-              <script>define('polymer-build-generated-module-2', ['polymer-build-generated-module-1', "./depC.js"], function (_depC) {"use strict";});</script>
+              <script>define('polymer-build-generated-module-1', ['./depB.js', 'polymer-build-generated-module-0']);</script>
+              <script>define('polymer-build-generated-module-2', ["./depC.js", 'polymer-build-generated-module-1'], function (_depC) {"use strict";});</script>
               <script>require(['polymer-build-generated-module-2']);</script>
             </body></html>
           `,

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-<!-- ## Unreleased -->
+## Unreleased
+* Fix AMD transform bug where if an HTML document had multiple type=module scripts, and any of them (apart from the first) had any kind of import, then that import was not accessible (because it was mapped to the wrong module callback function argument).
 <!-- Add new, unreleased items here. -->
 
 ## v1.7.0-pre.8 [04-10-2018]

--- a/packages/polyserve/CHANGELOG.md
+++ b/packages/polyserve/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Fix AMD transform bug where if an HTML document had multiple type=module scripts, and any of them (apart from the first) had any kind of import, then that import was not accessible (because it was mapped to the wrong module callback function argument).
+<!-- Add new, unreleased items here. -->
 
 ## [0.27.2] (2018-04-10)
 * Really bring in latest changes.

--- a/packages/polyserve/test/bower_components/test-modules/golden/test-suite-no-wct.html
+++ b/packages/polyserve/test/bower_components/test-modules/golden/test-suite-no-wct.html
@@ -4,7 +4,7 @@
   "use strict";
 });</script>
 
-  <script>define('polymer-build-generated-module-1', ['polymer-build-generated-module-0', './external.js']);</script><script>require(['polymer-build-generated-module-1']);</script>
+  <script>define('polymer-build-generated-module-1', ['./external.js', 'polymer-build-generated-module-0']);</script><script>require(['polymer-build-generated-module-1']);</script>
 
 
 </body></html>

--- a/packages/polyserve/test/bower_components/test-modules/golden/test-suite-wct.html
+++ b/packages/polyserve/test/bower_components/test-modules/golden/test-suite-wct.html
@@ -49,7 +49,7 @@
   doSomething(_libModule.foo);
 });</script>
 
-  <script>define('polymer-build-generated-module-1', ['polymer-build-generated-module-0', "./lib-module.js"], function (_libModule) {
+  <script>define('polymer-build-generated-module-1', ["./lib-module.js", 'polymer-build-generated-module-0'], function (_libModule) {
   "use strict";
 
   doSomethingElse(_libModule.foo);


### PR DESCRIPTION
Fix AMD transform bug where if an HTML document had multiple type=module
scripts, and any of them (apart from the first) had any kind of import,
then that import was not accessible (because it was mapped to the wrong
module callback function argument).

Fixes #112 