### PR TITLE
Run all tests in parallel on same vm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ env:
   global:
   - secure: IbrybaUaJDiwNh8VodFfTIAdSw2Nl4DGRh2oDIO2vL8SPgGilwxY0go5DWrxAG0aP+YIXFkK+SpblFppQqqxnAoLVYmd7kFSJoOZraNqmcJqUYSzrHrWArmuiGzY8gMgOWTsnbzVVNRldN8tpoSwpQB/+YhCtbYb9eqvw+u5Izk=
   - secure: grvHX6c0ReQwRsuQZferI+uyGsKlubujURKuJB8coNdA9lgZcvf+nmCkNBpSML83hSjQkJUTt8XnucNNgL/1VxUhgy0O/wkTUEmcDAU1b80As8NJkbreJcc3HFASA68wou4HoJsFmJV2cpBYoAJJSX+HyT6mYd6pBh09tPfOeBg=
-  matrix:
-  - TEST_COMMAND="run test:unit"
-  - TEST_COMMAND="run test:integration:parallel" MOCHA_TIMEOUT=120000
 language: node_js
 node_js:
 - '6'
@@ -24,7 +21,8 @@ install:
 - npm run bootstrap
 - npm run build
 script:
-- xvfb-run npm $TEST_COMMAND
+- xvfb-run npm run test:unit
+- xvfb-run npm run test:integration:parallel
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 - npm run bootstrap
 - npm run build
 script:
-- xvfb-run npm run test:unit
+- xvfb-run npm run test:unit:parallel
 - xvfb-run npm run test:integration:parallel
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build --stream",
     "test": "npm run build && npm run test:unit",
+    "test:all": "npm run test:unit && npm run test:integration",
+    "test:all:parallel": "npm run test:unit && npm run test:integration:parallel",
     "test:integration": "lerna run test:integration --stream",
     "test:integration:parallel": "lerna run test:integration --stream --parallel",
     "test:integration:windows": "lerna run test:integration --stream --ignore web-component-tester --parallel",
     "test:unit": "lerna run test:unit --stream",
-    "test:unit:paralle": "lerna run test:unit --stream --parallel",
+    "test:unit:parallel": "lerna run test:unit --stream --parallel",
     "test:unit:windows": "lerna run test:unit --stream --ignore polyserve --ignore web-component-tester"
   },
   "devDependencies": {

--- a/packages/browser-capabilities/test/mocha.opts
+++ b/packages/browser-capabilities/test/mocha.opts
@@ -1,3 +1,4 @@
 --ui tdd
 --require source-map-support/register
+--timeout 5000
 lib/test/**/*_test.js

--- a/packages/build/gulpfile.js
+++ b/packages/build/gulpfile.js
@@ -63,6 +63,7 @@ gulp.task('test:unit', function() {
   return gulp.src('lib/test/**/*_test.js', {read: false}).pipe(mocha({
     ui: 'tdd',
     reporter: 'spec',
+    timeout: 5000,
   }))
 });
 

--- a/packages/cli/gulpfile.js
+++ b/packages/cli/gulpfile.js
@@ -52,6 +52,7 @@ gulp.task(
                 ui: 'tdd',
                 reporter: 'spec',
                 retries: '3',
+                timeout: 5000,
               })));
 
 gulp.task(
@@ -59,6 +60,7 @@ gulp.task(
     () => gulp.src('lib/test/unit/**/*_test.js', {read: false}).pipe(mocha({
       ui: 'tdd',
       reporter: 'spec',
+      timeout: 5000,
     })));
 
 gulp.task(

--- a/packages/editor-service/test/mocha.opts
+++ b/packages/editor-service/test/mocha.opts
@@ -1,4 +1,5 @@
 --ui tdd
 --require source-map-support/register
 --retries 3
+--timeout 5000
 lib/test/*_test.js lib/test/**/*_test.js

--- a/packages/linter/test/mocha.opts
+++ b/packages/linter/test/mocha.opts
@@ -1,3 +1,4 @@
 -c 
 --ui tdd
+--timeout 5000
 lib/test/*.js lib/test/**/*.js

--- a/packages/polyserve/test/mocha.opts
+++ b/packages/polyserve/test/mocha.opts
@@ -1,3 +1,4 @@
 --ui tdd
 --require source-map-support/register
+--timeout 5000
 lib/test/*_test.js lib/test/**/*_test.js

--- a/packages/web-component-tester/gulpfile.js
+++ b/packages/web-component-tester/gulpfile.js
@@ -24,10 +24,7 @@ const rollup = require('rollup');
 const runSequence = require('run-sequence');
 const typescript = require('typescript');
 
-const mochaConfig = { reporter: 'spec', retries: 3 };
-if (process.env.MOCHA_TIMEOUT) {
-  mochaConfig.timeout = parseInt(process.env.MOCHA_TIMEOUT, 10);
-}
+const mochaConfig = { reporter: 'spec', retries: 3, timeout: 90000 };
 
 // const commonTools = require('tools-common/gulpfile');
 const commonTools = {

--- a/packages/web-component-tester/gulpfile.js
+++ b/packages/web-component-tester/gulpfile.js
@@ -154,7 +154,7 @@ gulp.task('build:wct-browser-legacy', [
 
 
 gulp.task('test:unit', function () {
-  return gulp.src('test/unit/*.js', { read: false })
+  return gulp.src('test/unit/*.js', { read: false, timeout: 5000, })
     .pipe(mocha(mochaConfig));
 });
 


### PR DESCRIPTION
Before...
![screenshot](https://user-images.githubusercontent.com/578/39078640-3efaa0ae-44c1-11e8-9012-b5d2e6a34ba9.png)

After merging...
<img width="1059" alt="screen shot 2018-04-20 at 11 17 13 pm" src="https://user-images.githubusercontent.com/578/39081151-0f1c2698-44f1-11e8-9999-cf6c3b42fdce.png">

There's about a 2min real-time *increase* but a 10min resource-time *decrease* to doing it this way.  Not clear if it's a win to make CI runs +10% longer to go green best-case scenario for a -30% resource-time reduction.  If travis resource utilization is high, waiting for VMs can add significantly more time (I've waited an hour before) than the extra 2min on an individual VM test run.