### PR TITLE
Don't build when executing test:unit or test:integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - google-chrome-stable
 
 env:
-  - TEST_COMMAND=test
+  - TEST_COMMAND="run test:unit"
   - TEST_COMMAND="run test:integration"
 
 language: node_js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm run test:windows
+  - npm run test:unit:windows
   - npm run test:integration:windows
 
 # Don't actually build.

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "test": "lerna run test",
-    "test:windows": "lerna run test --ignore polyserve",
+    "test": "lerna run build && lerna run test:unit",
     "test:integration": "lerna run test:integration",
-    "test:integration:windows": "lerna run test:integration"
+    "test:integration:windows": "lerna run test:integration",
+    "test:unit": "lerna run test:unit",
+    "test:unit:windows": "lerna run test:unit --ignore polyserve"
   },
   "devDependencies": {
     "lerna": "^2.10.1"

--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -22,10 +22,11 @@
     "build": "gulp build",
     "release": "npm run compile",
     "lint": "gulp lint",
-    "test": "npm run clean && npm run build && npm run lint && mocha",
-    "quicktest": "export QUICK_TESTS=true; npm run build && mocha",
+    "test": "npm run clean && npm run build && npm run lint && npm run test:unit",
+    "quicktest": "export QUICK_TESTS=true; npm run build && npm run test:unit",
     "initBench": "if [ ! -d bower_components ]; then bower install -s -f PolymerElements/app-elements PolymerElements/iron-elements PolymerElements/gold-elements PolymerElements/paper-elements PolymerElements/neon-elements GoogleWebComponents/google-web-components ; fi",
     "benchmark": "npm run build && npm run initBench && node --expose-gc lib/perf/parse-all-benchmark.js",
+    "test:unit": "mocha",
     "test:watch": "tsc-then -- mocha -c",
     "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i",
     "prepublishOnly": "tsc && npm test"

--- a/packages/browser-capabilities/package.json
+++ b/packages/browser-capabilities/package.json
@@ -14,7 +14,8 @@
     "build": "rm -Rf lib/ && tsc",
     "build:watch": "tsc --watch",
     "format": "find src -name '*.ts' | xargs clang-format --style=file -i",
-    "test": "npm run build && mocha",
+    "test": "npm run build && npm run test:unit",
+    "test:unit": "mocha",
     "test:watch": "watchy -w src -- npm run test"
   },
   "devDependencies": {

--- a/packages/build/gulpfile.js
+++ b/packages/build/gulpfile.js
@@ -52,7 +52,9 @@ gulp.task('compile', () => {
       .pipe(gulp.dest('lib'));
 });
 
-gulp.task('test', ['build'], function() {
+gulp.task('test', ['build', 'test:unit']);
+
+gulp.task('test:unit', function() {
   return gulp.src('lib/test/**/*_test.js', {read: false}).pipe(mocha({
     ui: 'tdd',
     reporter: 'spec',

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -54,8 +54,9 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && tslint -c tslint.json src/*.ts src/**/*.ts && mocha",
-    "format": "find src | grep '\\.js$\\|\\.ts$' | xargs ./node_modules/.bin/clang-format --style=file -i"
+    "format": "find src | grep '\\.js$\\|\\.ts$' | xargs ./node_modules/.bin/clang-format --style=file -i",
+    "test": "npm run build && tslint -c tslint.json src/*.ts src/**/*.ts && npm run test:unit",
+    "test:unit": "mocha"
   },
   "author": "The Polymer Project Authors",
   "license": "BSD-3-Clause",

--- a/packages/cli/gulpfile.js
+++ b/packages/cli/gulpfile.js
@@ -43,13 +43,7 @@ gulp.task('compile', () => {
 
 gulp.task('copy', () => gulp.src(['src/**/.gitignore']).pipe(gulp.dest('lib')));
 
-gulp.task(
-    'test',
-    ['build'],
-    () => gulp.src('lib/test/unit/**/*_test.js', {read: false}).pipe(mocha({
-      ui: 'tdd',
-      reporter: 'spec',
-    })));
+gulp.task('test', ['build', 'test:unit']);
 
 gulp.task(
     'test:integration',
@@ -59,6 +53,13 @@ gulp.task(
                 ui: 'tdd',
                 reporter: 'spec',
               })));
+
+gulp.task(
+    'test:unit', 
+    () => gulp.src('lib/test/unit/**/*_test.js', {read: false}).pipe(mocha({
+      ui: 'tdd',
+      reporter: 'spec',
+    })));
 
 gulp.task(
     'tslint',

--- a/packages/cli/gulpfile.js
+++ b/packages/cli/gulpfile.js
@@ -47,7 +47,6 @@ gulp.task('test', ['build', 'test:unit']);
 
 gulp.task(
     'test:integration',
-    ['build'],
     () => gulp.src(['lib/test/integration/**/*_test.js'], {read: false})
               .pipe(mocha({
                 ui: 'tdd',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
     "test:smoke": "gulp test",
     "test:smoke-lint": "gulp test lint",
     "test:integration": "gulp test:integration",
+    "test:unit": "gulp test:unit",
     "format": "find src gulpfile.js \\( -iname '*.ts' -o -iname '*.js' \\) -not -path '*fixtures*' | xargs clang-format --style=file -i",
     "test:watch": "tsc-then -- mocha -c --ui tdd lib/test/integration/*_test.js lib/test/unit/*_test.js lib/test/unit/*/*_test.js"
   },

--- a/packages/common/gulp-tasks.js
+++ b/packages/common/gulp-tasks.js
@@ -154,13 +154,21 @@ module.exports.buildAll = function(options) {
 module.exports.test = function(options) {
   module.exports.buildAll(options);
 
-  task('test', ['build'], () =>
-    gulp.src(['test/**/*_test.js', 'src/test/**/*_test.js'], {read: false})
+  task('test', ['build', 'test:unit', 'test:integration']);
+  
+  task('test:integration', () =>
+    gulp.src(['lib/test/integration/**/*_test.js'], {read: false})
         .pipe(mocha({
           ui: 'tdd',
           reporter: 'spec',
-        }))
-  );
+        })));
+
+  task('test:unit', () =>
+    gulp.src(['lib/test/unit/**/*_test.js'], {read: false})
+        .pipe(mocha({
+          ui: 'tdd',
+          reporter: 'spec',
+        })));
 }
 
 module.exports.generateCompleteTaskgraph = function(options) {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -10,6 +10,7 @@
     "init": "gulp init",
     "build": "gulp build",
     "test": "gulp test",
+    "test:unit": "gulp test:unit",
     "prepublishOnly": "gulp build-all",
     "format": "find src/ test/ -iname '*.ts' -o -iname '*.js' | xargs clang-format --style=file -i"
   },

--- a/packages/common/package.template.json
+++ b/packages/common/package.template.json
@@ -7,7 +7,8 @@
     "build": "gulp build --silent",
     "release": "npm run compile",
     "lint": "gulp lint",
-    "test": "npm run clean && npm run build && npm run lint && mocha",
+    "test": "npm run clean && npm run build && npm run lint && npm run test:unit",
+    "test:unit": "mocha",
     "test:watch": "watchy -w src/ -- npm test --loglevel=silent",
     "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs ./node_modules/.bin/clang-format --style=file -i",
     "prepublish": "tsc && npm test"

--- a/packages/editor-service/package.json
+++ b/packages/editor-service/package.json
@@ -17,8 +17,9 @@
     "build": "tsc",
     "prepublishOnly": "npm run clean && npm run build",
     "lint": "tslint --project ./tsconfig.json",
-    "test": "npm run clean && npm run build && mocha && npm run lint",
-    "test:watch": "tsc-then -- mocha",
+    "test": "npm run clean && npm run build && npm run test:unit && npm run lint",
+    "test:unit": "mocha",
+    "test:watch": "tsc-then -- npm run test:unit",
     "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs ./node_modules/.bin/clang-format --style=file -i"
   },
   "devDependencies": {

--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -46,8 +46,9 @@
     "clean": "touch lib && rm -rf lib && mkdir lib",
     "format": "find src | grep \"\\.[jt]s$\" | xargs clang-format --style=file -i",
     "lint": "tslint -c tslint.json src/*.ts src/**/*.ts",
-    "test": "npm run build && mocha && npm run lint",
-    "test:watch": "tsc-then -- mocha",
+    "test": "npm run build && npm run test:unit && npm run lint",
+    "test:unit": "mocha",
+    "test:watch": "tsc-then -- npm run test:unit",
     "run-on-polymer": "npm run build && (cd test/integration && bower install --silent) && INTEGRATION_TEST=true mocha lib/test/integration_test.js"
   },
   "repository": {

--- a/packages/polyserve/package.json
+++ b/packages/polyserve/package.json
@@ -12,7 +12,8 @@
     "start": "./bin/polyserve",
     "clean": "rimraf lib",
     "build": "npm run clean && tsc",
-    "test": "npm run build && mocha && tslint \"src/**/*.ts\"",
+    "test": "npm run build && npm run test:unit && tslint \"src/**/*.ts\"",
+    "test:unit": "mocha",
     "test:watch": "tsc-then -- mocha -c",
     "format": "find src test -iname '*.ts' | xargs clang-format --style=file -i"
   },

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -16,7 +16,8 @@
   "homepage": "https://github.com/Polymer/polymer-project-config#readme",
   "scripts": {
     "build": "tsc && typescript-json-schema src/index.ts ProjectOptions --ignoreErrors -o lib/schema.json",
-    "test": "npm run build && mocha --ui tdd",
+    "test": "npm run build && npm run test:unit",
+    "test:unit": "mocha --ui tdd",
     "format": "find src test \\( -iname '*.ts' -o -iname '*.js' \\) | xargs clang-format --style=file -i"
   },
   "dependencies": {


### PR DESCRIPTION
Install steps already run build tasks and all package 'test' scripts also run build tasks, so travis is spending a lot of time unnecessarily running build tasks.  Attempt to solve this by adding `test:unit` npm scripts to all packages and explicitly run those scripts instead.

Also removed the build gulp task dependencies on test:unit or test:integration where found.