### PR TITLE
Capture and assert on error output.

### DIFF
--- a/packages/build/src/test/js-transform_test.ts
+++ b/packages/build/src/test/js-transform_test.ts
@@ -17,6 +17,7 @@ import * as path from 'path';
 import stripIndent = require('strip-indent');
 
 import {jsTransform} from '../js-transform';
+import {interceptOutput} from './util';
 
 suite('jsTransform', () => {
   const rootDir =
@@ -66,10 +67,13 @@ suite('jsTransform', () => {
               invalidJs, {compileToEs5: true, softSyntaxError: false}));
     });
 
-    test('do not throw when softSyntaxError is true', () => {
-      assert.equal(
-          jsTransform(invalidJs, {compileToEs5: true, softSyntaxError: true}),
-          invalidJs);
+    test('do not throw when softSyntaxError is true', async () => {
+      const output = await interceptOutput(async () => {
+        assert.equal(
+            jsTransform(invalidJs, {compileToEs5: true, softSyntaxError: true}),
+            invalidJs);
+      });
+      assert.include(output, '[polymer-build]: failed to parse JavaScript:');
     });
   });
 

--- a/packages/build/src/test/util.ts
+++ b/packages/build/src/test/util.ts
@@ -83,3 +83,41 @@ const transformMapValues =
     <K, V1, V2>(map: Map<K, V1>, transform: (val: V1) => V2): Map<K, V2> =>
         new Map([...map.entries()].map(
             ([key, val]): [K, V2] => [key, transform(val)]));
+
+/**
+ * Calls the given async function and captures all console.log and friends
+ * output while until the returned Promise settles.
+ *
+ * Does not capture plylog, which doesn't seem to be very easy to intercept.
+ *
+ * TODO(rictic): this function is shared across many of our packages,
+ *   put it in a shared package instead.
+ */
+export async function interceptOutput(captured: () => Promise<void>):
+    Promise<string> {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  const buffer: string[] = [];
+  const capture = (...args: any[]) => {
+    buffer.push(args.join(' '));
+  };
+  console.log = capture;
+  console.error = capture;
+  console.warn = capture;
+  const restoreAndGetOutput = () => {
+    console.log = originalLog;
+    console.error = originalError;
+    console.warn = originalWarn;
+    return buffer.join('\n');
+  };
+  try {
+    await captured();
+  } catch (err) {
+    const output = restoreAndGetOutput();
+    console.error(output);
+    throw err;
+  }
+
+  return restoreAndGetOutput();
+}


### PR DESCRIPTION
I noticed when trying out #171 that `build` emits a super scary looking stack trace as part of its expected output when testing. This captures and asserts on that output instead.