### PR TITLE
Added custom typings for the inplace method of stable.d.ts to avoid implicit any warnings.

### DIFF
--- a/packages/analyzer/custom_typings/stable.d.ts
+++ b/packages/analyzer/custom_typings/stable.d.ts
@@ -1,0 +1,5 @@
+declare module 'stable' {
+  export default {
+    inplace<T>(collection: T[], comparator: (a: T, b: T) => -1 | 0 | 1): void;
+  };
+}

--- a/packages/analyzer/src/model/warning.ts
+++ b/packages/analyzer/src/model/warning.ts
@@ -13,17 +13,16 @@
  */
 
 import * as chalk from 'chalk';
+import stable from 'stable';
 
 import {Analyzer} from '../core/analyzer';
+import {UrlResolver} from '../index';
 import {ParsedDocument} from '../parser/document';
 import {underlineCode} from '../warning/code-printer';
 
 import {Analysis} from './analysis';
 import {comparePositionAndRange, isPositionInsideRange, SourceRange} from './source-range';
-
-import stable = require('stable');
 import {ResolvedUrl} from './url';
-import {UrlResolver} from '../index';
 
 export interface WarningInit {
   readonly message: string;


### PR DESCRIPTION
This was causing warnings to emit on build.  Just getting rid of that.