### PR TITLE
Try caching node_modules and packages/*/node_modules on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,7 @@ script:
 branches:
   only:
   - master
+cache:
+  directories:
+  - node_modules
+  - packages/*/node_modules


### PR DESCRIPTION
I don't know if travis supports `*` in the directories list for caching, but I'm trying that now.