### PR TITLE
update @polymer/polymer version

### DIFF
--- a/packages/web-component-tester/wct-browser-legacy/package.json
+++ b/packages/web-component-tester/wct-browser-legacy/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/polymer/web-component-tester#readme",
   "dependencies": {
-    "@polymer/polymer": "^3.0.0-pre.1",
+    "@polymer/polymer": "^3.0.0-pre.12",
     "@polymer/sinonjs": "^1.14.1",
-    "@polymer/test-fixture": "^3.0.0-pre.1",
+    "@polymer/test-fixture": "^3.0.0-pre.12",
     "@webcomponents/webcomponentsjs": "^1.0.7",
     "accessibility-developer-tools": "^2.12.0",
     "async": "^1.5.2",


### PR DESCRIPTION
I think this is causing the polymer init template for p3 elements to b0rk

```
Uncaught DOMException: Failed to execute 'define' on 'CustomElementRegistry': this name has already been used with this registry
    at http://127.0.0.1:8081/components/@polymer/polymer/lib/elements/dom-module.js:134:16
```