### PR TITLE
Remove @types/rollup from bundler

### DIFF
--- a/packages/bundler/package-lock.json
+++ b/packages/bundler/package-lock.json
@@ -4,6 +4,169 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
+			"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.46"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.46.tgz",
+			"integrity": "sha512-5VfaEVkPG0gpNSTcf70jvV+MjbMoNn4g2iluwM7MhciedkolEtmG7PcdoUj5W1EmMfngz5cF65V7UMZXJO6y8Q==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.46",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.2.0",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+					"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.46.tgz",
+			"integrity": "sha512-zm4Kc5XB2njGs8PkmjV1zE/g1hBuphbh+VcDyFLaQsxkxSFSUtCbKwFL8AQpL/qPIcGbvX1MBt50a/3ZZH2CQA==",
+			"requires": {
+				"@babel/helper-get-function-arity": "7.0.0-beta.46",
+				"@babel/template": "7.0.0-beta.46",
+				"@babel/types": "7.0.0-beta.46"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.46.tgz",
+			"integrity": "sha512-dPrTb7QHVx44xJLjUl3LGAc13iS7hdXdO0fiOxdRN1suIS91yGGgeuwiQBlrw5SxbFchYtwenhlKbqHdVfGyVA==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.46"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.46.tgz",
+			"integrity": "sha512-UT7acgV7wsnBPwnqslqcnUFvsPBP4TtVaYM82xPGA7+evAa8q8HXOmFk08qsMK/pX/yy4+51gJJwyw2zofnacA==",
+			"requires": {
+				"@babel/types": "7.0.0-beta.46"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
+			"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/template": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.46.tgz",
+			"integrity": "sha512-3/qi4m0l6G/vZbEwtqfzJk73mYtuE7nvAO1zT3/ZrTAHy4sHf2vaF9Eh1w+Tau263Yrkh0bjVQPb9zw6G+GeMQ==",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.46",
+				"@babel/types": "7.0.0-beta.46",
+				"babylon": "7.0.0-beta.46",
+				"lodash": "^4.2.0"
+			},
+			"dependencies": {
+				"babylon": {
+					"version": "7.0.0-beta.46",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
+				}
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.46.tgz",
+			"integrity": "sha512-IU7MTGbcjpfhf5tyCu3sDB7sWYainZQcT+CqOBdVZXZfq5MMr130R7aiZBI2g5dJYUaW1PS81DVNpd0/Sq/Gzg==",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.46",
+				"@babel/generator": "7.0.0-beta.46",
+				"@babel/helper-function-name": "7.0.0-beta.46",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.46",
+				"@babel/types": "7.0.0-beta.46",
+				"babylon": "7.0.0-beta.46",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.2.0"
+			},
+			"dependencies": {
+				"babylon": {
+					"version": "7.0.0-beta.46",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.5.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+					"integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ=="
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.46.tgz",
+			"integrity": "sha512-uA5aruF2KKsJxToWdDpftsrPOIQtoGrGno2hiaeO9JRvfT9xZdK11nPoC+/RF9emNzmNbWn4HCRdCY+McT5Nbw==",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.2.0",
+				"to-fast-properties": "^2.0.0"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
 		"@types/acorn": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.3.tgz",
@@ -33,11 +196,31 @@
 			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.1.tgz",
 			"integrity": "sha512-EkcOk09rjhivbovP8WreGRbXW20YRfe/qdgXOGq3it3u3aAOWDRNsQhL/XPAWFF7zhZZ+uR+nT+3b+TCkIap1w=="
 		},
+		"@types/babylon": {
+			"version": "6.16.2",
+			"resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
+			"integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
+			"requires": {
+				"@types/babel-types": "*"
+			}
+		},
 		"@types/chai": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
-			"integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
-			"dev": true
+			"integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4="
+		},
+		"@types/chai-subset": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
+			"integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
+			"requires": {
+				"@types/chai": "*"
+			}
+		},
+		"@types/chalk": {
+			"version": "0.4.31",
+			"resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
+			"integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk="
 		},
 		"@types/chokidar": {
 			"version": "1.7.5",
@@ -54,6 +237,16 @@
 			"resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
 			"integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
 		},
+		"@types/cssbeautify": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+			"integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8="
+		},
+		"@types/doctrine": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
+			"integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
+		},
 		"@types/estree": {
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -65,6 +258,16 @@
 			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
 			"dev": true
 		},
+		"@types/is-windows": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+			"integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8="
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+		},
 		"@types/mocha": {
 			"version": "2.2.48",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -74,8 +277,7 @@
 		"@types/node": {
 			"version": "8.10.12",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.12.tgz",
-			"integrity": "sha512-aRFUGj/f9JVA0qSQiCK9ebaa778mmqMIcy1eKnPktgfm9O6VsnIzzB5wJnjp9/jVrfm7fX1rr3OR1nndppGZUg==",
-			"dev": true
+			"integrity": "sha512-aRFUGj/f9JVA0qSQiCK9ebaa778mmqMIcy1eKnPktgfm9O6VsnIzzB5wJnjp9/jVrfm7fX1rr3OR1nndppGZUg=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -92,12 +294,17 @@
 				}
 			}
 		},
-		"@types/rollup": {
-			"version": "0.54.0",
-			"resolved": "https://registry.npmjs.org/@types/rollup/-/rollup-0.54.0.tgz",
-			"integrity": "sha512-oeYztLHhQ98jnr+u2cs1c3tHOGtpzrm9DJlIdEjznwoXWidUbrI+X6ib7zCkPIbB7eJ7VbbKNQ5n/bPnSg6Naw==",
+		"@types/path-is-inside": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+			"integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw=="
+		},
+		"@types/resolve": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+			"integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
 			"requires": {
-				"rollup": "*"
+				"@types/node": "*"
 			}
 		},
 		"@types/source-map": {
@@ -105,6 +312,14 @@
 			"resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.2.tgz",
 			"integrity": "sha512-++w4WmMbk3dS3UeHGzAG+xJOSz5Xqtjys/TBkqG3qp3SeWE7Wwezqe5eB7B51cxUyh4PW7bwVotpsLdBK0D8cw==",
 			"dev": true
+		},
+		"@types/whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -352,8 +567,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"bluebird": {
 			"version": "3.5.1",
@@ -382,7 +596,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -420,6 +633,21 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
 			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
 			"dev": true
+		},
+		"cancel-token": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+			"integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+			"requires": {
+				"@types/node": "^4.0.30"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "4.2.23",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+					"integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w=="
+				}
+			}
 		},
 		"capture-stack-trace": {
 			"version": "1.0.0",
@@ -519,7 +747,6 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-			"dev": true,
 			"requires": {
 				"color-name": "^1.1.1"
 			}
@@ -527,8 +754,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"columnify": {
 			"version": "1.5.4",
@@ -581,8 +807,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -632,6 +857,11 @@
 			"requires": {
 				"capture-stack-trace": "^1.0.0"
 			}
+		},
+		"cssbeautify": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
+			"integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
 		},
 		"d": {
 			"version": "1.0.0",
@@ -1204,8 +1434,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-unicode": {
 			"version": "2.0.1",
@@ -1246,6 +1475,11 @@
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 			"dev": true
+		},
+		"indent": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
+			"integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -1529,6 +1763,11 @@
 			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
 			"dev": true
 		},
+		"jsonschema": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+		},
 		"latest-version": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
@@ -1573,6 +1812,11 @@
 			"version": "4.17.10",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
 			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"log-update": {
 			"version": "1.0.2",
@@ -1646,7 +1890,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -1869,14 +2112,12 @@
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-			"dev": true
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
 		},
 		"pify": {
 			"version": "2.3.0",
@@ -1904,6 +2145,96 @@
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
 			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
 			"dev": true
+		},
+		"polymer-analyzer": {
+			"version": "3.0.0-pre.25",
+			"resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.25.tgz",
+			"integrity": "sha512-jbpIHLQJPfhiZ/1urHfsjG3o8XYGtqRalpoMGtY95wijeGWHkpSS3x92tHiHUsYlqcIeQXCwimiBv0rnr+2n3Q==",
+			"requires": {
+				"@babel/generator": "^7.0.0-beta.42",
+				"@babel/traverse": "^7.0.0-beta.42",
+				"@babel/types": "^7.0.0-beta.42",
+				"@types/babel-generator": "^6.25.1",
+				"@types/babel-traverse": "^6.25.2",
+				"@types/babel-types": "^6.25.1",
+				"@types/babylon": "^6.16.2",
+				"@types/chai-subset": "^1.3.0",
+				"@types/chalk": "^0.4.30",
+				"@types/clone": "^0.1.30",
+				"@types/cssbeautify": "^0.3.1",
+				"@types/doctrine": "^0.0.1",
+				"@types/is-windows": "^0.2.0",
+				"@types/minimatch": "^3.0.1",
+				"@types/node": "^9.6.4",
+				"@types/parse5": "^2.2.34",
+				"@types/path-is-inside": "^1.0.0",
+				"@types/resolve": "0.0.6",
+				"@types/whatwg-url": "^6.4.0",
+				"babylon": "^7.0.0-beta.42",
+				"cancel-token": "^0.1.1",
+				"chalk": "^1.1.3",
+				"clone": "^2.0.0",
+				"cssbeautify": "^0.3.1",
+				"doctrine": "^2.0.2",
+				"dom5": "^3.0.0",
+				"indent": "0.0.2",
+				"is-windows": "^1.0.2",
+				"jsonschema": "^1.1.0",
+				"minimatch": "^3.0.4",
+				"parse5": "^4.0.0",
+				"path-is-inside": "^1.0.2",
+				"resolve": "^1.5.0",
+				"shady-css-parser": "^0.1.0",
+				"stable": "^0.1.6",
+				"strip-indent": "^2.0.0",
+				"vscode-uri": "^1.0.1",
+				"whatwg-url": "^6.4.0"
+			},
+			"dependencies": {
+				"@types/babel-types": {
+					"version": "6.25.2",
+					"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
+					"integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA=="
+				},
+				"@types/node": {
+					"version": "9.6.12",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.12.tgz",
+					"integrity": "sha512-2Z8ziWjJbvV8hHL5YcqCG9ng+/qwUlO1gB4frBD7QI5Wm1Y1iM+AEkGVEv0S5P+aDMwTtAhPJFR4rp1uqagSig=="
+				},
+				"babylon": {
+					"version": "7.0.0-beta.46",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+					"integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg=="
+				},
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				},
+				"dom5": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.0.tgz",
+					"integrity": "sha512-PbE+7C4Sh1dHDTLNuSDaMUGD1ivDiSZw0L+a9xVUzUKeQ8w3vdzfKHRA07CxcrFZZOa1SGl2nIJ9T49j63q+bg==",
+					"requires": {
+						"@types/parse5": "^2.2.32",
+						"clone": "^2.1.0",
+						"parse5": "^4.0.0"
+					}
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+					"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+				},
+				"parse5": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+				}
+			}
 		},
 		"popsicle": {
 			"version": "8.2.0",
@@ -2111,7 +2442,6 @@
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
 			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -2148,9 +2478,20 @@
 			}
 		},
 		"rollup": {
-			"version": "0.56.5",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.5.tgz",
-			"integrity": "sha512-IGPk5vdWrsc4vkiW9XMeXr5QMtxmvATTttTi59w2jBQWe9G/MMQtn8teIBAj+DdK51TrpVT6P0aQUaQUlUYCJA=="
+			"version": "0.58.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.58.2.tgz",
+			"integrity": "sha512-RZVvCWm9BHOYloaE6LLiE/ibpjv1CmI8F8k0B0Cp+q1eezo3cswszJH1DN0djgzSlo0hjuuCmyeI+1XOYLl4wg==",
+			"requires": {
+				"@types/estree": "0.0.38",
+				"@types/node": "*"
+			},
+			"dependencies": {
+				"@types/estree": {
+					"version": "0.0.38",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
+					"integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA=="
+				}
+			}
 		},
 		"run-async": {
 			"version": "0.1.0",
@@ -2187,6 +2528,11 @@
 			"requires": {
 				"semver": "^5.0.3"
 			}
+		},
+		"shady-css-parser": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+			"integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA=="
 		},
 		"shelljs": {
 			"version": "0.6.1",
@@ -2247,6 +2593,11 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+		},
 		"string-template": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
@@ -2289,6 +2640,11 @@
 			"requires": {
 				"is-utf8": "^0.2.0"
 			}
+		},
+		"strip-indent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 		},
 		"strip-json-comments": {
 			"version": "1.0.4",
@@ -2439,6 +2795,21 @@
 			"dev": true,
 			"requires": {
 				"punycode": "^1.4.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "^2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+					"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+				}
 			}
 		},
 		"trim-right": {
@@ -2713,6 +3084,21 @@
 			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"whatwg-url": {
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"widest-line": {

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -4,7 +4,7 @@
   "description": "Process Web Components into one output file",
   "homepage": "https://github.com/Polymer/tools/tree/master/packages/bundler",
   "repository": "github:Polymer/tools",
-  "bugs": "https://github.com/Polymer/polymer-bundler/issues",
+  "bugs": "https://github.com/Polymer/tools/issues",
   "license": "BSD-3-Clause",
   "author": "The Polymer Project Authors",
   "main": "lib/bundler.js",

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -3,13 +3,8 @@
   "version": "4.0.0-pre.7",
   "description": "Process Web Components into one output file",
   "homepage": "https://github.com/Polymer/tools/tree/master/packages/bundler",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/Polymer/polymer-bundler.git"
-  },
-  "bugs": {
-    "url": "https://github.com/Polymer/polymer-bundler/issues"
-  },
+  "repository": "github:Polymer/tools",
+  "bugs": "https://github.com/Polymer/polymer-bundler/issues",
   "license": "BSD-3-Clause",
   "author": "The Polymer Project Authors",
   "main": "lib/bundler.js",

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -3,8 +3,13 @@
   "version": "4.0.0-pre.7",
   "description": "Process Web Components into one output file",
   "homepage": "https://github.com/Polymer/tools/tree/master/packages/bundler",
-  "repository": "github:Polymer/tools",
-  "bugs": "https://github.com/Polymer/tools/issues",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Polymer/polymer-bundler.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Polymer/polymer-bundler/issues"
+  },
   "license": "BSD-3-Clause",
   "author": "The Polymer Project Authors",
   "main": "lib/bundler.js",
@@ -21,7 +26,6 @@
     "@types/acorn": "^4.0.3",
     "@types/babel-generator": "^6.25.1",
     "@types/babel-traverse": "^6.25.3",
-    "@types/rollup": "^0.54.0",
     "acorn-import-meta": "^0.2.1",
     "babel-generator": "^6.26.1",
     "babel-traverse": "^6.26.0",
@@ -34,7 +38,7 @@
     "mkdirp": "^0.5.1",
     "parse5": "^2.2.2",
     "polymer-analyzer": "=3.0.0-pre.25",
-    "rollup": "^0.56.1",
+    "rollup": "^0.58.2",
     "source-map": "^0.5.6",
     "vscode-uri": "^1.0.1"
   },
@@ -65,19 +69,11 @@
     "test:unit": "mocha \"lib/test/**/*_test.js\"",
     "test:watch": "tsc-then -- mocha \"lib/test/**/*_test.js\""
   },
-  "license": "BSD-3-Clause",
   "directories": {
     "test": "test"
   },
   "keywords": [
     "web components",
     "polymer"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/Polymer/polymer-bundler.git"
-  },
-  "bugs": {
-    "url": "https://github.com/Polymer/polymer-bundler/issues"
-  }
+  ]
 }


### PR DESCRIPTION
These typings are now being shipped by Rollup itself: https://www.npmjs.com/package/@types/rollup

My `npm install` reordered some fields in the `package.json`. I assume this is new npm behavior :thinking: The content is still the same though. (For example `license` was duplicate specified)