### PR TITLE
Add `polymer lint` to the Polymer 3 element template integration test.

### DIFF
--- a/packages/cli/src/test/integration/integration_test.ts
+++ b/packages/cli/src/test/integration/integration_test.ts
@@ -52,9 +52,7 @@ suite('integration tests', function() {
       // packages.
       await exec('npm install', {cwd: dir});
 
-      // TODO(#130): Add this back in when `polymer lint` has a Polymer 3
-      // option.
-      // await runCommand(binPath, ['lint'], {cwd: dir});
+      await runCommand(binPath, ['lint'], {cwd: dir});
 
       // TODO(#113): Remove the `--module-resolution=node` argument once
       // `polymer test` passes them in correctly

--- a/packages/cli/templates/element/polymer-3.x/polymer.json
+++ b/packages/cli/templates/element/polymer-3.x/polymer.json
@@ -1,4 +1,9 @@
 {
   "npm": true,
-  "moduleResolution": "node"
+  "moduleResolution": "node",
+  "lint": {
+    "rules": [
+      "polymer-3"
+    ]
+  }
 }


### PR DESCRIPTION
This was specifically excluded [in #115](https://github.com/Polymer/tools/pull/115/files#diff-10eed550dca082f37ae2a959b6f87823R49) because `polymer lint` did not have a set of rules for Polymer 3 at the time.