### PR TITLE
Disable minify-constant-folding plugin.

### DIFF
--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Disable Babel `minify-constant-folding` plugin when minifying. This plugin has a bug that breaks when a constant is exported from a module (https://github.com/babel/minify/issues/820).
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.13] - 2018-04-18

--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -69,8 +69,15 @@ const babelSyntaxPlugins = [
   require('@babel/plugin-syntax-import-meta'),
 ];
 
-const babelPresetMinify =
-    require('babel-preset-minify')({}, {simplifyComparisons: false});
+const babelPresetMinify = require('babel-preset-minify')({}, {
+  // Disable the minify-constant-folding plugin because it has a bug relating to
+  // invalid substitution of constant values into export specifiers:
+  // https://github.com/babel/minify/issues/820
+  evaluate: false,
+
+  // TODO(aomarks) Find out why we disabled this plugin.
+  simplifyComparisons: false,
+});
 
 /**
  * Options for jsTransform.

--- a/packages/build/src/test/js-transform_test.ts
+++ b/packages/build/src/test/js-transform_test.ts
@@ -29,14 +29,23 @@ suite('jsTransform', () => {
         jsTransform('const foo = 3;', {compileToEs5: true}), 'var foo = 3;');
   });
 
-  test('minifies', () => {
-    assert.equal(jsTransform('const foo = 3;', {minify: true}), 'const foo=3;');
-  });
+  suite('minifies', () => {
+    test('a simple expression', () => {
+      assert.equal(
+          jsTransform('const foo = 3;', {minify: true}), 'const foo=3;');
+    });
 
-  test('compiles and minifies', () => {
-    assert.equal(
-        jsTransform('const foo = 3;', {compileToEs5: true, minify: true}),
-        'var foo=3;');
+    test('an exported const', () => {
+      assert.equal(
+          jsTransform('const foo = "foo"; export { foo };', {minify: true}),
+          'const foo="foo";export{foo};');
+    });
+
+    test('and compiles', () => {
+      assert.equal(
+          jsTransform('const foo = 3;', {compileToEs5: true, minify: true}),
+          'var foo=3;');
+    });
   });
 
   test('does not unnecessarily reformat', () => {
@@ -81,7 +90,7 @@ suite('jsTransform', () => {
     const js = 'const foo = 2**2;';
 
     test('minifies', () => {
-      assert.equal(jsTransform(js, {minify: true}), 'const foo=4;');
+      assert.equal(jsTransform(js, {minify: true}), 'const foo=2**2;');
     });
 
     test('compiles to ES5', () => {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 
-<!-- ## Unreleased -->
+## Unreleased
+* `build`, `serve`, `test`:
+  * Disable Babel `minify-constant-folding` plugin when minifying. This plugin has a bug that breaks when a constant is exported from a module (https://github.com/babel/minify/issues/820).
 <!-- Add new, unreleased items here. -->
 
 ## v1.7.0-pre.13 [04-19-2018]

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## Unreleased
-* `build`, `serve`, `test`:
+* `build`:
   * Disable Babel `minify-constant-folding` plugin when minifying. This plugin has a bug that breaks when a constant is exported from a module (https://github.com/babel/minify/issues/820).
 <!-- Add new, unreleased items here. -->
 

--- a/packages/polyserve/CHANGELOG.md
+++ b/packages/polyserve/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
-* Disable Babel `minify-constant-folding` plugin when minifying. This plugin has a bug that breaks when a constant is exported from a module (https://github.com/babel/minify/issues/820).
+<!-- ## Unreleased -->
 <!-- Add new, unreleased items here. -->
 
 ## [0.27.6] (2018-04-18)

--- a/packages/polyserve/CHANGELOG.md
+++ b/packages/polyserve/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Disable Babel `minify-constant-folding` plugin when minifying. This plugin has a bug that breaks when a constant is exported from a module (https://github.com/babel/minify/issues/820).
 <!-- Add new, unreleased items here. -->
 
 ## [0.27.6] (2018-04-18)


### PR DESCRIPTION
Disable Babel `minify-constant-folding` plugin when minifying. This
plugin has a bug that breaks when a constant is exported from a module
(https://github.com/babel/minify/issues/820).

Fixes https://github.com/Polymer/polymer-cli/issues/998