### PR TITLE
Replace all instances of `console.assert()` with `assert()` from 'assert' standard lib.

### DIFF
--- a/packages/analyzer/src/javascript/esutil.ts
+++ b/packages/analyzer/src/javascript/esutil.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as assert from 'assert';
 import generate from '@babel/generator';
 import babelTraverse from '@babel/traverse';
 import {NodePath} from '@babel/traverse';
@@ -48,7 +49,7 @@ export function matchesCallExpression(
   if (!expression.property || !expression.object) {
     return false;
   }
-  console.assert(path.length >= 2);
+  assert(path.length >= 2);
 
   if (!babel.isIdentifier(expression.property)) {
     return false;

--- a/packages/analyzer/src/polymer/behavior-scanner.ts
+++ b/packages/analyzer/src/polymer/behavior-scanner.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as assert from 'assert';
 import {NodePath} from '@babel/traverse';
 import * as babel from '@babel/types';
 
@@ -127,12 +128,12 @@ class BehaviorVisitor implements Visitor {
   }
 
   private _startBehavior(behavior: ScannedBehavior) {
-    console.assert(this.currentBehavior == null);
+    assert(this.currentBehavior == null);
     this.currentBehavior = behavior;
   }
 
   private _finishBehavior() {
-    console.assert(this.currentBehavior != null);
+    assert(this.currentBehavior != null);
     this.behaviors.add(this.currentBehavior!);
     this.currentBehavior = null;
   }

--- a/packages/build/src/html-splitter.ts
+++ b/packages/build/src/html-splitter.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as assert from 'assert';
 import * as dom5 from 'dom5/lib/index-next';
 import * as parse5 from 'parse5';
 import * as osPath from 'path';
@@ -127,13 +128,13 @@ export class SplitFile {
   }
 
   setPartContent(path: string, content: string): void {
-    console.assert(
+    assert(
         this.parts.get(path) !== undefined,
         `Trying to save unexpected file part "${path}".`);
-    console.assert(
+    assert(
         this.parts.get(path) === null,
         `Trying to save already-saved file part "${path}".`);
-    console.assert(
+    assert(
         this.outstandingPartCount > 0,
         `Trying to save valid file part "${path}", ` +
             `but somehow no file parts are outstanding.`);

--- a/packages/build/src/service-worker.ts
+++ b/packages/build/src/service-worker.ts
@@ -14,6 +14,7 @@
 
 /// <reference path="../custom_typings/sw-precache.d.ts" />
 
+import * as assert from 'assert';
 import {writeFile} from 'fs';
 import * as path from 'path';
 import * as logging from 'plylog';
@@ -91,9 +92,9 @@ export const hasNoFileExtension = /\/[^\/\.]*(\?|$)/;
  */
 export async function generateServiceWorkerConfig(
     options: AddServiceWorkerOptions): Promise<SWConfig> {
-  console.assert(!!options, '`project` & `buildRoot` options are required');
-  console.assert(!!options.project, '`project` option is required');
-  console.assert(!!options.buildRoot, '`buildRoot` option is required');
+  assert(!!options, '`project` & `buildRoot` options are required');
+  assert(!!options.project, '`project` option is required');
+  assert(!!options.buildRoot, '`buildRoot` option is required');
   options = fixDeprecatedOptions(options);
 
   options = Object.assign({}, options);

--- a/packages/bundler/src/bundle-manifest.ts
+++ b/packages/bundler/src/bundle-manifest.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as assert from 'assert';
 import * as clone from 'clone';
 import {PackageRelativeUrl, ResolvedUrl, UrlResolver} from 'polymer-analyzer';
 
@@ -115,7 +116,7 @@ export class BundleManifest {
       const bundleUrl = bundleMapEntry[0];
       const bundle = bundleMapEntry[1];
       for (const fileUrl of bundle.files) {
-        console.assert(!this._bundleUrlForFile.has(fileUrl));
+        assert(!this._bundleUrlForFile.has(fileUrl));
         this._bundleUrlForFile.set(fileUrl, bundleUrl);
       }
     }

--- a/packages/project-config/src/index.ts
+++ b/packages/project-config/src/index.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as assert from 'assert';
 import * as fs from 'fs';
 import * as jsonschema from 'jsonschema';
 import * as path from 'path';
@@ -469,36 +470,36 @@ export class ProjectConfig {
   validate(): boolean {
     const validateErrorPrefix = `Polymer Config Error`;
     if (this.entrypoint) {
-      console.assert(
+      assert(
           this.entrypoint.startsWith(this.root),
           `${validateErrorPrefix}: entrypoint (${this.entrypoint}) ` +
               `does not resolve within root (${this.root})`);
     }
     if (this.shell) {
-      console.assert(
+      assert(
           this.shell.startsWith(this.root),
           `${validateErrorPrefix}: shell (${this.shell}) ` +
               `does not resolve within root (${this.root})`);
     }
     this.fragments.forEach((f) => {
-      console.assert(
+      assert(
           f.startsWith(this.root),
           `${validateErrorPrefix}: a "fragments" path (${f}) ` +
               `does not resolve within root (${this.root})`);
     });
     this.sources.forEach((s) => {
-      console.assert(
+      assert(
           getPositiveGlob(s).startsWith(this.root),
           `${validateErrorPrefix}: a "sources" path (${s}) ` +
               `does not resolve within root (${this.root})`);
     });
     this.extraDependencies.forEach((d) => {
-      console.assert(
+      assert(
           getPositiveGlob(d).startsWith(this.root),
           `${validateErrorPrefix}: an "extraDependencies" path (${d}) ` +
               `does not resolve within root (${this.root})`);
     });
-    console.assert(
+    assert(
         moduleResolutionStrategies.has(this.moduleResolution),
         `${validateErrorPrefix}: "moduleResolution" must be one of: ` +
             `${[...moduleResolutionStrategies].join(', ')}.`);
@@ -507,7 +508,7 @@ export class ProjectConfig {
     // file system. Potentially become async function for this.
 
     if (this.builds) {
-      console.assert(
+      assert(
           Array.isArray(this.builds),
           `${validateErrorPrefix}: "builds" (${this.builds}) ` +
               `expected an array of build configurations.`);
@@ -517,15 +518,15 @@ export class ProjectConfig {
         for (const build of this.builds) {
           const buildName = build.name;
           const buildPreset = build.preset;
-          console.assert(
+          assert(
               !buildPreset || isValidPreset(buildPreset),
               `${validateErrorPrefix}: "${buildPreset}" is not a valid ` +
                   ` "builds" preset.`);
-          console.assert(
+          assert(
               buildName,
               `${validateErrorPrefix}: all "builds" require ` +
                   `a "name" property when there are multiple builds defined.`);
-          console.assert(
+          assert(
               !buildNames.has(buildName!),
               `${validateErrorPrefix}: "builds" duplicate build name ` +
                   `"${buildName}" found. Build names must be unique.`);


### PR DESCRIPTION
As of node 10, `console.assert()` doesn't throw an AssertionError anymore.  However `const assert = require('assert'); assert();` does.  So I switched over to `assert()` wherever `console.assert()` was in use.