### PR TITLE
Remove 'WIP' from the monorepo README because, c'mon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WIP Polymer Tools Monorepo
+# Polymer Tools Monorepo
 
 [![Travis Build Status](https://travis-ci.org/Polymer/tools.svg?branch=master)](https://travis-ci.org/Polymer/tools/branches)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/4ss50o7t0312c2v1/branch/master?svg=true)](https://ci.appveyor.com/project/Polymer/tools/branch/master)


### PR DESCRIPTION
![drop-the-wip](https://user-images.githubusercontent.com/578/39843074-3353e58a-539e-11e8-91cf-60ce325c2526.jpg)
