### PR TITLE
`Feature#astNode` is now an AstNodeWithLanguage

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* [BREAKING] `Feature.astNode` is now an `AstNodeWithLanguage` rather than
+  being an unwrapped ast node (usually typed as `any`). This makes it easier
+  and safer to handle features which could be declared in HTML or JS. Most
+  tools will not care about these ast nodes, this mostly comes up in tools
+  like the linter, which does additional analysis of the AST.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.22] - 2018-04-09

--- a/packages/analyzer/src/core/analyzer.ts
+++ b/packages/analyzer/src/core/analyzer.ts
@@ -16,6 +16,7 @@
 
 import * as path from 'path';
 
+import {ParsedDocument} from '..';
 import {Analysis, Document, Warning} from '../model/model';
 import {PackageRelativeUrl, ResolvedUrl} from '../model/url';
 import {Parser} from '../parser/parser';
@@ -29,7 +30,7 @@ import {MinimalCancelToken, neverCancels} from './cancel-token';
 export interface Options {
   urlLoader: UrlLoader;
   urlResolver?: UrlResolver;
-  parsers?: Map<string, Parser<any>>;
+  parsers?: Map<string, Parser<ParsedDocument>>;
   scanners?: ScannerTable;
 
   /**
@@ -65,7 +66,7 @@ export interface ForkOptions { urlLoader?: UrlLoader; }
 
 export class NoKnownParserError extends Error {};
 
-export type ScannerTable = Map<string, Scanner<any, any, any>[]>;
+export type ScannerTable = Map<string, Scanner<ParsedDocument, {}, {}>[]>;
 export type LazyEdgeMap = Map<ResolvedUrl, PackageRelativeUrl[]>;
 
 /**

--- a/packages/analyzer/src/core/utils.ts
+++ b/packages/analyzer/src/core/utils.ts
@@ -50,10 +50,10 @@ export function trimLeft(str: string, char: string): string {
 export class Deferred<T> {
   promise: Promise<T>;
   resolve!: (result: T) => void;
-  reject!: (error: Error) => void;
+  reject!: (error: {}|undefined|null) => void;
   resolved = false;
   rejected = false;
-  error: any;
+  error: {}|undefined|null;
 
   constructor() {
     this.promise = new Promise((resolve, reject) => {

--- a/packages/analyzer/src/html/html-element-reference-scanner.ts
+++ b/packages/analyzer/src/html/html-element-reference-scanner.ts
@@ -39,7 +39,9 @@ export class HtmlElementReferenceScanner implements HtmlScanner {
     const visitor = (node: ASTNode) => {
       if (node.tagName && this.matches(node)) {
         const element = new ScannedElementReference(
-            node.tagName, document.sourceRangeForNode(node)!, node);
+            node.tagName,
+            document.sourceRangeForNode(node)!,
+            {language: 'html', containingDocument: document, node});
 
         if (node.attrs) {
           for (const attr of node.attrs) {

--- a/packages/analyzer/src/html/html-import-scanner.ts
+++ b/packages/analyzer/src/html/html-import-scanner.ts
@@ -69,7 +69,7 @@ export class HtmlImportScanner implements HtmlScanner {
           href,
           document.sourceRangeForNode(node)!,
           document.sourceRangeForAttributeValue(node, 'href')!,
-          node,
+          {language: 'html', node, containingDocument: document},
           lazy));
     });
     if (this._lazyEdges) {
@@ -77,7 +77,13 @@ export class HtmlImportScanner implements HtmlScanner {
       if (edges) {
         for (const edge of edges) {
           imports.push(new ScannedImport(
-              type, edge as any, undefined, undefined, null, true));
+              type,
+              // This cast is very suspicious.
+              edge as string as FileRelativeUrl,
+              undefined,
+              undefined,
+              undefined,
+              true));
         }
       }
     }

--- a/packages/analyzer/src/html/html-script-scanner.ts
+++ b/packages/analyzer/src/html/html-script-scanner.ts
@@ -47,7 +47,7 @@ export class HtmlScriptScanner implements HtmlScanner {
               src,
               document.sourceRangeForNode(node)!,
               document.sourceRangeForAttributeValue(node, 'src')!,
-              node,
+              {language: 'html', node, containingDocument: document},
               false));
         } else {
           const locationOffset =

--- a/packages/analyzer/src/html/html-style-scanner.ts
+++ b/packages/analyzer/src/html/html-style-scanner.ts
@@ -50,7 +50,7 @@ export class HtmlStyleScanner implements HtmlScanner {
               href,
               document.sourceRangeForNode(node)!,
               document.sourceRangeForAttributeValue(node, 'href')!,
-              node,
+              {language: 'html', node, containingDocument: document},
               true));
         } else {
           const contents = dom5.getTextContent(node);

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -25,6 +25,8 @@ export * from './model/model';
 export {WarningPrinter, Verbosity as WarningPrinterVerbosity} from './warning/warning-printer';
 export {WarningFilter} from './warning/warning-filter';
 export {Namespace} from './javascript/namespace';
+export {JavascriptImport} from './javascript/javascript-import-scanner';
+export {Export} from './javascript/javascript-export-scanner';
 export {ParsedDocument} from './parser/document';
 
 // Analysis

--- a/packages/analyzer/src/javascript/esutil.ts
+++ b/packages/analyzer/src/javascript/esutil.ts
@@ -254,7 +254,7 @@ export function getPropertyValue(
 export function toScannedMethod(
     node: babel.ObjectProperty|babel.ObjectMethod|babel.ClassMethod,
     sourceRange: SourceRange,
-    document: ParsedDocument): ScannedMethod {
+    document: JavaScriptDocument): ScannedMethod {
   const parsedJsdoc = jsdoc.parseJsdoc(getAttachedComment(node) || '');
   const description = parsedJsdoc.description.trim();
   const maybeName = getPropertyName(node);
@@ -283,7 +283,7 @@ export function toScannedMethod(
     description,
     sourceRange,
     warnings,
-    astNode: node,
+    astNode: {language: 'js', node, containingDocument: document},
     jsdoc: parsedJsdoc,
     privacy: getOrInferPrivacy(name, parsedJsdoc)
   };
@@ -571,7 +571,7 @@ export function extractPropertyFromGetterOrSetter(
 
   return {
     name,
-    astNode: method,
+    astNode: {language: 'js', node: method, containingDocument: document},
     type,
     jsdoc: jsdocAnn,
     sourceRange: document.sourceRangeForNode(method)!,
@@ -646,7 +646,7 @@ export function extractPropertiesFromClassOrObjectBody(
 
     properties.set(name, {
       name,
-      astNode,
+      astNode: {language: 'js', node: astNode, containingDocument: document},
       type,
       jsdoc: jsdocAnn,
       sourceRange,

--- a/packages/analyzer/src/javascript/function-scanner.ts
+++ b/packages/analyzer/src/javascript/function-scanner.ts
@@ -183,7 +183,7 @@ class FunctionVisitor implements Visitor {
         description,
         summary,
         getOrInferPrivacy(specificName, docs),
-        node,
+        {language: 'js', node, containingDocument: this.document},
         docs,
         sourceRange,
         functionParams,

--- a/packages/analyzer/src/javascript/function.ts
+++ b/packages/analyzer/src/javascript/function.ts
@@ -12,9 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as babel from '@babel/types';
-
-import {Document, Feature, Privacy, Resolvable, SourceRange, Warning} from '../model/model';
+import {Document, Feature, JsAstNode, Privacy, Resolvable, SourceRange, Warning} from '../model/model';
 
 import {Annotation as JsDocAnnotation} from './jsdoc';
 
@@ -24,7 +22,7 @@ export class ScannedFunction implements Resolvable {
   summary?: string;
   jsdoc?: JsDocAnnotation;
   sourceRange: SourceRange;
-  astNode: babel.Node;
+  astNode: JsAstNode;
   warnings: Warning[];
   params?: {name: string, type?: string}[];
   return?: {type?: string, desc?: string};
@@ -36,7 +34,7 @@ export class ScannedFunction implements Resolvable {
       description: string,
       summary: string,
       privacy: Privacy,
-      astNode: babel.Node,
+      astNode: JsAstNode,
       jsdoc: JsDocAnnotation,
       sourceRange: SourceRange,
       params?: {name: string, type?: string}[],
@@ -74,7 +72,7 @@ export class Function implements Feature {
   kinds: Set<string>;
   identifiers: Set<string>;
   sourceRange: SourceRange;
-  astNode: any;
+  astNode: JsAstNode;
   warnings: Warning[];
   params?: {name: string, type?: string}[];
   return?: {type?: string, desc?: string};

--- a/packages/analyzer/src/javascript/javascript-document.ts
+++ b/packages/analyzer/src/javascript/javascript-document.ts
@@ -33,7 +33,7 @@ export {Visitor} from './estree-visitor';
  * operator, and it doesn't need to be a real Node as all of this happens at
  * analysis time, and nothing happens at runtime.
  */
-const __exampleNode: Node = <any>null;
+const __exampleNode: Node = null as any;
 type EstreeType = typeof __exampleNode.type;
 interface SkipRecord {
   type: EstreeType;

--- a/packages/analyzer/src/javascript/namespace-scanner.ts
+++ b/packages/analyzer/src/javascript/namespace-scanner.ts
@@ -123,7 +123,7 @@ class NamespaceVisitor implements Visitor {
 
   private _createPropertyFromExpression(
       name: string, node: babel.AssignmentExpression|babel.MemberExpression,
-      jsdocAnn: jsdoc.Annotation|undefined) {
+      jsdocAnn: jsdoc.Annotation|undefined): ScannedProperty|undefined {
     let description;
     let type;
     let readOnly = false;
@@ -155,7 +155,7 @@ class NamespaceVisitor implements Visitor {
 
     return {
       name,
-      astNode: node,
+      astNode: {language: 'js', node, containingDocument: this.document},
       type,
       jsdoc: jsdocAnn,
       sourceRange,
@@ -203,7 +203,7 @@ class NamespaceVisitor implements Visitor {
             namespaceName,
             description,
             summary,
-            node,
+            {language: 'js', node, containingDocument: this.document},
             properties,
             docs,
             sourceRange));

--- a/packages/analyzer/src/javascript/namespace.ts
+++ b/packages/analyzer/src/javascript/namespace.ts
@@ -12,9 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as babel from '@babel/types';
-
-import {Document, Feature, Property, Resolvable, ScannedProperty, SourceRange, Warning} from '../model/model';
+import {Document, Feature, JsAstNode, Property, Resolvable, ScannedProperty, SourceRange, Warning} from '../model/model';
 
 import {Annotation as JsDocAnnotation} from './jsdoc';
 
@@ -27,12 +25,12 @@ export class ScannedNamespace implements Resolvable {
   summary?: string;
   jsdoc?: JsDocAnnotation;
   sourceRange: SourceRange;
-  astNode: babel.Node;
+  astNode: JsAstNode;
   warnings: Warning[];
   properties: Map<string, ScannedProperty>;
 
   constructor(
-      name: string, description: string, summary: string, astNode: babel.Node,
+      name: string, description: string, summary: string, astNode: JsAstNode,
       properties: Map<string, ScannedProperty>, jsdoc: JsDocAnnotation,
       sourceRange: SourceRange) {
     this.name = name;
@@ -63,7 +61,7 @@ export class Namespace implements Feature {
   kinds: Set<string>;
   identifiers: Set<string>;
   sourceRange: SourceRange;
-  astNode: any;
+  astNode: JsAstNode;
   warnings: Warning[];
   readonly properties = new Map<string, Property>();
 

--- a/packages/analyzer/src/model/class.ts
+++ b/packages/analyzer/src/model/class.ts
@@ -16,7 +16,7 @@ import * as babel from '@babel/types';
 
 import {ElementMixin} from '..';
 import * as jsdocLib from '../javascript/jsdoc';
-import {Document, Feature, Method, Privacy, Property, Resolvable, ScannedFeature, ScannedMethod, ScannedProperty, ScannedReference, Severity, SourceRange, Warning} from '../model/model';
+import {AstNodeWithLanguage, Document, Feature, Method, Privacy, Property, Resolvable, ScannedFeature, ScannedMethod, ScannedProperty, ScannedReference, Severity, SourceRange, Warning} from '../model/model';
 import {ParsedDocument} from '../parser/document';
 
 import {DeclaredWithStatement} from './document';
@@ -39,7 +39,7 @@ export class ScannedClass implements ScannedFeature, Resolvable {
   readonly name: string|undefined;
   /** The name of the class in the local scope where it is defined. */
   readonly localName: string|undefined;
-  readonly astNode: babel.Node;
+  readonly astNode: AstNodeWithLanguage;
   readonly statementAst: babel.Statement|undefined;
   readonly jsdoc: jsdocLib.Annotation;
   readonly description: string;
@@ -57,7 +57,7 @@ export class ScannedClass implements ScannedFeature, Resolvable {
   readonly demos: Demo[];
   constructor(
       className: string|undefined, localClassName: string|undefined,
-      astNode: babel.Node, statementAst: babel.Statement|undefined,
+      astNode: AstNodeWithLanguage, statementAst: babel.Statement|undefined,
       jsdoc: jsdocLib.Annotation, description: string, sourceRange: SourceRange,
       properties: Map<string, ScannedProperty>,
       methods: Map<string, ScannedMethod>,
@@ -116,7 +116,7 @@ declare module '../model/queryable' {
 
 export interface ClassInit {
   readonly sourceRange: SourceRange|undefined;
-  readonly astNode: any;
+  readonly astNode: AstNodeWithLanguage|undefined;
   readonly statementAst: babel.Statement|undefined;
   readonly warnings?: Warning[];
   readonly summary: string;
@@ -139,8 +139,7 @@ export class Class implements Feature, DeclaredWithStatement {
   readonly kinds = new Set(['class']);
   readonly identifiers = new Set<string>();
   readonly sourceRange: SourceRange|undefined;
-  // TODO(rictic): make this an AstWithLanguage
-  readonly astNode: any;
+  readonly astNode: AstNodeWithLanguage|undefined;
   readonly statementAst: babel.Statement|undefined;
   readonly warnings: Warning[];
   readonly summary: string;

--- a/packages/analyzer/src/model/element-base.ts
+++ b/packages/analyzer/src/model/element-base.ts
@@ -13,7 +13,6 @@
  */
 
 import * as babel from '@babel/types';
-import * as dom5 from 'dom5/lib/index-next';
 import {ASTNode} from 'parse5';
 
 import * as jsdoc from '../javascript/jsdoc';
@@ -23,7 +22,7 @@ import {Class, ClassInit} from './class';
 import {Privacy} from './feature';
 import {ImmutableArray} from './immutable';
 import {ScannedMethod} from './method';
-import {Attribute, Document, Event, Feature, Resolvable, ScannedAttribute, ScannedEvent, ScannedProperty, ScannedReference, SourceRange, Warning} from './model';
+import {AstNodeWithLanguage, Attribute, Document, Event, Feature, Resolvable, ScannedAttribute, ScannedEvent, ScannedProperty, ScannedReference, SourceRange, Warning} from './model';
 import {FileRelativeUrl} from './url';
 import {Severity} from './warning';
 
@@ -42,7 +41,7 @@ export abstract class ScannedElementBase implements Resolvable {
   sourceRange: SourceRange|undefined;
   staticMethods: Map<string, ScannedMethod> = new Map();
   methods: Map<string, ScannedMethod> = new Map();
-  astNode: babel.Node|null = null;
+  astNode: AstNodeWithLanguage|undefined = undefined;
   statementAst: babel.Statement|undefined;
   warnings: Warning[] = [];
   jsdoc?: jsdoc.Annotation;
@@ -79,17 +78,17 @@ export abstract class ScannedElementBase implements Resolvable {
     }
   }
 
-  resolve(_document: Document): any {
-    throw new Error('abstract');
-  }
+  abstract resolve(_document: Document): Feature;
 }
 
 export class Slot {
   name: string;
   range: SourceRange;
-  astNode?: dom5.Node;
+  astNode?: AstNodeWithLanguage;
 
-  constructor(name: string, range: SourceRange, astNode: dom5.Node|undefined) {
+  constructor(
+      name: string, range: SourceRange,
+      astNode: AstNodeWithLanguage|undefined) {
     this.name = name;
     this.range = range;
     this.astNode = astNode;

--- a/packages/analyzer/src/model/element-reference.ts
+++ b/packages/analyzer/src/model/element-reference.ts
@@ -12,9 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as dom5 from 'dom5/lib/index-next';
 
-import {Feature, Resolvable, SourceRange, Warning} from '../model/model';
+import {Feature, HtmlAstNode, Resolvable, SourceRange, Warning} from '../model/model';
 
 import {Document} from './document';
 import {ImmutableArray, ImmutableMap, ImmutableSet} from './immutable';
@@ -37,7 +36,7 @@ export class ElementReference implements Feature {
   readonly tagName: string;
   readonly attributes: ImmutableMap<string, Attribute>;
   readonly sourceRange: SourceRange;
-  readonly astNode: dom5.Node;
+  readonly astNode: HtmlAstNode;
   readonly warnings: ImmutableArray<Warning>;
   readonly kinds: ImmutableSet<string> = new Set(['element-reference']);
 
@@ -58,10 +57,10 @@ export class ScannedElementReference implements Resolvable {
   readonly tagName: string;
   readonly attributes = new Map<string, Attribute>();
   readonly sourceRange: SourceRange;
-  readonly astNode: dom5.Node;
+  readonly astNode: HtmlAstNode;
   readonly warnings: ImmutableArray<Warning> = [];
 
-  constructor(tagName: string, sourceRange: SourceRange, ast: dom5.Node) {
+  constructor(tagName: string, sourceRange: SourceRange, ast: HtmlAstNode) {
     this.tagName = tagName;
     this.sourceRange = sourceRange;
     this.astNode = ast;

--- a/packages/analyzer/src/model/event.ts
+++ b/packages/analyzer/src/model/event.ts
@@ -12,7 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as babel from '@babel/types';
+import {JsAstNode} from '..';
+
 import {ScannedFeature} from './feature';
 
 export interface ScannedEvent extends ScannedFeature {
@@ -20,7 +21,7 @@ export interface ScannedEvent extends ScannedFeature {
   readonly type?: string;
   readonly description?: string;
   readonly params: {type: string, desc: string, name: string}[];
-  readonly astNode: babel.Node|null;
+  readonly astNode: JsAstNode|undefined;
 }
 
 export interface Event {
@@ -28,6 +29,6 @@ export interface Event {
   readonly type?: string;
   // TODO: represent detail object properly
   readonly description?: string;
-  readonly astNode: babel.Node|null;
+  readonly astNode: JsAstNode|undefined;
   readonly inheritedFrom?: string;
 }

--- a/packages/analyzer/src/model/feature.ts
+++ b/packages/analyzer/src/model/feature.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {AstNodeWithLanguage} from '..';
 import * as jsdoc from '../javascript/jsdoc';
 
 import {ImmutableArray, ImmutableSet} from './immutable';
@@ -29,13 +30,13 @@ export abstract class Feature {
    * The AST Node, if any, that corresponds to this feature in its containing
    * document.
    */
-  readonly astNode?: any;
+  readonly astNode?: AstNodeWithLanguage;
 
   /** Warnings that were encountered while processing this feature. */
   readonly warnings: Array<Warning>|ImmutableArray<Warning>;
 
   constructor(
-      sourceRange?: SourceRange, astNode?: any,
+      sourceRange?: SourceRange, astNode?: AstNodeWithLanguage,
       warnings?: Array<Warning>|ImmutableArray<Warning>) {
     this.sourceRange = sourceRange;
     this.astNode = astNode;
@@ -57,14 +58,14 @@ export abstract class ScannedFeature {
    * The AST Node, if any, that corresponds to this feature in its containing
    * document.
    */
-  readonly astNode?: any;
+  readonly astNode?: AstNodeWithLanguage;
 
   /** Warnings that were encountered while processing this feature. */
   readonly warnings: Array<Warning>|ImmutableArray<Warning>;
 
   constructor(
-      sourceRange?: SourceRange, astNode?: any, description?: string,
-      jsdoc?: jsdoc.Annotation, warnings?: Warning[]) {
+      sourceRange?: SourceRange, astNode?: AstNodeWithLanguage,
+      description?: string, jsdoc?: jsdoc.Annotation, warnings?: Warning[]) {
     this.sourceRange = sourceRange;
     this.astNode = astNode;
     this.description = description;

--- a/packages/analyzer/src/model/import.ts
+++ b/packages/analyzer/src/model/import.ts
@@ -14,7 +14,7 @@
 
 import {Document} from './document';
 import {Feature} from './feature';
-import {SourceRange} from './model';
+import {AstNodeWithLanguage, SourceRange} from './model';
 import {Resolvable} from './resolvable';
 import {FileRelativeUrl, ResolvedUrl} from './url';
 import {Severity, Warning} from './warning';
@@ -44,7 +44,7 @@ export class ScannedImport implements Resolvable {
    */
   urlSourceRange: SourceRange|undefined;
 
-  astNode: any|null;
+  astNode: AstNodeWithLanguage|undefined;
 
   warnings: Warning[] = [];
 
@@ -57,7 +57,7 @@ export class ScannedImport implements Resolvable {
   constructor(
       type: string, url: FileRelativeUrl|undefined,
       sourceRange: SourceRange|undefined, urlSourceRange: SourceRange|undefined,
-      ast: any|null, lazy: boolean) {
+      ast: AstNodeWithLanguage|undefined, lazy: boolean) {
     this.type = type;
     this.url = url;
     this.sourceRange = sourceRange;
@@ -163,15 +163,15 @@ export class Import implements Feature {
   readonly kinds = new Set(['import']);
   readonly sourceRange: SourceRange|undefined;
   readonly urlSourceRange: SourceRange|undefined;
-  readonly astNode: any|null;
+  readonly astNode: AstNodeWithLanguage|undefined;
   readonly warnings: Warning[];
   readonly lazy: boolean;
 
   constructor(
       url: ResolvedUrl, originalUrl: FileRelativeUrl, type: string,
       document: Document|undefined, sourceRange: SourceRange|undefined,
-      urlSourceRange: SourceRange|undefined, ast: any, warnings: Warning[],
-      lazy: boolean) {
+      urlSourceRange: SourceRange|undefined, ast: AstNodeWithLanguage|undefined,
+      warnings: Warning[], lazy: boolean) {
     this.url = url;
     this.originalUrl = originalUrl;
     this.type = type;

--- a/packages/analyzer/src/model/inline-document.ts
+++ b/packages/analyzer/src/model/inline-document.ts
@@ -15,8 +15,10 @@
 import * as babel from '@babel/types';
 import * as dom5 from 'dom5/lib/index-next';
 import {ASTNode} from 'parse5';
+import * as shady from 'shady-css-parser';
 import * as util from 'util';
 
+import {ParsedCssDocument} from '..';
 import {isFakeNode, ParsedHtmlDocument} from '../html/html-document';
 import {JavaScriptDocument} from '../javascript/javascript-document';
 import * as jsdoc from '../javascript/jsdoc';
@@ -36,15 +38,26 @@ export interface InlineDocInfo {
   baseUrl?: ResolvedUrl;
 }
 
-export type AstNodeWithLanguage = {
-  language: 'html',
-  node: dom5.Node,
-  containingDocument: ParsedHtmlDocument,
-}|{
-  language: 'js',
-  node: babel.Node,
-  containingDocument: JavaScriptDocument,
-};
+export interface HtmlAstNode {
+  language: 'html';
+  node: dom5.Node;
+  containingDocument: ParsedHtmlDocument;
+}
+;
+
+export interface JsAstNode<N extends babel.Node = babel.Node> {
+  language: 'js';
+  node: N;
+  containingDocument: JavaScriptDocument;
+}
+
+export interface CssAstNode {
+  language: 'css';
+  node: shady.Node;
+  containingDocument: ParsedCssDocument;
+}
+
+export type AstNodeWithLanguage = HtmlAstNode|JsAstNode|CssAstNode;
 
 /**
  * Represents an inline document, usually a <script> or <style> tag in an HTML

--- a/packages/analyzer/src/model/property.ts
+++ b/packages/analyzer/src/model/property.ts
@@ -13,7 +13,7 @@
  */
 
 import * as jsdoc from '../javascript/jsdoc';
-import {SourceRange} from '../model/model';
+import {JsAstNode, SourceRange} from '../model/model';
 
 import {Privacy, ScannedFeature} from './model';
 import {Warning} from './warning';
@@ -26,6 +26,7 @@ export interface ScannedProperty extends ScannedFeature {
   readOnly?: boolean;
   changeEvent?: string;
   warnings: Warning[];
+  astNode: JsAstNode|undefined;
 }
 
 export interface Property {
@@ -39,4 +40,5 @@ export interface Property {
   readonly sourceRange?: SourceRange;
   readonly inheritedFrom?: string;
   readonly changeEvent?: string;
+  readonly astNode: JsAstNode|undefined;
 }

--- a/packages/analyzer/src/model/reference.ts
+++ b/packages/analyzer/src/model/reference.ts
@@ -16,6 +16,7 @@ import {NodePath} from '@babel/traverse';
 import * as babel from '@babel/types';
 import * as util from 'util';
 
+import {AstNodeWithLanguage} from '..';
 import * as esutil from '../javascript/esutil';
 import {Annotation} from '../javascript/jsdoc';
 
@@ -37,12 +38,12 @@ export class ScannedReference<K extends keyof FeatureKindMap> extends
   readonly kind: K;
   readonly sourceRange: SourceRange|undefined;
   readonly astPath: NodePath;
-  readonly astNode: babel.Node|undefined;
+  readonly astNode: AstNodeWithLanguage|undefined;
 
   constructor(
       kind: K, identifier: string, sourceRange: SourceRange|undefined,
-      astNode: babel.Node|undefined, astPath: NodePath, description?: string,
-      jsdoc?: Annotation, warnings?: Warning[]) {
+      astNode: AstNodeWithLanguage|undefined, astPath: NodePath,
+      description?: string, jsdoc?: Annotation, warnings?: Warning[]) {
     super(sourceRange, astNode, description, jsdoc, warnings);
     this.kind = kind;
     this.astNode = astNode;
@@ -105,7 +106,8 @@ export class ScannedReference<K extends keyof FeatureKindMap> extends
       }
       [feature] = features;
     }
-    return new Reference<FeatureKindMap[K]>(this, feature, warnings);
+    return new Reference<FeatureKindMap[K]>(
+        this.identifier, this.sourceRange, this.astNode, feature, warnings);
   }
 }
 
@@ -235,15 +237,17 @@ export class Reference<F extends Feature> implements Feature {
   readonly identifiers = emptySet;
   readonly identifier: string;
   readonly sourceRange: SourceRange|undefined;
-  readonly astNode: any;
+  readonly astNode: AstNodeWithLanguage|undefined;
   readonly feature: F|undefined;
   readonly warnings: ReadonlyArray<Warning>;
 
   constructor(
-      scannedReference: ScannedReference<any>, feature: F|undefined,
+      identifier: string, sourceRange: SourceRange|undefined,
+      astNode: AstNodeWithLanguage|undefined, feature: F|undefined,
       warnings: ReadonlyArray<Warning>) {
-    this.identifier = scannedReference.identifier;
-    this.sourceRange = scannedReference.sourceRange;
+    this.identifier = identifier;
+    this.sourceRange = sourceRange;
+    this.astNode = astNode;
     this.warnings = warnings;
     this.feature = feature;
   }

--- a/packages/analyzer/src/model/resolvable.ts
+++ b/packages/analyzer/src/model/resolvable.ts
@@ -23,6 +23,7 @@ export interface Resolvable extends ScannedFeature {
   resolve(document: Document): Feature|undefined;
 }
 
-export function isResolvable(x: any): x is Resolvable {
-  return x.resolve && typeof x.resolve === 'function';
+export function isResolvable(x: ScannedFeature&
+                             {resolve?: Function}): x is Resolvable {
+  return !!x.resolve && typeof x.resolve === 'function';
 }

--- a/packages/analyzer/src/model/warning.ts
+++ b/packages/analyzer/src/model/warning.ts
@@ -254,9 +254,8 @@ export interface EditResult {
  * over later ones.
  */
 export async function applyEdits(
-    edits: Edit[],
-    loader: (url: ResolvedUrl) =>
-        Promise<ParsedDocument<any, any>>): Promise<EditResult> {
+    edits: Edit[], loader: (url: ResolvedUrl) => Promise<ParsedDocument>):
+    Promise<EditResult> {
   const result: EditResult = {
     appliedEdits: [],
     incompatibleEdits: [],

--- a/packages/analyzer/src/parser/parser.ts
+++ b/packages/analyzer/src/parser/parser.ts
@@ -18,7 +18,7 @@ import {UrlResolver} from '../url-loader/url-resolver';
 
 import {ParsedDocument} from './document';
 
-export interface Parser<D extends ParsedDocument<any, any>> {
+export interface Parser<D extends ParsedDocument> {
   parse(
       contents: string, url: ResolvedUrl, urlResolver: UrlResolver,
       inlineDocInfo?: InlineDocInfo): D;

--- a/packages/analyzer/src/polymer/behavior-scanner.ts
+++ b/packages/analyzer/src/polymer/behavior-scanner.ts
@@ -13,7 +13,6 @@
  */
 
 import {NodePath} from '@babel/traverse';
-
 import * as babel from '@babel/types';
 
 import {getIdentifierName, getNamespacedIdentifier} from '../javascript/ast-value';
@@ -156,9 +155,8 @@ class BehaviorVisitor implements Visitor {
         return;
       }
     }
-
     this._startBehavior(new ScannedBehavior({
-      astNode: node,
+      astNode: {language: 'js', node, containingDocument: this.document},
       statementAst: esutil.getCanonicalStatement(path),
       description: parsedJsdocs.description,
       events: esutil.getEventComments(node),
@@ -272,7 +270,11 @@ class BehaviorVisitor implements Visitor {
               'behavior',
               behaviorName,
               this.document.sourceRangeForNode(arrElement)!,
-              arrElement,
+              {
+                language: 'js',
+                node: arrElement,
+                containingDocument: this.document
+              },
               path));
         }
       }

--- a/packages/analyzer/src/polymer/css-import-scanner.ts
+++ b/packages/analyzer/src/polymer/css-import-scanner.ts
@@ -42,7 +42,7 @@ export class CssImportScanner implements HtmlScanner {
             href,
             document.sourceRangeForNode(node)!,
             document.sourceRangeForAttributeValue(node, 'href')!,
-            node,
+            {language: 'html', node, containingDocument: document},
             false));
       }
     });

--- a/packages/analyzer/src/polymer/declaration-property-handlers.ts
+++ b/packages/analyzer/src/polymer/declaration-property-handlers.ts
@@ -53,7 +53,7 @@ export function getBehaviorReference(
         'behavior',
         behaviorName,
         document.sourceRangeForNode(argNode)!,
-        argNode,
+        {language: 'js', node: argNode, containingDocument: document},
         path)
   };
 }

--- a/packages/analyzer/src/polymer/docs.ts
+++ b/packages/analyzer/src/polymer/docs.ts
@@ -91,7 +91,7 @@ export function annotateEvent(annotation: jsdoc.Annotation): ScannedEvent {
         undefined,
     jsdoc: annotation,
     sourceRange: undefined,
-    astNode: null,
+    astNode: undefined,
     warnings: [],
     params: []
   };

--- a/packages/analyzer/src/polymer/js-utils.ts
+++ b/packages/analyzer/src/polymer/js-utils.ts
@@ -15,9 +15,9 @@
 import * as babel from '@babel/types';
 
 import {configurationProperties, getAttachedComment, getClosureType, getOrInferPrivacy, getPropertyName} from '../javascript/esutil';
+import {JavaScriptDocument} from '../javascript/javascript-document';
 import * as jsdoc from '../javascript/jsdoc';
 import {Severity, SourceRange, Warning} from '../model/model';
-import {ParsedDocument} from '../parser/document';
 
 import {ScannedPolymerProperty} from './polymer-element';
 
@@ -27,7 +27,7 @@ import {ScannedPolymerProperty} from './polymer-element';
 export function toScannedPolymerProperty(
     node: babel.ObjectMethod|babel.ObjectProperty|babel.ClassMethod,
     sourceRange: SourceRange,
-    document: ParsedDocument): ScannedPolymerProperty|undefined {
+    document: JavaScriptDocument): ScannedPolymerProperty|undefined {
   const parsedJsdoc = jsdoc.parseJsdoc(getAttachedComment(node) || '');
   const description = parsedJsdoc.description.trim();
   const maybeName = getPropertyName(node);
@@ -64,7 +64,7 @@ export function toScannedPolymerProperty(
     description,
     sourceRange,
     warnings,
-    astNode: node,
+    astNode: {node, language: 'js', containingDocument: document},
     isConfiguration: configurationProperties.has(name),
     jsdoc: parsedJsdoc,
     privacy: getOrInferPrivacy(name, parsedJsdoc)

--- a/packages/analyzer/src/polymer/polymer-core-feature-scanner.ts
+++ b/packages/analyzer/src/polymer/polymer-core-feature-scanner.ts
@@ -65,7 +65,7 @@ class PolymerCoreFeatureVisitor implements Visitor {
         jsdoc.parseJsdoc(esutil.getAttachedComment(parent) || '');
     const feature = new ScannedPolymerCoreFeature(
         this.document.sourceRangeForNode(assignment),
-        assignment,
+        {node: assignment, language: 'js', containingDocument: this.document},
         parsedJsdoc.description.trim(),
         parsedJsdoc);
     this.features.push(feature);
@@ -100,7 +100,7 @@ class PolymerCoreFeatureVisitor implements Visitor {
         jsdoc.parseJsdoc(esutil.getAttachedComment(parent) || '');
     const feature = new ScannedPolymerCoreFeature(
         this.document.sourceRangeForNode(call),
-        call,
+        {language: 'js', node: call, containingDocument: this.document},
         parsedJsdoc.description.trim(),
         parsedJsdoc);
     this.features.push(feature);

--- a/packages/analyzer/src/polymer/polymer-element-mixin.ts
+++ b/packages/analyzer/src/polymer/polymer-element-mixin.ts
@@ -14,7 +14,7 @@
 import * as babel from '@babel/types';
 
 import {Annotation as JsDocAnnotation} from '../javascript/jsdoc';
-import {Class, Document, ElementMixin, Privacy, ScannedElementMixin, ScannedMethod, ScannedReference, SourceRange} from '../model/model';
+import {AstNodeWithLanguage, Class, Document, ElementMixin, Privacy, ScannedElementMixin, ScannedMethod, ScannedReference, SourceRange} from '../model/model';
 
 import {addMethod, addProperty, getBehaviors, LocalId, Observer, PolymerExtension, PolymerProperty, ScannedPolymerExtension, ScannedPolymerProperty} from './polymer-element';
 
@@ -26,7 +26,7 @@ export interface Options {
   privacy: Privacy;
   sourceRange: SourceRange;
   mixins: ScannedReference<'element-mixin'>[];
-  astNode: babel.Node;
+  astNode: AstNodeWithLanguage;
   statementAst: babel.Statement|undefined;
   classAstNode?: babel.Node;
 }

--- a/packages/analyzer/src/polymer/polymer-element-scanner.ts
+++ b/packages/analyzer/src/polymer/polymer-element-scanner.ts
@@ -63,7 +63,7 @@ class ElementVisitor implements Visitor {
     const jsDoc = jsdoc.parseJsdoc(rawDescription || '');
     const element = new ScannedPolymerElement({
       className,
-      astNode: node,
+      astNode: {node, language: 'js', containingDocument: this.document},
       statementAst: esutil.getCanonicalStatement(path),
       description: jsDoc.description,
       events: esutil.getEventComments(parent),

--- a/packages/analyzer/src/polymer/polymer-element.ts
+++ b/packages/analyzer/src/polymer/polymer-element.ts
@@ -20,7 +20,7 @@ import {getOrInferPrivacy} from '../javascript/esutil';
 import * as jsdoc from '../javascript/jsdoc';
 import {Annotation as JsDocAnnotation, Annotation} from '../javascript/jsdoc';
 import {ImmutableArray} from '../model/immutable';
-import {Class, Document, Element, ElementBase, LiteralValue, Privacy, Property, ScannedAttribute, ScannedElement, ScannedElementBase, ScannedEvent, ScannedMethod, ScannedProperty, SourceRange, Warning} from '../model/model';
+import {AstNodeWithLanguage, Class, Document, Element, ElementBase, LiteralValue, Privacy, Property, ScannedAttribute, ScannedElement, ScannedElementBase, ScannedEvent, ScannedMethod, ScannedProperty, SourceRange, Warning} from '../model/model';
 import {ScannedReference} from '../model/reference';
 
 import {Behavior} from './behavior';
@@ -155,8 +155,7 @@ export interface Options {
 
   abstract: boolean;
   privacy: Privacy;
-  // TODO(rictic): make this AstNodeWithLanguage
-  astNode: any;
+  astNode: AstNodeWithLanguage;
   statementAst: babel.Statement|undefined;
   sourceRange: SourceRange|undefined;
 }

--- a/packages/analyzer/src/polymer/polymer2-mixin-scanner.ts
+++ b/packages/analyzer/src/polymer/polymer2-mixin-scanner.ts
@@ -87,7 +87,7 @@ export class MixinVisitor implements Visitor {
     const mixin = new ScannedPolymerElementMixin({
       name: namespacedName,
       sourceRange,
-      astNode: node,
+      astNode: {language: 'js', node, containingDocument: this._document},
       statementAst: esutil.getCanonicalStatement(nodePath),
       description: docs.description,
       summary: (summaryTag && summaryTag.description) || '',

--- a/packages/analyzer/src/polymer/pseudo-element-scanner.ts
+++ b/packages/analyzer/src/polymer/pseudo-element-scanner.ts
@@ -43,7 +43,7 @@ export class PseudoElementScanner implements HtmlScanner {
         const tagName = pseudoTag && pseudoTag.name;
         if (tagName) {
           const element = new ScannedPolymerElement({
-            astNode: node,
+            astNode: {language: 'html', node, containingDocument: document},
             statementAst: undefined,
             tagName: tagName,
             jsdoc: parsedJsdoc,

--- a/packages/analyzer/src/test/javascript/javascript-export-scanner_test.ts
+++ b/packages/analyzer/src/test/javascript/javascript-export-scanner_test.ts
@@ -15,10 +15,14 @@
 
 import {assert} from 'chai';
 
+import {Analyzer} from '../../core/analyzer';
 import {createForDirectory, fixtureDir} from '../test-utils';
 
-suite('JavaScriptExportScanner', async () => {
-  const {analyzer} = await createForDirectory(fixtureDir);
+suite('JavaScriptExportScanner', () => {
+  let analyzer: Analyzer;
+  suiteSetup(async () => {
+    analyzer = (await createForDirectory(fixtureDir)).analyzer;
+  });
 
   async function getExports(filename: string) {
     const analysis = await analyzer.analyze([filename]);
@@ -30,7 +34,7 @@ suite('JavaScriptExportScanner', async () => {
     return result.value.getFeatures({kind: 'export'});
   }
 
-  test('identifies the names that of exports', async () => {
+  test('identifies the names of exports', async () => {
     const features = await getExports('javascript/all-export-types.js');
     assert.deepEqual([...features].map((f) => [...f.identifiers]), [
       ['namedConstIdentifier'],

--- a/packages/analyzer/src/typescript/typescript-import-scanner.ts
+++ b/packages/analyzer/src/typescript/typescript-import-scanner.ts
@@ -40,7 +40,8 @@ export class TypeScriptImportScanner implements
             // TODO(justinfagnani): make SourceRanges work
             null as any as SourceRange,
             null as any as SourceRange,
-            node,
+            // TODO(justinfagnani): add TypeScript to AstNodeWithLanguage
+            undefined,
             false));
       }
     }

--- a/packages/bundler/src/es6-rewriter.ts
+++ b/packages/bundler/src/es6-rewriter.ts
@@ -14,7 +14,7 @@
 import traverse, {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 import * as clone from 'clone';
-import {FileRelativeUrl, Import, PackageRelativeUrl, ResolvedUrl} from 'polymer-analyzer';
+import {FileRelativeUrl, PackageRelativeUrl, ResolvedUrl} from 'polymer-analyzer';
 import {rollup} from 'rollup';
 
 import {getAnalysisDocument} from './analyzer-utils';
@@ -93,14 +93,15 @@ export class Es6Rewriter {
                   imported: false,
                   externalPackages: true,
                   excludeBackreferences: true,
-                }) as Set<Import>;
+                });
                 const resolutions = new Map<string, ResolvedUrl>();
                 jsImportResolvedUrls.set(id, resolutions);
                 for (const jsImport of jsImports) {
-                  const source = jsImport.astNode && jsImport.astNode.source &&
-                      jsImport.astNode.source.value;
-                  if (source && jsImport.document !== undefined) {
-                    resolutions.set(source, jsImport.document.url);
+                  const node = jsImport.astNode.node;
+                  if ('source' in node) {
+                    if (node.source && jsImport.document !== undefined) {
+                      resolutions.set(node.source.value, jsImport.document.url);
+                    }
                   }
                 }
               }

--- a/packages/bundler/src/html-bundler.ts
+++ b/packages/bundler/src/html-bundler.ts
@@ -248,7 +248,10 @@ export class HtmlBundler {
         if (existingImportDependencies.get(existingImport.document!.url)!
                 .indexOf(importUrl) !== -1) {
           const newPrependTarget = dom5.query(
-              ast, (node) => isSameNode(node, existingImport.astNode));
+              ast,
+              (node) => existingImport.astNode !== undefined &&
+                  existingImport.astNode.language === 'html' &&
+                  isSameNode(node, existingImport.astNode.node));
 
           // IF we don't have a target already or if the old target comes
           // after the new one in the source code, the new one will replace
@@ -467,11 +470,13 @@ export class HtmlBundler {
       const {code} = await es6Rewriter.rollup(
           this.document.parsedDocument.baseUrl,
           inlineModuleScript.parsedDocument.contents);
-      // Second argument 'true' tells encodeString to escape the <script>
-      // content.
-      dom5.setTextContent(
-          (inlineModuleScript.astNode as any).node,
-          encodeString(`\n${code}\n`, true));
+      if (inlineModuleScript.astNode &&
+          inlineModuleScript.astNode.language === 'html') {
+        // Second argument 'true' tells encodeString to escape the <script>
+        // content.
+        dom5.setTextContent(
+            inlineModuleScript.astNode.node, encodeString(`\n${code}\n`, true));
+      }
     }
   }
 

--- a/packages/bundler/src/matchers.ts
+++ b/packages/bundler/src/matchers.ts
@@ -116,7 +116,10 @@ export const elementsWithUrlAttrsToRewrite: Matcher = predicates.AND(
  */
 const nextToHiddenDiv = (offset: number) => {
   return (node: parse5.ASTNode) => {
-    const siblings = node.parentNode!.childNodes!;
+    if (!node.parentNode) {
+      return false;
+    }
+    const siblings = node.parentNode.childNodes!;
     const hiddenDivIndex = siblings.indexOf(node) + offset;
     if (hiddenDivIndex < 0 || hiddenDivIndex >= siblings.length) {
       return false;

--- a/packages/bundler/src/test/bundler_test.ts
+++ b/packages/bundler/src/test/bundler_test.ts
@@ -902,10 +902,10 @@ suite('Bundler', () => {
     test('Entrypoint body content should not be wrapped', async () => {
       const {ast: doc} = await bundle('default.html');
       assert(doc);
-      const myElement = dom5.query(doc, preds.hasTagName('my-element'));
+      const myElement = dom5.query(doc, preds.hasTagName('my-element'))!;
       assert(myElement);
-      assert(preds.NOT(preds.parentMatches(
-          preds.hasAttr('by-polymer-bundler')))(<parse5.ASTNode>myElement));
+      assert(preds.NOT(
+          preds.parentMatches(preds.hasAttr('by-polymer-bundler')))(myElement));
     });
 
     test('eagerly importing a fragment', async () => {

--- a/packages/bundler/src/test/shards_test.ts
+++ b/packages/bundler/src/test/shards_test.ts
@@ -98,7 +98,7 @@ suite('Bundler', () => {
           [common, entrypoint1, entrypoint2],
           {strategy: generateSharedDepsMergeStrategy(2)});
       assert.equal(documents.size, 4);
-      const commonDoc: parse5.ASTNode = documents.get(common)!.ast;
+      const commonDoc = documents.get(common)!.ast;
       assert.isDefined(commonDoc);
       const entrypoint1Doc = documents.get(entrypoint1)!.ast;
       assert.isDefined(entrypoint1Doc);
@@ -129,7 +129,7 @@ suite('Bundler', () => {
             strategy: generateShellMergeStrategy(analyzer.resolveUrl(shell)!, 2)
           });
       assert.equal(documents.size, 3);
-      const shellDoc: parse5.ASTNode = documents.get(shell)!.ast;
+      const shellDoc = documents.get(shell)!.ast;
       assert.isDefined(shellDoc);
       const entrypoint1Doc = documents.get(entrypoint1)!.ast;
       assert.isDefined(entrypoint1Doc);

--- a/packages/linter/src/html/move-style-into-template.ts
+++ b/packages/linter/src/html/move-style-into-template.ts
@@ -64,7 +64,7 @@ class MoveStyleIntoTemplate extends HtmlRule {
     const warnings: Warning[] = [];
     const domModules = document.getFeatures({kind: 'dom-module'});
     for (const domModule of domModules) {
-      const moduleChildren = domModule.astNode.childNodes || [];
+      const moduleChildren = domModule.astNode.node.childNodes || [];
       const template = moduleChildren.find((n) => n.tagName === 'template');
       if (!template) {
         continue;

--- a/packages/linter/src/html/undefined-elements.ts
+++ b/packages/linter/src/html/undefined-elements.ts
@@ -51,7 +51,8 @@ class UndefinedElements extends HtmlRule {
       });
 
       if (el.size === 0) {
-        const sourceRange = parsedDocument.sourceRangeForStartTag(ref.astNode);
+        const sourceRange =
+            parsedDocument.sourceRangeForStartTag(ref.astNode.node);
         if (!sourceRange) {
           continue;
         }

--- a/packages/linter/src/html/validate-element-name.ts
+++ b/packages/linter/src/html/validate-element-name.ts
@@ -51,9 +51,13 @@ class ValidateElementName extends Rule {
         continue;  // Valid element
       }
 
-      const isP2 = babel.isClassDeclaration(el.astNode);
+      if (el.astNode === undefined || el.astNode.language !== 'js') {
+        continue;
+      }
+
+      const isP2 = babel.isClassDeclaration(el.astNode.node);
       let sourceRange = el.sourceRange;
-      babelTraverse(el.astNode, {
+      babelTraverse(el.astNode.node, {
         noScope: true,
         ObjectProperty(path) {
           if (isP2) {

--- a/packages/linter/src/polymer/call-super-in-callbacks.ts
+++ b/packages/linter/src/polymer/call-super-in-callbacks.ts
@@ -42,10 +42,14 @@ class CallSuperInCallbacks extends Rule {
         ...document.getFeatures({kind: 'element-mixin'}));
 
     for (const elementLike of elementLikes) {
+      if (elementLike.astNode === undefined ||
+          elementLike.astNode.language !== 'js') {
+        continue;
+      }
       // TODO(rictic): methods should have astNodes, that would make this
       //     simpler. Filed as:
       //     https://github.com/Polymer/polymer-analyzer/issues/562
-      const classBody = getClassBody(elementLike.astNode);
+      const classBody = getClassBody(elementLike.astNode.node);
       if (!classBody) {
         continue;
       }

--- a/packages/linter/src/polymer/content-to-slot-declarations.ts
+++ b/packages/linter/src/polymer/content-to-slot-declarations.ts
@@ -45,7 +45,8 @@ class ContentToSlotDeclarations extends HtmlRule {
     const warnings: Warning[] = [];
 
     for (const domModule of document.getFeatures({kind: 'dom-module'})) {
-      const template = dom5.query(domModule.astNode, p.hasTagName('template'));
+      const template =
+          dom5.query(domModule.astNode.node, p.hasTagName('template'));
       if (!template) {
         continue;
       }

--- a/packages/linter/src/polymer/databind-with-unknown-property.ts
+++ b/packages/linter/src/polymer/databind-with-unknown-property.ts
@@ -53,7 +53,7 @@ class DatabindWithUnknownProperty extends HtmlRule {
       ]);
       const scopedProperties: {scope: SourceRange, property: string}[] = [];
       const domRepeats = dom5.queryAll(
-          domModule.astNode, isDomRepeat, dom5.childNodesIncludeTemplate);
+          domModule.astNode.node, isDomRepeat, dom5.childNodesIncludeTemplate);
       for (const domRepeat of domRepeats) {
         const scope = parsedDocument.sourceRangeForNode(domRepeat)!;
         const itemProperty = dom5.getAttribute(domRepeat, 'as') || 'item';

--- a/packages/linter/src/polymer/element-before-dom-module.ts
+++ b/packages/linter/src/polymer/element-before-dom-module.ts
@@ -114,7 +114,8 @@ class ElementBeforeDomModule extends HtmlRule {
                 `\`<dom-module>\`. If it can't find its \`<dom-module>\` ` +
                 `when it is registered, it will assume it does not have one.`,
             severity: Severity.ERROR,
-            sourceRange: parsedHtml.sourceRangeForStartTag(domModule.astNode) ||
+            sourceRange:
+                parsedHtml.sourceRangeForStartTag(domModule.astNode.node) ||
                 domModule.sourceRange,
           }));
         }

--- a/packages/linter/src/polymer/elements/iron-flex-layout-classes.ts
+++ b/packages/linter/src/polymer/elements/iron-flex-layout-classes.ts
@@ -109,7 +109,7 @@ class IronFlexLayoutClasses extends HtmlRule {
     // Search in the dom-modules.
     for (const domModule of document.getFeatures({kind: 'dom-module'})) {
       const misplacedStyle =
-          dom5.query(domModule.astNode, p.hasTagName('style'));
+          dom5.query(domModule.astNode.node, p.hasTagName('style'));
       if (misplacedStyle) {
         warnings.push(new Warning({
           code: 'iron-flex-layout-classes',
@@ -121,7 +121,8 @@ class IronFlexLayoutClasses extends HtmlRule {
         }));
         continue;
       }
-      const template = dom5.query(domModule.astNode, p.hasTagName('template'));
+      const template =
+          dom5.query(domModule.astNode.node, p.hasTagName('template'));
       if (!template) {
         continue;
       }

--- a/packages/linter/src/polymer/root-selector-to-html.ts
+++ b/packages/linter/src/polymer/root-selector-to-html.ts
@@ -49,7 +49,7 @@ class RootSelectorToHtml extends Rule {
     const domModules = document.getFeatures({kind: 'dom-module'});
     if (domModules.size > 0) {
       for (const domModule of domModules) {
-        const moduleChildren = domModule.astNode.childNodes || [];
+        const moduleChildren = domModule.astNode.node.childNodes || [];
         const template: any =
             moduleChildren.find((m) => m.tagName === 'template');
         if (template === undefined ||

--- a/packages/linter/src/polymer/set-unknown-attribute.ts
+++ b/packages/linter/src/polymer/set-unknown-attribute.ts
@@ -52,7 +52,7 @@ class SetUnknownAttribute extends HtmlRule {
         [...dom5.queryAll(parsedDoc.ast, isDatabindingTemplate)].map(
             (t) => parsedDoc.sourceRangeForNode(t)!);
     for (const ref of elementReferences) {
-      const node = ref.astNode;
+      const node = ref.astNode.node;
       if (!node || !node.tagName) {
         continue;
       }


### PR DESCRIPTION
This removes the largest remaining use of `any` in the analyzer's API. What previously was an AST node is now wrapped with a union discriminated by the language name. This way, a user can process an ast node that might be a parse5 node, or a babel node, or even a future language, all in a type safe way.

The main place where we'll get errors without Typescript warning is is where we're doing `babel.isSpecificTypeOfNode(feature.astNode)`. The babel-types API is very permissive in the types of the values it accepts, meaning that this will not warn, but it will now always return false. We need to change that to `feature.astNode.node`.