### PR TITLE
Update the CLI README.md to include info about `polymer install --npm`.

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,7 +72,7 @@ Installs your dependencies from Bower or npm.
 
 If the `--variants` option is provided, the command will also search your project's `bower.json` for a `"variants"` property and install any dependency variants listed there. [Dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) describe alternative sets of dependencies to install alongside your normal `bower_components/` folder. Other CLI commands like `polymer test` and `polymer serve` are able to read these alternative dependency sets and test/serve them in parallel. This is especially useful if you need to test your elements against multiple versions of Polymer and/or other dependencies.
 
-By default, `polymer install` installs dependencies from Bower, similar to running `bower install`. If the `--npm` option is provided or `npm: true` is specified in your `polymer.json`, then this command is equivalent to running `npm install`.
+By default, `polymer install` installs dependencies from Bower, similar to running `bower install`. If the `--npm` option is provided or `"npm": true` is specified in your `polymer.json`, then this command is equivalent to running `npm install`.
 
 
 ### `polymer serve [options...]`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,9 +68,11 @@ Run `polymer init` to choose a template from a list of all installed templates. 
 
 ### `polymer install [--variants]`
 
-Install your dependencies, similar to running `bower install`.
+Installs your dependencies from Bower or npm.
 
 If the `--variants` option is provided, the command will also search your project's `bower.json` for a `"variants"` property and install any dependency variants listed there. [Dependency variants](https://www.polymer-project.org/2.0/docs/glossary#dependency-variants) describe alternative sets of dependencies to install alongside your normal `bower_components/` folder. Other CLI commands like `polymer test` and `polymer serve` are able to read these alternative dependency sets and test/serve them in parallel. This is especially useful if you need to test your elements against multiple versions of Polymer and/or other dependencies.
+
+By default, `polymer install` installs dependencies from Bower, similar to running `bower install`. If the `--npm` option is provided or `npm: true` is specified in your `polymer.json`, then this command is equivalent to running `npm install`.
 
 
 ### `polymer serve [options...]`


### PR DESCRIPTION
`polymer install` now installs from npm if you provide the `--npm` flag or add the `npm` setting in your `polymer.json`.

https://github.com/Polymer/tools/blob/0cdecd03e7e3709f84fa4f5a52443c19988112be/packages/cli/src/install/install.ts#L50-L53

Fixes #197.