### PR TITLE
Rewrite the source value of export declarations so we do not emit file URLs in our output.

### DIFF
--- a/packages/bundler/src/test/es6-module-bundling-scenarios_test.ts
+++ b/packages/bundler/src/test/es6-module-bundling-scenarios_test.ts
@@ -17,7 +17,7 @@
 import {assert} from 'chai';
 import {PackageRelativeUrl} from 'polymer-analyzer';
 
-import {generateShellMergeStrategy} from '../bundle-manifest';
+import {generateSharedDepsMergeStrategy, generateShellMergeStrategy} from '../bundle-manifest';
 import {Bundler} from '../bundler';
 
 import {heredoc, inMemoryAnalyzer} from './test-utils';
@@ -60,6 +60,58 @@ suite('Es6 Module Bundling', () => {
         C: C
       };
       export { a as $a, b as $b, c as $c, C, B, A, C as C$1, B as B$1, C as C$2, C as $cDefault };`);
+  });
+
+  suite('rewriting export specifiers', () => {
+
+    // TODO(usergenic): If we want to support `export x from './something.js'`
+    // then Rollup returns the following message: "This experimental syntax
+    // requires enabling the parser plugin: 'exportDefaultFrom' (1:7)"
+
+    // TODO(usergenic): If we want to support `export * from './something.js'`
+    // there's a parse error in the analyzer:
+    // "Unexpected token, expected "(" (7:6)"
+
+    const analyzer = inMemoryAnalyzer({
+      'a.js': `
+        export {b} from './b.js';
+      `,
+      'b.js': `
+        export const b = '🐝';
+      `,
+      'c.js': `
+        import {b} from './b.js';
+        export {b as bee};
+      `,
+    });
+    const aUrl = analyzer.resolveUrl('a.js')!;
+    const bUrl = analyzer.resolveUrl('b.js')!;
+    const cUrl = analyzer.resolveUrl('c.js')!;
+
+    test('export specifier is in a bundle', async () => {
+      const bundler =
+          new Bundler({analyzer, strategy: generateSharedDepsMergeStrategy(2)});
+      const {documents} =
+          await bundler.bundle(await bundler.generateManifest([aUrl, cUrl]));
+      assert.deepEqual(documents.get(aUrl)!.content, heredoc`
+        export { b } from './shared_bundle_1.js';
+        var a = {
+          b: b
+        };
+        export { a as $a };`);
+    });
+
+    test('export specifier is not in a bundle', async () => {
+      const bundler = new Bundler({analyzer, excludes: [bUrl]});
+      const {documents} =
+          await bundler.bundle(await bundler.generateManifest([aUrl]));
+      assert.deepEqual(documents.get(aUrl)!.content, heredoc`
+        export { b } from './b.js';
+        var a = {
+          b: b
+        };
+        export { a as $a };`);
+    });
   });
 
   suite('rewriting import specifiers', () => {


### PR DESCRIPTION
There were a few of things that were fixed here.

One small one is, bundler excludes were resulting in rollup errors when imports/exports referenced them.  That was quickly addressed with https://github.com/Polymer/tools/compare/wtf-file-urls?expand=1#diff-87a72e027be8b635fde7aca6c20d749bR52 and that was found and covered now because I used an `excludes` setting in a test to prove the behavior of the focus of the PR, which is...

Second fix is that export sources are rewritten to the bundle URL or otherwise correct relative URL.

Third fix was forgetting to ensure leading dot for relative URL in the import from non-bundled URL case.