### PR TITLE
Module script tag imports are normal imports.

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Dropped support for node v6. This is a soft break, as we aren't
   making any changes that are known to break node v6, but we're no longer testing against it. See our [node version support policy](https://www.polymer-project.org/2.0/docs/tools/node-support)
   for details.
+* ScriptTagImport#isModule is true for `<script type="module" src="...">`
+* Module `<script>` imports don't inherit imports from the HTML file that
+  imports them, because unlike normal scripts, modules can be imported from
+  many HTML files, and they have their own way to import their dependencies,
+  rather than depending on HTML container files.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.24] - 2018-04-18

--- a/packages/analyzer/src/html/html-script-scanner.ts
+++ b/packages/analyzer/src/html/html-script-scanner.ts
@@ -43,12 +43,11 @@ export class HtmlScriptScanner implements HtmlScanner {
             dom5.getAttribute(node, 'src') as FileRelativeUrl | undefined;
         if (src) {
           features.push(new ScannedScriptTagImport(
-              'html-script',
               src,
               document.sourceRangeForNode(node)!,
               document.sourceRangeForAttributeValue(node, 'src')!,
               {language: 'html', node, containingDocument: document},
-              false));
+              dom5.getAttribute(node, 'type') === 'module'));
         } else {
           const locationOffset =
               getLocationOffsetOfStartOfTextContent(node, document);

--- a/packages/analyzer/src/test/core/analyzer_test.ts
+++ b/packages/analyzer/src/test/core/analyzer_test.ts
@@ -803,6 +803,19 @@ var DuplicateNamespace = {};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~`]);
   });
 
+  test('treats module script tags as normal imports', async () => {
+    const analysis =
+        await analyzer.analyze(['static/script-tags/modules/index.html']);
+    const warnings = analysis.getWarnings();
+    assert.deepEqual(
+        warnings.map((w) => w.code), ['could-not-resolve-reference']);
+    assert.deepEqual(await underliner.underline(analysis.getWarnings()), [
+      `
+class Bar extends Foo {
+                  ~~~`,
+    ]);
+  });
+
   suite('analyzePackage', () => {
     test('produces a package with the right documents', async () => {
       const {analyzer} =

--- a/packages/analyzer/src/test/static/script-tags/modules/index.html
+++ b/packages/analyzer/src/test/static/script-tags/modules/index.html
@@ -1,0 +1,6 @@
+<script>
+  class Foo {
+
+  }
+</script>
+<script type="module" src="usesClass.js"></script>

--- a/packages/analyzer/src/test/static/script-tags/modules/usesClass.js
+++ b/packages/analyzer/src/test/static/script-tags/modules/usesClass.js
@@ -1,0 +1,4 @@
+// This should not work
+class Bar extends Foo {
+
+}


### PR DESCRIPTION
They opt out of our funky reverse-import-and-artificial-document hack we did for non-module scripts.

Also add `ScriptTagImport#isModule`.

This also fixes an issue in generating analysis.json for webcomponents.org