### PR TITLE
Break out more shop tests.

### DIFF
--- a/packages/build/src/babel-plugin-bare-specifiers.ts
+++ b/packages/build/src/babel-plugin-bare-specifiers.ts
@@ -94,12 +94,7 @@ const maybeResolve = (
     return resolve(specifier, filePath, componentInfo);
   } catch (e) {
     if (!isPathSpecifier(specifier)) {
-      // Don't warn if the specifier was already a path, even though we do
-      // resolve paths, because maybe the user is serving it some other
-      // way.
-      console.warn(
-          `Could not resolve module specifier "${specifier}" ` +
-          `in file "${filePath}".`);
+      // We should warn here if there's a helpful way to do that.
     }
     return specifier;
   }

--- a/packages/build/src/babel-plugin-bare-specifiers.ts
+++ b/packages/build/src/babel-plugin-bare-specifiers.ts
@@ -93,8 +93,16 @@ const maybeResolve = (
     }
     return resolve(specifier, filePath, componentInfo);
   } catch (e) {
-    if (!isPathSpecifier(specifier)) {
-      // We should warn here if there's a helpful way to do that.
+    // `require` and `meta` are fake imports that our other build tooling
+    // injects, so we should not warn for them.
+    if (!isPathSpecifier(specifier) && specifier !== 'require' &&
+        specifier !== 'meta') {
+      // Don't warn if the specifier was already a path, even though we do
+      // resolve paths, because maybe the user is serving it some other
+      // way.
+      console.warn(
+          `Could not resolve module specifier "${specifier}" ` +
+          `in file "${filePath}".`);
     }
     return specifier;
   }

--- a/packages/cli/src/github/github.ts
+++ b/packages/cli/src/github/github.ts
@@ -14,7 +14,6 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as logging from 'plylog';
 import * as semver from 'semver';
 
 import request = require('request');
@@ -28,8 +27,6 @@ const fileFilterList = [
   '.github',
   '.travis.yml',
 ];
-
-const logger = logging.getLogger('cli.github');
 
 export type RequestAPI = request.RequestAPI<
     request.Request,
@@ -137,7 +134,6 @@ export class Github {
                       tarballUrl, response.statusCode, response.statusMessage));
                   return;
                 }
-                logger.info('Unpacking template files');
               })
           .on('error', reject)
           .pipe(gunzip())
@@ -145,7 +141,6 @@ export class Github {
           .pipe(tarPipe)
           .on('error', reject)
           .on('finish', () => {
-            logger.info('Finished writing template files');
             resolve();
           });
     });

--- a/packages/cli/src/init/github.ts
+++ b/packages/cli/src/init/github.ts
@@ -63,7 +63,6 @@ export function createGithubGenerator(githubOptions: GithubGeneratorOptions):
         codeSource = await this._github.getBranch(branch);
       }
 
-      logger.info(`Downloading ${codeSource.name} of ${owner}/${repo}`);
       await this._github.extractReleaseTarball(
           codeSource.tarball_url, this.destinationRoot());
       this._github.removeUnwantedFiles(this.destinationRoot());

--- a/packages/cli/src/test/integration/integration_test.ts
+++ b/packages/cli/src/test/integration/integration_test.ts
@@ -23,6 +23,8 @@ import {ProjectConfig, ProjectOptions} from 'polymer-project-config';
 import * as tempMod from 'temp';
 import * as fs from 'fs';
 
+const debugging = !!process.env['DEBUG_CLI_TESTS'];
+
 const temp = tempMod.track();
 
 const disposables: Array<() => void | Promise<void>> = [];
@@ -58,18 +60,14 @@ async function serve(dirToServe: string, options: ServerOptions = {}) {
  * thrown, and it waits a few rAFs after the load to be really sure the page is
  * ready.
  */
-async function gotoOrDie(
-    page: puppeteer.Page, url: string, configurationName?: string) {
-  const configurationMessage =
-      configurationName ? ` with config ${configurationName}` : '';
+async function gotoOrDie(page: puppeteer.Page, url: string) {
   let error: string|undefined;
   const handler = (e: string) => error = error || e;
   // Grab the first page error, if any.
   page.on('pageerror', handler);
   await page.goto(url);
   if (error) {
-    throw new Error(
-        `Error loading ${url} in Chrome${configurationMessage}: ${error}`);
+    throw new Error(`Error loading ${url} in Chrome: ${error}`);
   }
   // For the moment we don't type check in-browser expressions.
   // tslint:disable-next-line: no-any
@@ -82,8 +80,8 @@ async function gotoOrDie(
     });
   }
   if (error) {
-    throw new Error(`Error during rAFs after loading ${url} in Chrome${
-        configurationMessage}. Browser Error:\n${error}`);
+    throw new Error(`Error during rAFs after loading ${
+        url} in Chrome. Browser Error:\n${error}`);
   }
   page.removeListener('pageerror', handler);
 }
@@ -96,7 +94,6 @@ suite('integration tests', function() {
     await Promise.all(disposables.map((d) => d()));
     disposables.length = 0;
   });
-  teardown(async () => {});
 
   suite('init templates', () => {
     skipOnWindows('test the Polymer 3.x element template', async () => {
@@ -174,146 +171,6 @@ suite('integration tests', function() {
       //   {cwd: dir})
       // await runCommand(binPath, ['test'], {cwd: dir})
       await runCommand(binPath, ['build'], {cwd: dir});
-    });
-
-    // Serves the given directory with polyserve, then opens a Chrome tab
-    // and pokes around to test that the site is serving a working Shop.
-    async function assertThatShopWorks(
-        dirToServe: string, configurationName: string) {
-      const baseUrl = await serve(dirToServe);
-      const debugging = !!process.env['DEBUG_CLI_TESTS'];
-      let browser: puppeteer.Browser;
-      if (debugging) {
-        browser = await puppeteer.launch({headless: false, slowMo: 250});
-      } else {
-        browser = await puppeteer.launch();
-      }
-      const page = await browser.newPage();
-      disposables.push(() => browser.close());
-
-      // Evaluate an expression as a string in the browser.
-      const evaluate = async (expression: string) => {
-        try {
-          return await page.evaluate(expression);
-        } catch (e) {
-          throw new Error(`Failed evaluating expression \`${
-              expression} in the browser with build configuration ${
-              configurationName}. Error: ${e}`);
-        }
-      };
-      // Assert on an expression's result in the browser.
-      const assertTrueInPage = async (expression: string) => {
-        assert(
-            await evaluate(expression),
-            `Expected \`${
-                expression}\` to evaluate to true in the browser with build configuration ${
-                configurationName}`);
-      };
-      // For the moment we don't type check in-browser expressions.
-      // tslint:disable-next-line: no-any
-      type Window = any;
-      const waitFor =
-          async (name: string, cb: (this: Window) => boolean | Promise<{}>) => {
-        try {
-          await page.waitFor(cb);
-        } catch (e) {
-          throw new Error(`Error waiting for ${
-              name} in the browser with build configuration ${
-              configurationName}`);
-        }
-      };
-
-      await gotoOrDie(page, `${baseUrl}/`, configurationName);
-      assert.deepEqual(`${baseUrl}/`, page.url());
-      await waitFor('shop-app to be defined', function() {
-        return this.customElements.get('shop-app') !== undefined;
-      });
-      await waitFor('shop-app to have a shadowRoot', function() {
-        return this.document.querySelector('shop-app').shadowRoot !== undefined;
-      });
-      // The cart shouldn't be registered yet, because we've only loaded the
-      // main page.
-      await assertTrueInPage(`customElements.get('shop-cart') === undefined`);
-      // Click the shopping cart button.
-      await evaluate(`
-          (
-            // shop 3.0
-            document.querySelector('shop-app').shadowRoot
-                .querySelector('a[href="/cart"]')
-            ||
-            // shop lit
-            document.querySelector('shop-app').shadowRoot
-                .querySelector('shop-cart-button').shadowRoot
-                    .querySelector('a[href="/cart"]')
-          ).click()`);
-      // Url changes immediately
-      assert.deepEqual(`${baseUrl}/cart`, page.url());
-      // We'll lazy load the code for shop-cart. We'll know that it worked
-      // when the element is registered. If this resolves, it loaded
-      // successfully!
-      await waitFor('shop-cart to be defined', function() {
-        return this.customElements.get('shop-cart') !== undefined;
-      });
-    }
-
-    test('test the 3.0 "shop" template', async function() {
-      // Shop has a lot of build configurations, they take a long time.
-      this.timeout(10 * 60 * 1000);
-      const ShopGenerator = createGithubGenerator(
-          {owner: 'Polymer', repo: 'shop', githubToken, branch: '3.0'});
-
-      const dir = await runGenerator(ShopGenerator).toPromise();
-      await runCommand(binPath, ['install'], {cwd: dir});
-      await Promise.all([
-        // Does not lint clean at the moment.
-        // TODO: https://github.com/Polymer/tools/issues/274
-        // runCommand(binPath, ['lint', '--rules=polymer-3'], {cwd: dir}),
-        runCommand(binPath, ['build'], {cwd: dir}),
-      ]);
-
-      const config =
-          ProjectConfig.loadConfigFromFile(path.join(dir, 'polymer.json'));
-      if (config == null) {
-        throw new Error('Failed to load shop\'s polymer.json');
-      }
-
-      // Ideally this would be multiple independent tests, but `polymer build`
-      // takes a really long time, and we can also get a bit better performance
-      // by running these browser tests in parallel.
-      await Promise.all(config.builds.map((b) => {
-        const name = b.name || 'default';
-        return assertThatShopWorks(path.join(dir, 'build', name), name);
-      }));
-    });
-
-    test('test the lit-element "shop" template', async function() {
-      // Shop has a lot of build configurations, they take a long time.
-      this.timeout(10 * 60 * 1000);
-      const ShopGenerator = createGithubGenerator(
-          {owner: 'Polymer', repo: 'shop', githubToken, branch: 'lit-element'});
-
-      const dir = await runGenerator(ShopGenerator).toPromise();
-      await runCommand(binPath, ['install'], {cwd: dir});
-      await Promise.all([
-        // Does not lint clean at the moment.
-        // TODO: https://github.com/Polymer/tools/issues/274
-        // runCommand(binPath, ['lint', '--rules=polymer-3'], {cwd: dir}),
-        runCommand(binPath, ['build'], {cwd: dir}),
-      ]);
-
-      const config =
-          ProjectConfig.loadConfigFromFile(path.join(dir, 'polymer.json'));
-      if (config == null) {
-        throw new Error('Failed to load shop\'s polymer.json');
-      }
-      const dirs = config.builds.map(
-          (b) => path.join(dir, 'build', b.name || 'default'));
-      // Ideally this would be multiple independent tests, but `polymer
-      // build` takes a really long time, and we can also get a bit better
-      // performance by running these browser tests in parallel.
-      await Promise.all(dirs.map(async (builtShopDir) => {
-        await assertThatShopWorks(builtShopDir, path.basename(builtShopDir));
-      }));
     });
 
     // TODO(justinfagnani): consider removing these integration tests
@@ -532,5 +389,220 @@ suite('import.meta support', async () => {
         }
       });
     }
+  });
+});
+
+suite('polymer shop', function() {
+  if (debugging) {
+    // browser is much slower when debugging.
+    this.timeout(60 * 1000);
+  }
+
+  // Given the URL of a server serving out Polymer shop, opens a Chrome tab
+  // and pokes around to test that Shop is working there.
+  async function assertThatShopWorks(baseUrl: string) {
+    let browser: puppeteer.Browser;
+    if (debugging) {
+      browser = await puppeteer.launch({headless: false, slowMo: 250});
+    } else {
+      browser = await puppeteer.launch();
+    }
+    const page = await browser.newPage();
+    disposables.push(() => browser.close());
+
+    // Evaluate an expression as a string in the browser.
+    const evaluate = async (expression: string) => {
+      try {
+        return await page.evaluate(expression);
+      } catch (e) {
+        throw new Error(`Failed evaluating expression \`${
+            expression} in the browser. Error: ${e}`);
+      }
+    };
+    // Assert on an expression's result in the browser.
+    const assertTrueInPage = async (expression: string) => {
+      assert(
+          await evaluate(expression),
+          `Expected \`${expression}\` to evaluate to true in the browser`);
+    };
+    // For the moment we don't type check in-browser expressions.
+    // tslint:disable-next-line: no-any
+    type Window = any;
+    const waitFor =
+        async (name: string, cb: (this: Window) => boolean | Promise<{}>) => {
+      try {
+        await page.waitFor(cb);
+      } catch (e) {
+        throw new Error(`Error waiting for ${name} in the browser`);
+      }
+    };
+
+    await gotoOrDie(page, `${baseUrl}/`);
+    assert.deepEqual(`${baseUrl}/`, page.url());
+    await waitFor('shop-app to be defined', function() {
+      return this.customElements.get('shop-app') !== undefined;
+    });
+    await waitFor('shop-app to be rendered', function() {
+      const shadowRoot = this.document.querySelector('shop-app').shadowRoot;
+      return shadowRoot &&
+          shadowRoot.querySelector('a[href="/cart/"], shop-cart-button');
+    });
+    // The cart shouldn't be registered yet, because we've only loaded the
+    // main page.
+    await assertTrueInPage(`customElements.get('shop-cart') === undefined`);
+    // Click the shopping cart button.
+    await evaluate(`
+        (
+          // shop 3.0
+          document.querySelector('shop-app').shadowRoot
+              .querySelector('a[href="/cart"]')
+          ||
+          // shop lit
+          document.querySelector('shop-app').shadowRoot
+              .querySelector('shop-cart-button').shadowRoot
+                  .querySelector('a[href="/cart"]')
+        ).click()`);
+    // Url changes immediately
+    assert.deepEqual(`${baseUrl}/cart`, page.url());
+    // We'll lazy load the code for shop-cart. We'll know that it worked
+    // when the element is registered. If this resolves, it loaded
+    // successfully!
+    await waitFor('shop-cart to be defined', function() {
+      return this.customElements.get('shop-cart') !== undefined;
+    });
+  }
+
+  suiteTeardown(async () => {
+    await Promise.all(disposables.map((d) => d()));
+    disposables.length = 0;
+  });
+
+  suite('the 3.0 branch', () => {
+    let dir: string;
+    suiteSetup(async function() {
+      // Cloning and installing takes a minute
+      this.timeout(2 * 60 * 1000);
+      const ShopGenerator = createGithubGenerator(
+          {owner: 'Polymer', repo: 'shop', githubToken, branch: '3.0'});
+
+      dir = await runGenerator(ShopGenerator).toPromise();
+      await runCommand(binPath, ['install'], {cwd: dir});
+    });
+
+    test('serving sources with polyserve and `never` compile', async () => {
+      const baseUrl =
+          await serve(dir, {compile: 'never', moduleResolution: 'node'});
+      await assertThatShopWorks(baseUrl);
+    });
+
+    const testName = 'serving sources with polyserve and `always` compile';
+    test(testName, async function() {
+      // Compiling is a little slow.
+      this.timeout(30 * 1000);
+      const baseUrl =
+          await serve(dir, {compile: 'always', moduleResolution: 'node'});
+      await assertThatShopWorks(baseUrl);
+    });
+
+    test('serving sources with polyserve and `auto` compile', async () => {
+      const baseUrl =
+          await serve(dir, {compile: 'auto', moduleResolution: 'node'});
+      await assertThatShopWorks(baseUrl);
+    });
+
+    suite('when built with polymer build', () => {
+      const expectedBuildNames =
+          ['es5-bundled', 'es6-bundled', 'esm-bundled'].sort();
+      suiteSetup(async function() {
+        // Building takes a few minutes.
+        this.timeout(10 * 60 * 1000);
+        await Promise.all([
+          // Does not lint clean at the moment.
+          // TODO: https://github.com/Polymer/tools/issues/274
+          // runCommand(binPath, ['lint', '--rules=polymer-3'], {cwd: dir}),
+          runCommand(binPath, ['build'], {cwd: dir}),
+        ]);
+        const config =
+            ProjectConfig.loadConfigFromFile(path.join(dir, 'polymer.json'));
+        if (config == null) {
+          throw new Error('Failed to load shop\'s polymer.json');
+        }
+        assert.deepEqual(
+            config.builds.map((b) => b.name || 'default').sort(),
+            expectedBuildNames);
+      });
+
+
+      for (const buildName of expectedBuildNames) {
+        test(`works in the ${buildName} configuration`, async () => {
+          const baseUrl = await serve(path.join(dir, 'build', buildName));
+          await assertThatShopWorks(baseUrl);
+        });
+      }
+    });
+  });
+
+  suite('the lit-element branch', function() {
+    let dir: string;
+    suiteSetup(async function() {
+      // Cloning and installing takes a minute
+      this.timeout(2 * 60 * 1000);
+      const ShopGenerator = createGithubGenerator(
+          {owner: 'Polymer', repo: 'shop', githubToken, branch: 'lit-element'});
+
+      dir = await runGenerator(ShopGenerator).toPromise();
+      await runCommand(binPath, ['install'], {cwd: dir});
+    });
+
+    test('serving sources with polyserve and `never` compile', async () => {
+      const baseUrl =
+          await serve(dir, {compile: 'never', moduleResolution: 'node'});
+      await assertThatShopWorks(baseUrl);
+    });
+
+    const testName = 'serving sources with polyserve and `always` compile';
+    test(testName, async function() {
+      // Compiling is a little slow.
+      this.timeout(30 * 1000);
+      const baseUrl =
+          await serve(dir, {compile: 'always', moduleResolution: 'node'});
+      await assertThatShopWorks(baseUrl);
+    });
+
+    test('serving sources with polyserve and `auto` compile', async () => {
+      const baseUrl =
+          await serve(dir, {compile: 'auto', moduleResolution: 'node'});
+      await assertThatShopWorks(baseUrl);
+    });
+
+    suite('when built with polymer build', () => {
+      const expectedBuildNames =
+          ['es5-bundled', 'es6-bundled', 'esm-bundled'].sort();
+      suiteSetup(async function() {
+        // Building takes a few minutes.
+        this.timeout(10 * 60 * 1000);
+        await Promise.all([
+          // Does not lint clean at the moment.
+          // TODO: https://github.com/Polymer/tools/issues/274
+          // runCommand(binPath, ['lint', '--rules=polymer-3'], {cwd: dir}),
+          runCommand(binPath, ['build'], {cwd: dir}),
+        ]);
+        const config =
+            ProjectConfig.loadConfigFromFile(path.join(dir, 'polymer.json'));
+        if (config == null) {
+          throw new Error('Failed to load shop\'s polymer.json');
+        }
+        assert.deepEqual(
+            config.builds.map((b) => b.name || 'default').sort(),
+            expectedBuildNames);
+      });
+
+      for (const buildName of expectedBuildNames) {
+        test(`works in the ${buildName} configuration`, async () => {
+          const baseUrl = await serve(path.join(dir, 'build', buildName));
+          await assertThatShopWorks(baseUrl);
+        });
+      }
+    });
   });
 });

--- a/packages/cli/src/test/integration/integration_test.ts
+++ b/packages/cli/src/test/integration/integration_test.ts
@@ -393,10 +393,7 @@ suite('import.meta support', async () => {
 });
 
 suite('polymer shop', function() {
-  if (debugging) {
-    // browser is much slower when debugging.
-    this.timeout(60 * 1000);
-  }
+  this.timeout(60 * 1000);
 
   // Given the URL of a server serving out Polymer shop, opens a Chrome tab
   // and pokes around to test that Shop is working there.


### PR DESCRIPTION
Adds tests of the source with a few different polyserve definitions.

Also breaks out each of the individual build configuration tests.

This isn't bad performance-wise, because the vast majority of the cost is in `npm install` and `polymer build` which is not repeated.

Also removes some unnecessary and distracting logging statements.