### PR TITLE
Skip the AutoCompleter suite for the moment due to flaky tests.

### DIFF
--- a/packages/editor-service/src/test/auto-completer_test.ts
+++ b/packages/editor-service/src/test/auto-completer_test.ts
@@ -187,7 +187,9 @@ const attributeCompletions: CompletionItem[] = [
   },
 ];
 
-suite('AutoCompleter', () => {
+// TODO(https://github.com/Polymer/tools/issues/170): these tests are slightly
+//     flaky, skip for now.
+suite.skip('AutoCompleter', () => {
   const indexFile = path.join('editor-service', 'index.html');
   const indexContents = readFileSync(path.join(fixtureDir, indexFile), 'utf-8');
   const tagPosition = {line: 7, column: 9};


### PR DESCRIPTION
See #170