### PR TITLE
Re-enable editor-service tests

### DIFF
--- a/packages/editor-service/src/test/auto-completer_test.ts
+++ b/packages/editor-service/src/test/auto-completer_test.ts
@@ -187,9 +187,7 @@ const attributeCompletions: CompletionItem[] = [
   },
 ];
 
-// TODO(https://github.com/Polymer/tools/issues/170): these tests are slightly
-//     flaky, skip for now.
-suite.skip('AutoCompleter', () => {
+suite('AutoCompleter', () => {
   const indexFile = path.join('editor-service', 'index.html');
   const indexContents = readFileSync(path.join(fixtureDir, indexFile), 'utf-8');
   const tagPosition = {line: 7, column: 9};

--- a/packages/editor-service/src/test/definition-finder_test.ts
+++ b/packages/editor-service/src/test/definition-finder_test.ts
@@ -20,9 +20,7 @@ import {createTestEnvironment} from './util';
 
 const fixtureDir = path.join(__dirname, '..', '..', 'src', 'test', 'static');
 
-// TODO(https://github.com/Polymer/tools/issues/170): these tests are slightly
-//     flaky, skip for now.
-suite.skip('DefinitionFinder', function() {
+suite('DefinitionFinder', function() {
   const indexFile = path.join('editor-service', 'index.html');
   const tagPosition = {line: 7, column: 9};
   const localAttributePosition = {line: 7, column: 31};


### PR DESCRIPTION
I was not able to let them fail locally, so let's see what CI says.

Fixes #170 