### PR TITLE
Simplify Travis build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ env:
   - secure: IbrybaUaJDiwNh8VodFfTIAdSw2Nl4DGRh2oDIO2vL8SPgGilwxY0go5DWrxAG0aP+YIXFkK+SpblFppQqqxnAoLVYmd7kFSJoOZraNqmcJqUYSzrHrWArmuiGzY8gMgOWTsnbzVVNRldN8tpoSwpQB/+YhCtbYb9eqvw+u5Izk=
   - secure: grvHX6c0ReQwRsuQZferI+uyGsKlubujURKuJB8coNdA9lgZcvf+nmCkNBpSML83hSjQkJUTt8XnucNNgL/1VxUhgy0O/wkTUEmcDAU1b80As8NJkbreJcc3HFASA68wou4HoJsFmJV2cpBYoAJJSX+HyT6mYd6pBh09tPfOeBg=
 
+# By default you get two Travis builds for a PR: one that builds the feature
+# branch directly (called "branch"), and another that makes a hypothetical merge
+# commit on master (called "PR"). The merge build is what really matters, and we
+# don't want to waste resources by also building the branch.
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,52 @@
 sudo: required
 dist: trusty
-addons:
-  firefox: latest
-  apt:
-    sources:
-    - google-chrome
-    packages:
-    - google-chrome-stable
-  sauce_connect: true
+language: node_js
+
 env:
   global:
   - secure: IbrybaUaJDiwNh8VodFfTIAdSw2Nl4DGRh2oDIO2vL8SPgGilwxY0go5DWrxAG0aP+YIXFkK+SpblFppQqqxnAoLVYmd7kFSJoOZraNqmcJqUYSzrHrWArmuiGzY8gMgOWTsnbzVVNRldN8tpoSwpQB/+YhCtbYb9eqvw+u5Izk=
   - secure: grvHX6c0ReQwRsuQZferI+uyGsKlubujURKuJB8coNdA9lgZcvf+nmCkNBpSML83hSjQkJUTt8XnucNNgL/1VxUhgy0O/wkTUEmcDAU1b80As8NJkbreJcc3HFASA68wou4HoJsFmJV2cpBYoAJJSX+HyT6mYd6pBh09tPfOeBg=
-  matrix:
-  - TEST_COMMAND="npm run test:unit"
-  - TEST_COMMAND="npm run test:integration" SKIP_REMOTE_BROWSERS=true
-  - TEST_COMMAND="npm run test:integration" RUN_SAUCE_TESTS=true
-matrix:
-  exclude:
-  - env: TEST_COMMAND="npm run test:integration" RUN_SAUCE_TESTS=true
-    node_js: '8'
-  - env: TEST_COMMAND="npm run test:integration" SKIP_REMOTE_BROWSERS=true
-    node_js: '9'
-language: node_js
-node_js:
-- '8'
-- '9' # TODO(https://github.com/Polymer/tools/issues/280): update to node 10
+
+branches:
+  only:
+  - master
+
 cache:
   directories:
   - "$HOME/.npm"
+
 install:
 - npm i -g npm@latest
 - npm ci
 - npm run bootstrap
 - npm run build
+
 script:
-- xvfb-run $TEST_COMMAND
-branches:
-  only:
-  - master
+- $TEST_COMMAND
+
+matrix:
+  include:
+
+  - node_js: '8'
+    env:
+    - TEST_COMMAND="npm run test:unit"
+
+  - node_js: '9'
+    env:
+    - TEST_COMMAND="npm run test:unit"
+
+  - node_js: '8'
+    addons:
+      chrome: stable
+      firefox: latest
+    env:
+    - TEST_COMMAND="xvfb-run npm run test:integration"
+    - SKIP_REMOTE_BROWSERS=true
+
+  - node_js: '9'
+    addons:
+      chrome: stable
+      firefox: latest
+      sauce_connect: true
+    env:
+    - TEST_COMMAND="xvfb-run npm run test:integration"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
     env:
     - TEST_COMMAND="npm run test:unit"
 
+  # TODO(https://github.com/Polymer/tools/issues/280): update to node 10
   - node_js: '9'
     env:
     - TEST_COMMAND="npm run test:unit"


### PR DESCRIPTION
Simplify Travis config by using "include" to set the matrix directly.

Also scopes browser installation and xvfb to only those builds that need it.