### PR TITLE
[bundler] Tie up a few small loose ends in bundler code

### DIFF
--- a/packages/bundler/src/es6-module-utils.ts
+++ b/packages/bundler/src/es6-module-utils.ts
@@ -58,10 +58,6 @@ export function getOrSetBundleModuleExportName(
 
 /**
  * Returns a set of every name exported by a module.
- *
- * TODO(usergenic): This does not include names brought in by the statement
- * `export * from './module-a.js';`.
- * https://github.com/Polymer/polymer-bundler/issues/641
  */
 export function getModuleExportNames(document: Document): Set<string> {
   const exports_ = document.getFeatures({kind: 'export'});

--- a/packages/bundler/src/es6-rewriter.ts
+++ b/packages/bundler/src/es6-rewriter.ts
@@ -14,7 +14,7 @@
 import traverse, {NodePath} from 'babel-traverse';
 import * as babel from 'babel-types';
 import * as clone from 'clone';
-import {Document, FileRelativeUrl, PackageRelativeUrl, ResolvedUrl} from 'polymer-analyzer';
+import {Document, FileRelativeUrl, PackageRelativeUrl, ParsedJavaScriptDocument, ResolvedUrl} from 'polymer-analyzer';
 import {rollup} from 'rollup';
 
 import {assertIsJsDocument, getAnalysisDocument} from './analyzer-utils';
@@ -113,7 +113,9 @@ export class Es6Rewriter {
             // When the requested document is part of the bundle, get it from
             // the analysis.
             if (this.bundle.bundle.files.has(id)) {
-              const document = getAnalysisDocument(analysis, id);
+              const document =
+                  assertIsJsDocument(getAnalysisDocument(analysis, id));
+
               if (!jsImportResolvedUrls.has(id)) {
                 jsImportResolvedUrls.set(
                     id, this._getJsImportResolutions(document));
@@ -134,13 +136,8 @@ export class Es6Rewriter {
                   ensureLeadingDot(this.bundler.analyzer.urlResolver.relative(
                       this.bundle.url, id));
 
-              // TODO(usergenic): This code makes assumptions about the type of
-              // the ast and the document contents that are potentially not true
-              // if there are coding or resolution errors. Need to add some kind
-              // of type checking or assertion that we're dealing with at least
-              // a `Document<ParsedJavascriptDocument>` here.
               const newAst = this._rewriteImportMetaToBundleMeta(
-                  document.parsedDocument.ast as babel.File, relativeUrl);
+                  document.parsedDocument.ast, relativeUrl);
               const newCode = serialize(newAst).code;
               return newCode;
             }

--- a/packages/bundler/src/test/import-meta-url_test.ts
+++ b/packages/bundler/src/test/import-meta-url_test.ts
@@ -29,11 +29,12 @@ suite('import.meta.url', () => {
     `,
     'subfolder/b.js': `
       import {myUrl as aUrl} from '../a.js';
+      const bundledImportMeta = 'Potential naming conflict!';
       const myUrl = import.meta.url;
-      export {myUrl, aUrl};
+      export {myUrl, aUrl, bundledImportMeta as bDefinedImportMeta};
     `,
     'c.js': `
-      import {aUrl, myUrl as bUrl} from './subfolder/b.js';
+      import {aUrl, myUrl as bUrl, bDefinedImportMeta} from './subfolder/b.js';
       const myMeta = import.meta;
       export {aUrl, bUrl, myMeta};
     `,
@@ -61,19 +62,21 @@ suite('import.meta.url', () => {
     const {documents} =
         await bundler.bundle(await bundler.generateManifest([bUrl]));
     assert.deepEqual(documents.get(bUrl)!.content, heredoc`
-      const __bundledImportMeta = { ...import.meta,
+      const bundledImportMeta = { ...import.meta,
         url: new URL('../a.js', import.meta.url).href
       };
-      const myUrl = __bundledImportMeta.url;
+      const myUrl = bundledImportMeta.url;
       var a = {
         myUrl: myUrl
       };
+      const bundledImportMeta$1 = 'Potential naming conflict!';
       const myUrl$1 = import.meta.url;
       var b = {
         myUrl: myUrl$1,
-        aUrl: myUrl
+        aUrl: myUrl,
+        bDefinedImportMeta: bundledImportMeta$1
       };
-      export { a as $a, b as $b, myUrl as myUrl$1, myUrl$1 as myUrl, myUrl as aUrl };`);
+      export { a as $a, b as $b, myUrl as myUrl$1, myUrl$1 as myUrl, myUrl as aUrl, bundledImportMeta$1 as bDefinedImportMeta };`);
   });
 
   test('multiple corrected import.meta.url values', async () => {
@@ -81,20 +84,22 @@ suite('import.meta.url', () => {
     const {documents} =
         await bundler.bundle(await bundler.generateManifest([cUrl]));
     assert.deepEqual(documents.get(cUrl)!.content, heredoc`
-      const __bundledImportMeta = { ...import.meta,
+      const bundledImportMeta = { ...import.meta,
         url: new URL('./a.js', import.meta.url).href
       };
-      const myUrl = __bundledImportMeta.url;
+      const myUrl = bundledImportMeta.url;
       var a = {
         myUrl: myUrl
       };
-      const __bundledImportMeta$1 = { ...import.meta,
+      const bundledImportMeta$1 = { ...import.meta,
         url: new URL('./subfolder/b.js', import.meta.url).href
       };
-      const myUrl$1 = __bundledImportMeta$1.url;
+      const bundledImportMeta$2 = 'Potential naming conflict!';
+      const myUrl$1 = bundledImportMeta$1.url;
       var b = {
         myUrl: myUrl$1,
-        aUrl: myUrl
+        aUrl: myUrl,
+        bDefinedImportMeta: bundledImportMeta$2
       };
       const myMeta = import.meta;
       var c = {
@@ -102,6 +107,6 @@ suite('import.meta.url', () => {
         bUrl: myUrl$1,
         myMeta: myMeta
       };
-      export { a as $a, c as $c, b as $b, myUrl, myUrl as aUrl, myUrl$1 as bUrl, myMeta, myUrl$1, myUrl as aUrl$1 };`);
+      export { a as $a, c as $c, b as $b, myUrl, myUrl as aUrl, myUrl$1 as bUrl, myMeta, myUrl$1, myUrl as aUrl$1, bundledImportMeta$2 as bDefinedImportMeta };`);
   });
 });

--- a/packages/bundler/src/utils.ts
+++ b/packages/bundler/src/utils.ts
@@ -82,3 +82,18 @@ export function rewriteObject(target: Object, replacement: Object) {
     target[key] = replacement[key];
   }
 }
+
+/**
+ * Generate a valid identifier name which is unique (i.e. does not appear
+ * anywhere in the source text provided).  Do this by trying the provided
+ * `value` and then successively trying the value with an incrementing suffix
+ * counter until one is found that appears nowhere in the source.
+ */
+export function generateUniqueIdentifierName(
+    value: string, source: string): string {
+  let counter = 0, uniqueValue = value;
+  while (source.includes(uniqueValue)) {
+    uniqueValue = `${value}$${++counter}`;
+  }
+  return uniqueValue;
+}


### PR DESCRIPTION
- Removed an obsolete TODO about `export * from` which was previously fixed. 5fa64a1
- Use the already defined assertJsDocument() and avoid unnecessary cast. 7e9f6a5
- Generate unique identifier name for the bundledImportMeta stand-in variable for bundled import.meta transform. 6b907ae