### PR TITLE
Fix node resolution bug with path specifiers and the root package.

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   more strict type of `{} | null | undefined`. If this breaks downstream code,
   that code should probably use a more specific type of `ParsedDocument`, or
   `Document<MoreSpecificParsedDocType>`.
+* Fix node module resolution for the case where components/ directory URL
+  rewriting is happening (e.g. polyserve), and a root package is importing
+  something from its own package using a path.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.23] - 2018-04-17

--- a/packages/analyzer/src/test/javascript/resolve-specifier-node_test.ts
+++ b/packages/analyzer/src/test/javascript/resolve-specifier-node_test.ts
@@ -46,6 +46,10 @@ const scopedRootComponentInfo = {
 };
 
 suite('resolve', async () => {
+  test('non-component root to path', async () => {
+    assert.equal(resolve('./root.js', rootMain), './root.js');
+  });
+
   test('non-component root to shallow dep', async () => {
     assert.equal(
         resolve('shallow', rootMain), './node_modules/shallow/shallow.js');
@@ -67,6 +71,11 @@ suite('resolve', async () => {
     assert.equal(
         resolve('shallow', scopedDepMain, shallowRootComponentInfo),
         '../../shallow/shallow.js');
+  });
+
+  test('component-root to path', async () => {
+    assert.equal(
+        resolve('./root.js', rootMain, shallowRootComponentInfo), './root.js');
   });
 
   test('component-root to shallow dep', async () => {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-<!-- ## Unreleased -->
 <!-- Add new, unreleased items here. -->
+
+## Unreleased
+* `serve`
+  * Fix node module resolution for the case where the root package is served
+    from the components/ directory and imports a module from its own package
+    using a path.
 
 ## v1.7.0-pre.11 [04-17-2018]
 * `build`

--- a/packages/polyserve/CHANGELOG.md
+++ b/packages/polyserve/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Fix node module resolution for the case where the root package is served from
+  the components/ directory and imports a module from its own package using a
+  path.
 <!-- Add new, unreleased items here. -->
 
 ## [0.27.5] (2018-04-17)

--- a/packages/web-component-tester/CHANGELOG.md
+++ b/packages/web-component-tester/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Fix node module resolution for the case where the root package is served from
+  the components/ directory and imports a module from its own package using a
+  path.
 <!-- Add new, unreleased items here. -->
 
 ## 6.6.0-pre.5 - 2018-04-12


### PR DESCRIPTION
Fix node module resolution for the case where components/ directory URL
rewriting is happening (e.g. polyserve), and a root package is importing
something from its own package using a path.

Fixes #125