### PR TITLE
Scan exported functions

### DIFF
--- a/packages/analyzer/src/javascript/class-scanner.ts
+++ b/packages/analyzer/src/javascript/class-scanner.ts
@@ -572,28 +572,23 @@ class ClassFinder implements Visitor {
   }
 
   enterAssignmentExpression(
-      node: babel.AssignmentExpression, parent: babel.Node, path: NodePath) {
+      node: babel.AssignmentExpression, _parent: babel.Node, path: NodePath) {
     this.handleGeneralAssignment(
-        astValue.getIdentifierName(node.left), node.right, node, parent, path);
+        astValue.getIdentifierName(node.left), node.right, path);
   }
 
   enterVariableDeclarator(
-      node: babel.VariableDeclarator, parent: babel.Node, path: NodePath) {
+      node: babel.VariableDeclarator, _parent: babel.Node, path: NodePath) {
     if (node.init) {
       this.handleGeneralAssignment(
-          astValue.getIdentifierName(node.id), node.init, node, parent, path);
+          astValue.getIdentifierName(node.id), node.init, path);
     }
   }
 
   /** Generalizes over variable declarators and assignment expressions. */
   private handleGeneralAssignment(
-      assignedName: string|undefined, value: babel.Expression,
-      assignment: babel.VariableDeclarator|babel.AssignmentExpression,
-      statement: babel.Node, path: NodePath) {
-    const comment = esutil.getAttachedComment(value) ||
-        esutil.getAttachedComment(assignment) ||
-        esutil.getAttachedComment(statement) || '';
-    const doc = jsdoc.parseJsdoc(comment);
+      assignedName: string|undefined, value: babel.Expression, path: NodePath) {
+    const doc = jsdoc.parseJsdoc(esutil.getBestComment(path) || '');
     if (babel.isClassExpression(value)) {
       const name = assignedName ||
           value.id && astValue.getIdentifierName(value.id) || undefined;

--- a/packages/analyzer/src/javascript/esutil.ts
+++ b/packages/analyzer/src/javascript/esutil.ts
@@ -104,6 +104,18 @@ export function* getSimpleObjectProperties(node: babel.ObjectExpression) {
   }
 }
 
+/** Like getSimpleObjectProperties but deals with paths. */
+export function*
+    getSimpleObjectPropPaths(nodePath: NodePath<babel.ObjectExpression>) {
+  // tslint:disable-next-line: no-any typings are wrong here
+  const props = nodePath.get('properties') as any as Array<NodePath>;
+  for (const propPath of props) {
+    if (propPath.isObjectProperty() || propPath.isObjectMethod()) {
+      yield propPath;
+    }
+  }
+}
+
 export const CLOSURE_CONSTRUCTOR_MAP = new Map(
     [['Boolean', 'boolean'], ['Number', 'number'], ['String', 'string']]);
 
@@ -185,6 +197,11 @@ export function getBestComment(nodePath: NodePath): string|undefined {
       parent.node.declarations.length !== 1) {
     // The parent node is multiple declarations. We can't be sure its
     // comment applies to us.
+    return undefined;
+  }
+
+  if (parent.isClassBody() || nodePath.isObjectMember()) {
+    // don't go above an object or class member.
     return undefined;
   }
 

--- a/packages/analyzer/src/test/css/css-custom-property-scanner_test.ts
+++ b/packages/analyzer/src/test/css/css-custom-property-scanner_test.ts
@@ -14,10 +14,15 @@
 
 import {assert} from 'chai';
 
-import {createForDirectory, fixtureDir} from '../test-utils';
+import {Analyzer} from '../../core/analyzer';
+import {CodeUnderliner, createForDirectory, fixtureDir} from '../test-utils';
 
-suite('CssCustomPropertyScanner', async () => {
-  const {analyzer, underliner} = await createForDirectory(fixtureDir);
+suite('CssCustomPropertyScanner', () => {
+  let analyzer: Analyzer;
+  let underliner: CodeUnderliner;
+  before(async () => {
+    ({analyzer, underliner} = await createForDirectory(fixtureDir));
+  });
 
   test('finds custom property assignments', async () => {
     const result = await analyzer.analyze(['some-styles.html']);

--- a/packages/analyzer/src/test/html/html-document_test.ts
+++ b/packages/analyzer/src/test/html/html-document_test.ts
@@ -18,16 +18,21 @@ import * as fs from 'fs';
 import * as parse5 from 'parse5';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ParsedHtmlDocument} from '../../html/html-document';
 import {HtmlParser} from '../../html/html-parser';
 import {PackageUrlResolver} from '../../url-loader/package-url-resolver';
-import {createForDirectory, fixtureDir} from '../test-utils';
+import {CodeUnderliner, createForDirectory, fixtureDir} from '../test-utils';
 
-suite('ParsedHtmlDocument', async () => {
+suite('ParsedHtmlDocument', () => {
   const parser: HtmlParser = new HtmlParser();
   const url = `./source-ranges/html-complicated.html`;
   const file = fs.readFileSync(path.join(fixtureDir, url), 'utf8');
-  const {analyzer, underliner} = await createForDirectory(fixtureDir);
+  let analyzer: Analyzer;
+  let underliner: CodeUnderliner;
+  before(async () => {
+    ({analyzer, underliner} = await createForDirectory(fixtureDir));
+  });
 
   let document: ParsedHtmlDocument;
   setup(() => {
@@ -379,7 +384,7 @@ suite('ParsedHtmlDocument', async () => {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`);
         });
 
-    suite('for a void element', async () => {
+    suite('for a void element', () => {
       test('works for a string attribute', async () => {
         const linkTags = [...dom5.queryAll(
             document.ast, dom5.predicates.hasTagName('link'))];
@@ -448,7 +453,7 @@ suite('ParsedHtmlDocument', async () => {
                 ~~~~~~~~~~~~~~~~~~~~~~~~`);
         });
 
-    suite('for a void element', async () => {
+    suite('for a void element', () => {
       test('works for a string attribute', async () => {
         const linkTags = [...dom5.queryAll(
             document.ast, dom5.predicates.hasTagName('link'))];
@@ -522,7 +527,7 @@ suite('ParsedHtmlDocument', async () => {
                 ~~~~~~~~~~~~~~~~~~~`);
         });
 
-    suite('for a void element', async () => {
+    suite('for a void element', () => {
       test('works for a string attribute', async () => {
         const linkTags = [...dom5.queryAll(
             document.ast, dom5.predicates.hasTagName('link'))];

--- a/packages/analyzer/src/test/html/html-script-scanner_test.ts
+++ b/packages/analyzer/src/test/html/html-script-scanner_test.ts
@@ -81,11 +81,12 @@ suite('HtmlScriptScanner', () => {
             !!w.message.match('does-not-exist-lol-dont-care.js')));
   });
 
-  suite('modules', async () => {
-    const {analyzer} = await createForDirectory(fixtureDir);
+  suite('modules', () => {
+    let analyzer: Analyzer;
     let analysis: Analysis;
 
     before(async () => {
+      ({analyzer} = await createForDirectory(fixtureDir));
       analysis = await analyzer.analyze(
           ['js-modules.html', 'base-href/imports-js-module-with-base.html']);
     });

--- a/packages/analyzer/src/test/javascript/class-scanner_test.ts
+++ b/packages/analyzer/src/test/javascript/class-scanner_test.ts
@@ -15,13 +15,19 @@
 
 import {assert} from 'chai';
 
+import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {Class, Element, ElementMixin, Method, ScannedClass} from '../../model/model';
-import {createForDirectory, fixtureDir, runScanner} from '../test-utils';
+import {CodeUnderliner, createForDirectory, fixtureDir, runScanner} from '../test-utils';
 
 // tslint:disable: no-any This test is pretty hacky, uses a lot of any.
-suite('Class', async () => {
-  const {analyzer, underliner} = await createForDirectory(fixtureDir);
+suite('Class', () => {
+  let analyzer: Analyzer;
+  let underliner: CodeUnderliner;
+
+  before(async () => {
+    ({analyzer, underliner} = await createForDirectory(fixtureDir));
+  });
 
   async function getScannedFeatures(filename: string) {
     const {features} = await runScanner(analyzer, new ClassScanner(), filename);
@@ -260,7 +266,7 @@ suite('Class', async () => {
               name: 'methodWithComplexDefaultParam',
               description: '',
               params: [{name: 'a', defaultValue: '[1, 2, 3]'}],
-              return: { type: 'void' }
+              return: {type: 'void'}
             },
             {
               name: 'customInstanceFunctionWithJSDoc',
@@ -535,7 +541,7 @@ suite('Class', async () => {
               name: 'methodWithComplexDefaultParam',
               description: '',
               params: [{name: 'a', defaultValue: '[1, 2, 3]'}],
-              return: { type: 'void' }
+              return: {type: 'void'}
             },
             {
               name: 'customInstanceFunctionWithJSDoc',

--- a/packages/analyzer/src/test/javascript/function-scanner_test.ts
+++ b/packages/analyzer/src/test/javascript/function-scanner_test.ts
@@ -91,11 +91,11 @@ function aaa(a) {
         privacy: 'public',
         codeSnippet: `
 Polymer.bbb = function bbb() {
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~~~~~~~~~~~~~~~~
 
 
 };
-~~`,
+~`,
       },
       {
         name: 'Polymer.ccc',
@@ -121,7 +121,7 @@ Polymer.bbb = function bbb() {
         return: {type: 'void'},
         codeSnippet: `
   _ddd: function() {
-  ~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~
 
 
   },
@@ -137,7 +137,7 @@ Polymer.bbb = function bbb() {
         privacy: 'private',
         codeSnippet: `
   eee: () => {},
-  ~~~~~~~~~~~~~`,
+       ~~~~~~~~`,
       },
       {
         name: 'Polymer.fff',
@@ -201,11 +201,27 @@ Polymer.bbb = function bbb() {
         privacy: 'public',
         codeSnippet: `
 var jjj = function() {
-~~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~
 
 
 };
-~~`,
+~`,
+      },
+      {
+        name: 'lll',
+        description: 'lol\n ',
+        summary: '',
+        warnings: [],
+        params: [],
+        return: {type: 'void'},
+        privacy: 'public',
+        codeSnippet: `
+export function lll() {
+       ~~~~~~~~~~~~~~~~
+
+
+};
+~`,
       },
     ]);
   });

--- a/packages/analyzer/src/test/javascript/function-scanner_test.ts
+++ b/packages/analyzer/src/test/javascript/function-scanner_test.ts
@@ -16,13 +16,18 @@
 import {assert} from 'chai';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ScannedFunction} from '../../javascript/function';
 import {FunctionScanner} from '../../javascript/function-scanner';
-import {createForDirectory, fixtureDir, runScanner} from '../test-utils';
+import {CodeUnderliner, createForDirectory, fixtureDir, runScanner} from '../test-utils';
 
-suite('FunctionScanner', async () => {
-  const testFilesDir = path.resolve(fixtureDir, 'namespaces/');
-  const {analyzer, underliner} = await createForDirectory(testFilesDir);
+suite('FunctionScanner', () => {
+  let analyzer: Analyzer;
+  let underliner: CodeUnderliner;
+  before(async () => {
+    const testFilesDir = path.resolve(fixtureDir, 'namespaces/');
+    ({analyzer, underliner} = await createForDirectory(testFilesDir));
+  });
 
   async function getNamespaceFunctions(filename: string) {
     const {features} =
@@ -50,7 +55,7 @@ suite('FunctionScanner', async () => {
     };
   }
 
-  test('handles @memberof annotation', async () => {
+  test('recognizies functions', async () => {
     const namespaceFunctions =
         await getNamespaceFunctions('memberof-functions.js');
     const functionData =

--- a/packages/analyzer/src/test/javascript/javascript-import-scanner_test.ts
+++ b/packages/analyzer/src/test/javascript/javascript-import-scanner_test.ts
@@ -15,11 +15,15 @@
 
 import {assert} from 'chai';
 
+import {Analyzer} from '../../core/analyzer';
 import {JavaScriptImportScanner} from '../../javascript/javascript-import-scanner';
 import {createForDirectory, fixtureDir, runScanner} from '../test-utils';
 
-suite('JavaScriptImportScanner', async () => {
-  const {analyzer} = await createForDirectory(fixtureDir);
+suite('JavaScriptImportScanner', () => {
+  let analyzer: Analyzer;
+  before(async () => {
+    ({analyzer} = await createForDirectory(fixtureDir));
+  });
 
   test('finds imports', async () => {
     const {features, warnings} = await runScanner(

--- a/packages/analyzer/src/test/javascript/namespace-scanner_test.ts
+++ b/packages/analyzer/src/test/javascript/namespace-scanner_test.ts
@@ -16,13 +16,19 @@
 import {assert} from 'chai';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ScannedNamespace} from '../../javascript/namespace';
 import {NamespaceScanner} from '../../javascript/namespace-scanner';
-import {createForDirectory, fixtureDir, runScanner} from '../test-utils';
+import {CodeUnderliner, createForDirectory, fixtureDir, runScanner} from '../test-utils';
 
-suite('NamespaceScanner', async () => {
-  const testFilesDir = path.resolve(fixtureDir, 'namespaces/');
-  const {analyzer, underliner} = await createForDirectory(testFilesDir);
+suite('NamespaceScanner', () => {
+  let analyzer: Analyzer;
+  let underliner: CodeUnderliner;
+
+  before(async () => {
+    const testFilesDir = path.resolve(fixtureDir, 'namespaces/');
+    ({analyzer, underliner} = await createForDirectory(testFilesDir));
+  });
 
   async function getNamespaces(filename: string) {
     const {features} =

--- a/packages/analyzer/src/test/javascript/resolve-specifier-node_test.ts
+++ b/packages/analyzer/src/test/javascript/resolve-specifier-node_test.ts
@@ -45,7 +45,7 @@ const scopedRootComponentInfo = {
   componentDir
 };
 
-suite('resolve', async () => {
+suite('resolve', () => {
   test('non-component root to path', async () => {
     assert.equal(resolve('./root.js', rootMain), './root.js');
   });

--- a/packages/analyzer/src/test/polymer/polymer-element_test.ts
+++ b/packages/analyzer/src/test/polymer/polymer-element_test.ts
@@ -16,13 +16,18 @@
 import {assert} from 'chai';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {Severity, Warning} from '../../model/model';
 import {PolymerElement} from '../../polymer/polymer-element';
 import {createForDirectory, fixtureDir} from '../test-utils';
 
-suite('PolymerElement', async () => {
-  const {analyzer} =
-      await createForDirectory(path.resolve(fixtureDir, 'polymer2/'));
+suite('PolymerElement', () => {
+  let analyzer: Analyzer;
+
+  before(async () => {
+    ({analyzer} =
+         await createForDirectory(path.resolve(fixtureDir, 'polymer2/')));
+  });
 
   async function getElements(filename: string): Promise<Set<PolymerElement>> {
     const result = (await analyzer.analyze([filename])).getDocument(filename);

--- a/packages/analyzer/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
+++ b/packages/analyzer/src/test/polymer/polymer2-element-scanner-old-jsdoc_test.ts
@@ -16,15 +16,20 @@
 import {assert, use as chaiUse} from 'chai';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
-import {createForDirectory, fixtureDir, runScanner} from '../test-utils';
+import {CodeUnderliner, createForDirectory, fixtureDir, runScanner} from '../test-utils';
 
 chaiUse(require('chai-subset'));
 
-suite('Polymer2ElementScanner with old jsdoc annotations', async () => {
-  const testFilesDir = path.resolve(fixtureDir, 'polymer2-old-jsdoc/');
-  const {analyzer, underliner} = await createForDirectory(testFilesDir);
+suite('Polymer2ElementScanner with old jsdoc annotations', () => {
+  let analyzer: Analyzer;
+  let underliner: CodeUnderliner;
+  before(async () => {
+    const testFilesDir = path.resolve(fixtureDir, 'polymer2-old-jsdoc/');
+    ({analyzer, underliner} = await createForDirectory(testFilesDir));
+  });
 
   async function getElements(filename: string):
       Promise<ScannedPolymerElement[]> {

--- a/packages/analyzer/src/test/polymer/polymer2-element-scanner_test.ts
+++ b/packages/analyzer/src/test/polymer/polymer2-element-scanner_test.ts
@@ -16,16 +16,20 @@
 import {assert, use as chaiUse} from 'chai';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {ScannedPolymerElement} from '../../polymer/polymer-element';
 import {CodeUnderliner, createForDirectory, fixtureDir, runScanner} from '../test-utils';
 
 chaiUse(require('chai-subset'));
 
-suite('Polymer2ElementScanner', async () => {
-  const {analyzer} =
-      await createForDirectory(path.resolve(fixtureDir, 'polymer2/'));
-  const underliner = new CodeUnderliner(analyzer);
+suite('Polymer2ElementScanner', () => {
+  let analyzer: Analyzer;
+  let underliner: CodeUnderliner;
+  before(async () => {
+    ({analyzer, underliner} =
+         await createForDirectory(path.resolve(fixtureDir, 'polymer2/')));
+  });
 
   async function getElements(filename: string):
       Promise<ScannedPolymerElement[]> {

--- a/packages/analyzer/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
+++ b/packages/analyzer/src/test/polymer/polymer2-mixin-scanner-old-jsdoc_test.ts
@@ -16,13 +16,18 @@
 import {assert} from 'chai';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
-import {createForDirectory, fixtureDir, runScanner} from '../test-utils';
+import {CodeUnderliner, createForDirectory, fixtureDir, runScanner} from '../test-utils';
 
-suite('Polymer2MixinScanner with old jsdoc annotations', async () => {
-  const testFilesDir = path.resolve(fixtureDir, 'polymer2-old-jsdoc/');
-  const {analyzer, underliner} = await createForDirectory(testFilesDir);
+suite('Polymer2MixinScanner with old jsdoc annotations', () => {
+  let analyzer: Analyzer;
+  let underliner: CodeUnderliner;
+  before(async () => {
+    const testFilesDir = path.resolve(fixtureDir, 'polymer2-old-jsdoc/');
+    ({analyzer, underliner} = await createForDirectory(testFilesDir));
+  });
 
   async function getScannedMixins(filename: string) {
     const {features} = await runScanner(analyzer, new ClassScanner(), filename);

--- a/packages/analyzer/src/test/polymer/polymer2-mixin-scanner_test.ts
+++ b/packages/analyzer/src/test/polymer/polymer2-mixin-scanner_test.ts
@@ -16,13 +16,19 @@
 import {assert} from 'chai';
 import * as path from 'path';
 
+import {Analyzer} from '../../core/analyzer';
 import {ClassScanner} from '../../javascript/class-scanner';
 import {PolymerElementMixin, ScannedPolymerElementMixin} from '../../polymer/polymer-element-mixin';
-import {createForDirectory, fixtureDir, runScanner} from '../test-utils';
+import {CodeUnderliner, createForDirectory, fixtureDir, runScanner} from '../test-utils';
 
-suite('Polymer2MixinScanner', async () => {
-  const {analyzer, underliner} =
-      await createForDirectory(path.resolve(fixtureDir, 'polymer2/'));
+suite('Polymer2MixinScanner', () => {
+  let analyzer: Analyzer;
+  let underliner: CodeUnderliner;
+  before(async () => {
+    const testFilesDir = path.resolve(fixtureDir, 'polymer2/');
+    ({analyzer, underliner} = await createForDirectory(testFilesDir));
+  });
+
 
   async function getScannedMixins(filename: string) {
     const {features} = await runScanner(analyzer, new ClassScanner(), filename);

--- a/packages/analyzer/src/test/static/analysis/namespaces/analysis.json
+++ b/packages/analyzer/src/test/static/analysis/namespaces/analysis.json
@@ -27,7 +27,7 @@
             },
             "file": "namespaces.html",
             "start": {
-              "column": 4,
+              "column": 9,
               "line": 19
             }
           },
@@ -65,13 +65,15 @@
             },
             "file": "namespaces.html",
             "start": {
-              "column": 2,
+              "column": 12,
               "line": 36
             }
           },
           "summary": "",
           "params": [],
-          "return": {"type": "void"}
+          "return": {
+            "type": "void"
+          }
         },
         {
           "description": "",
@@ -90,7 +92,9 @@
           },
           "summary": "",
           "params": [],
-          "return": {"type": "void"}
+          "return": {
+            "type": "void"
+          }
         }
       ]
     }

--- a/packages/analyzer/src/test/static/namespaces/memberof-functions.js
+++ b/packages/analyzer/src/test/static/namespaces/memberof-functions.js
@@ -90,3 +90,10 @@ var jjj = function() {
 
 };
 Polymer.jjj = jjj;
+
+/**
+ * lol
+ */
+export function lll() {
+
+};


### PR DESCRIPTION
They're public and interesting, same as functions on namespaces.

Also use getBestComment in more places, rather than our more ad hoc methods.

This also changes function source ranges a bit, but not in an interesting way IMO.

Part of Polymer/docs#2379