### PR TITLE
Add CHANGELOG entries for new compile target options.

### DIFF
--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * The [regenerator runtime](https://github.com/facebook/regenerator) can now
   be injected either inline each time it is used by `jsTransform`, or inline
   into the HTML document by `htmlTransform`.
+* Added es5, es2015, es2016, es2017, and es2018 compile targets to `jsTransform`
+  to allow fine grained control over what features to compile.
 
 ## [3.0.0-pre.16] - 2018-05-01
 * Disable the `simplify` babel plugin when minifying javascript. See

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,8 +15,9 @@
   async/await and generators. `serve` will include the runtime in each script
   where it is used while `build` will include it once, inline, in the entrypoint
   HTML file.
-* Added es5, es2015, es2016, es2017, and es2018 compile targets to `build` to
-  allow fine grained control over what features to compile.
+* Added es5, es2015, es2016, es2017, and es2018 compile targets to the to
+  `js.compile` option of `polymer.json`, to allow fine grained control over
+  which JavaScript features to compile during `build`.
 
 ## v1.7.0-pre.16 [05-01-2018]
 * Dropped support for node v6. This is a soft break, as we aren't

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
   async/await and generators. `serve` will include the runtime in each script
   where it is used while `build` will include it once, inline, in the entrypoint
   HTML file.
-* Added es5, es2015, es2016, es2017, and es2018 compile targets to the to
+* Added es5, es2015, es2016, es2017, and es2018 compile targets to the
   `js.compile` option of `polymer.json`, to allow fine grained control over
   which JavaScript features to compile during `build`.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -15,6 +15,8 @@
   async/await and generators. `serve` will include the runtime in each script
   where it is used while `build` will include it once, inline, in the entrypoint
   HTML file.
+* Added es5, es2015, es2016, es2017, and es2018 compile targets to `build` to
+  allow fine grained control over what features to compile.
 
 ## v1.7.0-pre.16 [05-01-2018]
 * Dropped support for node v6. This is a soft break, as we aren't

--- a/packages/project-config/CHANGELOG.md
+++ b/packages/project-config/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   [@polymer/esm-amd-loader](https://github.com/Polymer/tools/tree/master/packages/esm-amd-loader),
   instead of injecting a static path. As a result, it is now always coupled with
   the AMD transform, and cannot be enabled independently.
+* Added es5, es2015, es2016, es2017, and es2018 compile targets to the to
+  `js.compile` option, to allow fine grained control over which JavaScript
+  features to compile.
 
 ## [3.13.0] - 2018-04-03
 * [breaking] Rename `build` option from `js.transformEsModulesToAmd` to `js.transformModulesToAmd`.

--- a/packages/project-config/CHANGELOG.md
+++ b/packages/project-config/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   [@polymer/esm-amd-loader](https://github.com/Polymer/tools/tree/master/packages/esm-amd-loader),
   instead of injecting a static path. As a result, it is now always coupled with
   the AMD transform, and cannot be enabled independently.
-* Added es5, es2015, es2016, es2017, and es2018 compile targets to the to
+* Added es5, es2015, es2016, es2017, and es2018 compile targets to the
   `js.compile` option, to allow fine grained control over which JavaScript
   features to compile.
 


### PR DESCRIPTION
These were forgotten earlier, but are pretty important.