### PR TITLE
[cli] Specify dependencies explicitly for GitHub generators in init.

### DIFF
--- a/packages/cli/src/init/github.ts
+++ b/packages/cli/src/init/github.ts
@@ -24,6 +24,11 @@ export interface GithubGeneratorOptions {
   repo: string;
   semverRange?: string;
   branch?: string;
+  installDependencies?: {
+    bower?: boolean;
+    npm?: boolean;
+    yarn?: boolean;
+  };
 }
 
 export function createGithubGenerator(githubOptions: GithubGeneratorOptions):
@@ -33,6 +38,7 @@ export function createGithubGenerator(githubOptions: GithubGeneratorOptions):
   const repo = githubOptions.repo;
   const semverRange = githubOptions.semverRange || '*';
   const branch = githubOptions.branch;
+  const installDependencies = githubOptions.installDependencies;
 
   return class GithubGenerator extends Generator {
     _github: Github;
@@ -74,7 +80,7 @@ export function createGithubGenerator(githubOptions: GithubGeneratorOptions):
     }
 
     install() {
-      this.installDependencies();
+      this.installDependencies(installDependencies);
     }
   };
 }

--- a/packages/cli/src/init/init.ts
+++ b/packages/cli/src/init/init.ts
@@ -56,7 +56,11 @@ const localGenerators: {[name: string]: GeneratorInfo} = {
     generator: createGithubGenerator({
       owner: 'Polymer',
       repo: 'polymer-starter-kit',
-      semverRange: '^4.0.0-pre.1',
+      semverRange: '^4.0.0',
+      installDependencies: {
+        bower: false,
+        npm: true,
+      },
     }),
   },
   'polymer-2-element': {
@@ -77,6 +81,10 @@ const localGenerators: {[name: string]: GeneratorInfo} = {
       owner: 'Polymer',
       repo: 'polymer-starter-kit',
       semverRange: '^3.0.0',
+      installDependencies: {
+        bower: true,
+        npm: true,
+      },
     }),
   },
   'shop': {
@@ -86,6 +94,10 @@ const localGenerators: {[name: string]: GeneratorInfo} = {
       owner: 'Polymer',
       repo: 'shop',
       semverRange: '^2.0.0',
+      installDependencies: {
+        bower: true,
+        npm: false,
+      },
     }),
   },
 };

--- a/packages/cli/src/test/integration/integration_test.ts
+++ b/packages/cli/src/test/integration/integration_test.ts
@@ -164,7 +164,12 @@ suite('integration tests', function() {
       const ShopGenerator = createGithubGenerator({
         owner: 'Polymer',
         repo: 'shop',
+        semverRange: '^2.0.0',
         githubToken,
+        installDependencies: {
+          bower: true,
+          npm: false,
+        },
       });
 
       const dir = await runGenerator(ShopGenerator).toPromise();
@@ -186,6 +191,10 @@ suite('integration tests', function() {
         repo: 'polymer-starter-kit',
         semverRange: '^2.0.0',
         githubToken,
+        installDependencies: {
+          bower: true,
+          npm: false,
+        },
       });
 
       const dir = await runGenerator(PSKGenerator).toPromise();
@@ -205,6 +214,10 @@ suite('integration tests', function() {
         repo: 'polymer-starter-kit',
         semverRange: '^3.0.0',
         githubToken,
+        installDependencies: {
+          bower: true,
+          npm: false,
+        },
       });
 
       const dir = await runGenerator(PSKGenerator).toPromise();
@@ -503,8 +516,16 @@ suite('polymer shop', function() {
       } else {
         // Cloning and installing takes a minute
         this.timeout(2 * 60 * 1000);
-        const ShopGenerator = createGithubGenerator(
-            {owner: 'Polymer', repo: 'shop', githubToken, branch: '3.0'});
+        const ShopGenerator = createGithubGenerator({
+          owner: 'Polymer',
+          repo: 'shop',
+          githubToken,
+          branch: '3.0',
+          installDependencies: {
+            bower: false,
+            npm: true,
+          },
+        });
 
         dir = await runGenerator(ShopGenerator).toPromise();
         await runCommand(binPath, ['install'], {cwd: dir});
@@ -577,7 +598,11 @@ suite('polymer shop', function() {
           owner: 'Polymer',
           repo: 'shop',
           githubToken,
-          branch: 'lit-element'
+          branch: 'lit-element',
+          installDependencies: {
+            bower: false,
+            npm: true,
+          },
         });
 
         dir = await runGenerator(ShopGenerator).toPromise();


### PR DESCRIPTION
- Pass dependency sources explicitly to the Yeoman generator that wraps GitHub projects.
- Bump PSK4 to the release version. (This should already be used during testing due to the hat.)
- Add an explicit version for the Shop generator tests. (^2.0.0)

Fixes #341. cc @motss