### PR TITLE
Speedup polymer cli init with lazy imports.

### DIFF
--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -12,6 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+// Be mindful of adding imports here, as this is on the hot path of all
+// commands.
+
 import {ArgDescriptor} from 'command-line-args';
 import {Environment} from './environment/environment';
 import {buildEnvironment} from './environments/environments';

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -12,10 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Be careful with these imports. As much as possible should be deferred until
-// the command is actually run, in order to minimize startup time from loading
-// unused code. Any imports that are only used as types will be removed from the
-// output JS and so not result in a require() statement.
+// Be careful with these imports. As many as possible should be dynamic imports
+// in the run method in order to minimize startup time from loading unused code.
 
 import {ProjectConfig} from 'polymer-project-config';
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -17,14 +17,9 @@
 // unused code. Any imports that are only used as types will be removed from the
 // output JS and so not result in a require() statement.
 
-import * as delTypeOnly from 'del';
-import * as mzfsTypeOnly from 'mz/fs';
-import * as pathTypeOnly from 'path';
 import * as logging from 'plylog';
-import {PolymerProject} from 'polymer-build';
 import {applyBuildPreset, ProjectBuildOptions, ProjectConfig} from 'polymer-project-config';
 
-import * as buildLibTypeOnly from '../build/build';
 import {dashToCamelCase} from '../util';
 
 import {Command, CommandOptions} from './command';
@@ -173,9 +168,10 @@ export class BuildCommand implements Command {
 
   async run(options: CommandOptions, config: ProjectConfig) {
     // Defer dependency loading until this specific command is run
-    const del = require('del') as typeof delTypeOnly;
-    const buildLib = require('../build/build') as typeof buildLibTypeOnly;
-    const path = require('path') as typeof pathTypeOnly;
+    const del = await import('del');
+    const buildLib = await import('../build/build');
+    const polymerBuild = await import('polymer-build');
+    const path = await import('path');
     let build = buildLib.build;
     const mainBuildDirectoryName = buildLib.mainBuildDirectoryName;
 
@@ -192,10 +188,10 @@ export class BuildCommand implements Command {
     logger.info(`Clearing ${mainBuildDirectoryName}${path.sep} directory...`);
     await del([mainBuildDirectoryName]);
 
-    const mzfs = require('mz/fs') as typeof mzfsTypeOnly;
+    const mzfs = await import('mz/fs');
     await mzfs.mkdir(mainBuildDirectoryName);
 
-    const polymerProject = new PolymerProject(config);
+    const polymerProject = new polymerBuild.PolymerProject(config);
 
     // If any the build command flags were passed as CLI arguments, generate
     // a single build based on those flags alone.

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -12,10 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Be careful with these imports. As much as possible should be deferred until
-// the command is actually run, in order to minimize startup time from loading
-// unused code. Any imports that are only used as types will be removed from the
-// output JS and so not result in a require() statement.
+// Be careful with these imports. As many as possible should be dynamic imports
+// in the run method in order to minimize startup time from loading unused code.
 
 import * as logging from 'plylog';
 import {applyBuildPreset, ProjectBuildOptions, ProjectConfig} from 'polymer-project-config';

--- a/packages/cli/src/commands/command.ts
+++ b/packages/cli/src/commands/command.ts
@@ -12,6 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+// Be mindful of adding imports here, as this is on the hot path of all
+// commands.
+
 import {ArgDescriptor} from 'command-line-args';
 import {UsageGroup} from 'command-line-usage';
 import {ProjectConfig} from 'polymer-project-config';

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -12,10 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Be careful with these imports. As much as possible should be deferred until
-// the command is actually run, in order to minimize startup time from loading
-// unused code. Any imports that are only used as types will be removed from the
-// output JS and so not result in a require() statement.
+// Be careful with these imports. As many as possible should be dynamic imports
+// in the run method in order to minimize startup time from loading unused code.
 
 import * as chalk from 'chalk';
 import * as commandLineUsage from 'command-line-usage';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -12,16 +12,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Be careful with these imports. As much as possible should be deferred until
-// the command is actually run, in order to minimize startup time from loading
-// unused code. Any imports that are only used as types will be removed from the
-// output JS and so not result in a require() statement.
+// Be careful with these imports. As many as possible should be dynamic imports
+// in the run method in order to minimize startup time from loading unused code.
 
 import {ArgDescriptor} from 'command-line-args';
 import * as logging from 'plylog';
 import {ProjectConfig} from 'polymer-project-config';
-
-import * as polymerInitTypeOnly from '../init/init';
 
 import {Command, CommandOptions} from './command';
 
@@ -42,7 +38,7 @@ export class InitCommand implements Command {
 
   async run(options: CommandOptions, _config: ProjectConfig) {
     // Defer dependency loading until needed
-    const polymerInit = require('../init/init') as typeof polymerInitTypeOnly;
+    const polymerInit = await import('../init/init');
 
     const templateName = options['name'];
     if (templateName) {

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -12,14 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Be careful with these imports. As much as possible should be deferred until
-// the command is actually run, in order to minimize startup time from loading
-// unused code. Any imports that are only used as types will be removed from the
-// output JS and so not result in a require() statement.
+// Be careful with these imports. As many as possible should be dynamic imports
+// in the run method in order to minimize startup time from loading unused code.
 
 import {ProjectConfig} from 'polymer-project-config';
-
-import {install as installTypeOnly} from '../install/install';
 
 import {Command, CommandOptions} from './command';
 
@@ -47,9 +43,7 @@ export class InstallCommand implements Command {
   ];
 
   async run(options: CommandOptions, config: ProjectConfig): Promise<void> {
-    // Defer dependency loading until this specific command is run
-    const install =
-        require('../install/install').install as typeof installTypeOnly;
+    const install = (await import('../install/install')).install;
 
     // Use `npm` from the config, if available and not passed as a CLI arg.
     if (options.npm === undefined && config.npm !== undefined) {

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -12,10 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Be careful with these imports. As much as possible should be deferred until
-// the command is actually run, in order to minimize startup time from loading
-// unused code. Any imports that are only used as types will be removed from the
-// output JS and so not result in a require() statement.
+// Be careful with these imports. As many as possible should be dynamic imports
+// in the run method in order to minimize startup time from loading unused code.
 
 import {ArgDescriptor} from 'command-line-args';
 import {UsageGroup} from 'command-line-usage';

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -12,10 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Be careful with these imports. As much as possible should be deferred until
-// the command is actually run, in order to minimize startup time from loading
-// unused code. Any imports that are only used as types will be removed from the
-// output JS and so not result in a require() statement.
+// Be careful with these imports. As many as possible should be dynamic imports
+// in the run method in order to minimize startup time from loading unused code.
 
 import * as logging from 'plylog';
 import {ProjectConfig} from 'polymer-project-config';

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -12,10 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Be careful with these imports. As much as possible should be deferred until
-// the command is actually run, in order to minimize startup time from loading
-// unused code. Any imports that are only used as types will be removed from the
-// output JS and so not result in a require() statement.
+// Be careful with these imports. As many as possible should be dynamic imports
+// in the run method in order to minimize startup time from loading unused code.
 
 import {ProjectConfig} from 'polymer-project-config';
 

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -18,7 +18,6 @@
 // output JS and so not result in a require() statement.
 
 import {ProjectConfig} from 'polymer-project-config';
-import * as wctTypeOnly from 'web-component-tester';
 
 import {Command, CommandOptions} from './command';
 
@@ -139,9 +138,8 @@ export class TestCommand implements Command {
     },
   ];
 
-  run(_options: CommandOptions, config: ProjectConfig): Promise<void> {
-    // Defer dependency loading until this specific command is run
-    const wct = require('web-component-tester') as typeof wctTypeOnly;
+  async run(_options: CommandOptions, config: ProjectConfig): Promise<void> {
+    const wct = await import('web-component-tester');
 
     const wctArgs = process.argv.slice(3);
 

--- a/packages/cli/src/lint/lint.ts
+++ b/packages/cli/src/lint/lint.ts
@@ -30,6 +30,11 @@ import {indent, prompt} from '../util';
 
 const logger = logging.getLogger('cli.lint');
 
+if (Symbol.asyncIterator === undefined) {
+  // tslint:disable-next-line: no-any polyfilling.
+  (Symbol as any).asyncIterator = Symbol('asyncIterator');
+}
+
 export async function lint(options: Options, config: ProjectConfig) {
   const lintOptions: Partial<typeof config.lint> = (config.lint || {});
 

--- a/packages/cli/src/polymer-cli.ts
+++ b/packages/cli/src/polymer-cli.ts
@@ -12,6 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+// Be mindful of adding imports here, as this is on the hot path of all
+// commands.
+
 import * as commandLineArgs from 'command-line-args';
 import {sep as pathSeperator} from 'path';
 import * as logging from 'plylog';

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -12,6 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+// Be mindful of adding imports here, as this is on the hot path of all
+// commands.
+
 import * as logging from 'plylog';
 import * as updateNotifier from 'update-notifier';
 import {PolymerCli} from './polymer-cli';

--- a/packages/cli/src/test/unit/commands/serve_test.ts
+++ b/packages/cli/src/test/unit/commands/serve_test.ts
@@ -9,12 +9,10 @@
  */
 
 import {assert} from 'chai';
-import * as polyserveTypeOnly from 'polyserve';
+import * as polyserve from 'polyserve';
 import * as sinon from 'sinon';
 
 import {PolymerCli} from '../../../polymer-cli';
-
-const polyserve = require('polyserve') as typeof polyserveTypeOnly;
 
 suite('serve', () => {
 

--- a/packages/cli/src/test/unit/commands/test_test.ts
+++ b/packages/cli/src/test/unit/commands/test_test.ts
@@ -10,11 +10,9 @@
 
 import {assert} from 'chai';
 import * as sinon from 'sinon';
-import * as wctTypeOnly from 'web-component-tester';
+import * as wct from 'web-component-tester';
 
 import {PolymerCli} from '../../../polymer-cli';
-
-const wct = require('web-component-tester') as typeof wctTypeOnly;
 
 suite('test', () => {
   let sandbox: sinon.SinonSandbox;

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -12,6 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+// Be mindful of adding imports here, as this is on the hot path of all
+// commands.
+
 import * as inquirer from 'inquirer';
 import {execSync} from 'mz/child_process';
 


### PR DESCRIPTION
~3x speedup of `polymer --help` from 2.25s  to 0.75s, mostly because of a strict import of polymer-build that crept in.