### PR TITLE
Fix broken test:unit gulp task.

### DIFF
--- a/packages/build/gulpfile.js
+++ b/packages/build/gulpfile.js
@@ -57,7 +57,7 @@ gulp.task('compile', () => {
       .pipe(gulp.dest('lib'));
 });
 
-gulp.task('test', ['build', 'test:unit']);
+gulp.task('test', (done) => runSeq('build', 'test:unit', done));
 
 gulp.task('test:unit', function() {
   return gulp.src('lib/test/**/*_test.js', {read: false}).pipe(mocha({


### PR DESCRIPTION
gulp dependencies run in parallel, so this recent change broke the test script.