### PR TITLE
Safari now supports Service Workers

### DIFF
--- a/packages/browser-capabilities/src/browser-capabilities.ts
+++ b/packages/browser-capabilities/src/browser-capabilities.ts
@@ -59,7 +59,7 @@ const browserPredicates: {
   'Mobile Safari': {
     es2015: since(10),
     push: since(9, 2),
-    serviceworker: () => false,
+    serviceworker: since(11, 3),
     modules: since(10, 3),
   },
   'Safari': {
@@ -70,8 +70,7 @@ const browserPredicates: {
           // caniuse.com.
           versionAtLeast([10, 11], parseVersion(ua.getOS().version));
     },
-    // https://webkit.org/status/#specification-service-workers
-    serviceworker: () => false,
+    serviceworker: since(11, 1),
     modules: since(10, 1),
   },
   'Edge': {


### PR DESCRIPTION
Versions 11.1 for desktop and 11.3 for iOS now support Service Workers as per https://caniuse.com/#search=serviceworkers. Verified locally with Xcode Simulator and desktop running macOS 10.13.4.