### PR TITLE
Added packages and node_modules folders to travis cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,7 @@ install:
 - npm run build
 script:
 - xvfb-run npm $TEST_COMMAND
+cache:
+  directories:
+    - node_modules
+    - packages


### PR DESCRIPTION
There's this caching thing that might speed up our installs https://docs.travis-ci.com/user/caching/

However, according to https://stackoverflow.com/questions/42521884/should-i-have-travis-cache-node-modules-or-home-npm when testing different versions of node in matrix, the cache can result in binaries being cached resulting in binary version mismatches and then failures.

I don't know if any of the packages we are reliant on include binaries, so this may or may not work.  I think by expressing a cache directory, the install step is skipped for all items in the matrix except the first one.

Running this now to try it out.