### PR TITLE
[build] Pin babel-plugin-minify-guarded-expressions to 0.4.1

### DIFF
--- a/packages/analyzer/package-lock.json
+++ b/packages/analyzer/package-lock.json
@@ -208,9 +208,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "9.6.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.15.tgz",
-			"integrity": "sha512-16zIiQkIZBc1ZpfrOZZZ/6LKDixPiAIZq5q1YE1stxG4Ic1VmQlkNNWGBydqBFcX8eS+m/Dd4z5HzDa+q0b2Xg=="
+			"version": "9.6.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.16.tgz",
+			"integrity": "sha512-fwUW7S8gaSVNpPa1XUdzI0URY71xqXsc90S9vKr2uFIUpVCKV+8ysnN9vvAFK8np4H03A7QGRkHpQvgah0964Q=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -2763,9 +2763,9 @@
 					}
 				},
 				"vinyl-fs": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.2.tgz",
-					"integrity": "sha512-AUSFda1OukBwuLPBTbyuO4IRWgfXmqC4UTW0f8xrCa8Hkv9oyIU+NSqBlgfOLZRoUt7cHdo75hKQghCywpIyIw==",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+					"integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
 					"dev": true,
 					"requires": {
 						"fs-mkdirp-stream": "^1.0.0",
@@ -4956,9 +4956,9 @@
 			"dev": true
 		},
 		"sparkles": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
 			"dev": true
 		},
 		"spdx-correct": {
@@ -5325,17 +5325,17 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "8.10.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.14.tgz",
-					"integrity": "sha512-TKQqQIaYNO+8MrOsFgobkt3fbMzkfXhBFKcg20Nip5Omptw1HOY/IEvYiFtMwIbr7Me/Y2H/JO+TgNUMJ9NGjA==",
+					"version": "8.10.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
+					"integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
 					"dev": true
 				}
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -5378,9 +5378,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/browser-capabilities/package-lock.json
+++ b/packages/browser-capabilities/package-lock.json
@@ -17,9 +17,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "8.10.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.14.tgz",
-			"integrity": "sha512-TKQqQIaYNO+8MrOsFgobkt3fbMzkfXhBFKcg20Nip5Omptw1HOY/IEvYiFtMwIbr7Me/Y2H/JO+TgNUMJ9NGjA==",
+			"version": "8.10.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
+			"integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
 			"dev": true
 		},
 		"@types/ua-parser-js": {
@@ -583,9 +583,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -617,9 +617,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Pin dependency babel-plugin-minify-guarded-expressions of
+  babel-preset-minify to known working version 0.4.1.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0] - 2018-05-08

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -892,9 +892,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "9.6.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.15.tgz",
-			"integrity": "sha512-16zIiQkIZBc1ZpfrOZZZ/6LKDixPiAIZq5q1YE1stxG4Ic1VmQlkNNWGBydqBFcX8eS+m/Dd4z5HzDa+q0b2Xg=="
+			"version": "9.6.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.16.tgz",
+			"integrity": "sha512-fwUW7S8gaSVNpPa1XUdzI0URY71xqXsc90S9vKr2uFIUpVCKV+8ysnN9vvAFK8np4H03A7QGRkHpQvgah0964Q=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -1233,14 +1233,14 @@
 			}
 		},
 		"babel-helper-evaluate-path": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.4.1.tgz",
-			"integrity": "sha1-a3XB4OMPFmKfKoZFyjBeGo01iaY="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.4.3.tgz",
+			"integrity": "sha1-ComvcCwGshcCf6NxkI3UmJ0+Yz8="
 		},
 		"babel-helper-flip-expressions": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.1.tgz",
-			"integrity": "sha1-zAPYBFjBA7n1BcHGpn++D1nKwyA="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+			"integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0="
 		},
 		"babel-helper-is-nodes-equiv": {
 			"version": "0.0.1",
@@ -1248,24 +1248,24 @@
 			"integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
 		},
 		"babel-helper-is-void-0": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.1.tgz",
-			"integrity": "sha1-ogu127ocMMSq/nPrMn0tGLKE7Ro="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+			"integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4="
 		},
 		"babel-helper-mark-eval-scopes": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.1.tgz",
-			"integrity": "sha1-A/nMmN76R0fnQS5wD069D+1ktXE="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+			"integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI="
 		},
 		"babel-helper-remove-or-void": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.1.tgz",
-			"integrity": "sha1-rdWwiBeFOVESpw8PHCWRebFSQmo="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+			"integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA="
 		},
 		"babel-helper-to-multiple-sequence-expressions": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.4.1.tgz",
-			"integrity": "sha1-FU7MOBGPXBybDp/CNd21OSFJvI8="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.4.3.tgz",
+			"integrity": "sha1-W1GLESf0ezA4dzOGoVYaK0jmMrY="
 		},
 		"babel-messages": {
 			"version": "6.23.0",
@@ -1277,38 +1277,38 @@
 			}
 		},
 		"babel-plugin-minify-builtins": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.4.1.tgz",
-			"integrity": "sha1-d6iMt2EO2SWxsCVKmQJAKR4LC+A=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.4.3.tgz",
+			"integrity": "sha1-nqPVn0rEp7uVjXEtKVVqH4b3+B4=",
 			"requires": {
-				"babel-helper-evaluate-path": "^0.4.1"
+				"babel-helper-evaluate-path": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-constant-folding": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.4.1.tgz",
-			"integrity": "sha1-LtT4Ow/yj01VU9CcXvyFtdti0RI=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.4.3.tgz",
+			"integrity": "sha1-MA+d6N2ghEoXaxk2U5YOJK0z4ZE=",
 			"requires": {
-				"babel-helper-evaluate-path": "^0.4.1"
+				"babel-helper-evaluate-path": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-dead-code-elimination": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.4.1.tgz",
-			"integrity": "sha1-81/PNIk06wqslEUCrTA3KRgu6yE=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.4.3.tgz",
+			"integrity": "sha1-c2KCZYZPkAjQAnUG9Yq+s8HQLZg=",
 			"requires": {
-				"babel-helper-evaluate-path": "^0.4.1",
-				"babel-helper-mark-eval-scopes": "^0.4.1",
-				"babel-helper-remove-or-void": "^0.4.1",
+				"babel-helper-evaluate-path": "^0.4.3",
+				"babel-helper-mark-eval-scopes": "^0.4.3",
+				"babel-helper-remove-or-void": "^0.4.3",
 				"lodash.some": "^4.6.0"
 			}
 		},
 		"babel-plugin-minify-flip-comparisons": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.1.tgz",
-			"integrity": "sha1-5wfl2rxpXJnNKSP+lw7ZrHjE5ws=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+			"integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
 			"requires": {
-				"babel-helper-is-void-0": "^0.4.1"
+				"babel-helper-is-void-0": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-guarded-expressions": {
@@ -1320,50 +1320,50 @@
 			}
 		},
 		"babel-plugin-minify-infinity": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.1.tgz",
-			"integrity": "sha1-zJw33MFmbcB/HrR4wrchoRz7lJE="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+			"integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco="
 		},
 		"babel-plugin-minify-mangle-names": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.4.1.tgz",
-			"integrity": "sha1-d76P7TUOkxo6qaCfl/KCYWgIMTM=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.4.3.tgz",
+			"integrity": "sha1-FvG/90t6fJPfwkHngx3V+0sCPvc=",
 			"requires": {
-				"babel-helper-mark-eval-scopes": "^0.4.1"
+				"babel-helper-mark-eval-scopes": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-numeric-literals": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.1.tgz",
-			"integrity": "sha1-lktObMdIfG1KMalRl8P0IbYMmkc="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+			"integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw="
 		},
 		"babel-plugin-minify-replace": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.4.1.tgz",
-			"integrity": "sha1-xRnYhYxiKySWo2SmE1rSd1V42UM="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.4.3.tgz",
+			"integrity": "sha1-nSifS6FdTmAR6HmfpfG6d+yBIZ0="
 		},
 		"babel-plugin-minify-simplify": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.4.1.tgz",
-			"integrity": "sha1-XlX0ibLV8CyQjCswm/CBTxXHV74=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.4.3.tgz",
+			"integrity": "sha1-N3VthcYURktLCSfytOQXGR1Vc4o=",
 			"requires": {
-				"babel-helper-flip-expressions": "^0.4.1",
+				"babel-helper-flip-expressions": "^0.4.3",
 				"babel-helper-is-nodes-equiv": "^0.0.1",
-				"babel-helper-to-multiple-sequence-expressions": "^0.4.1"
+				"babel-helper-to-multiple-sequence-expressions": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-type-constructors": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.1.tgz",
-			"integrity": "sha1-eSJNE0bDPk+kQnVqI0JkkVjvlEg=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+			"integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
 			"requires": {
-				"babel-helper-is-void-0": "^0.4.1"
+				"babel-helper-is-void-0": "^0.4.3"
 			}
 		},
 		"babel-plugin-transform-inline-consecutive-adds": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.1.tgz",
-			"integrity": "sha1-F13t/odsL/enjHUe1NncBZfRFx0="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+			"integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE="
 		},
 		"babel-plugin-transform-member-expression-literals": {
 			"version": "6.10.0-alpha.f95869d4",
@@ -1389,9 +1389,9 @@
 			}
 		},
 		"babel-plugin-transform-regexp-constructors": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.1.tgz",
-			"integrity": "sha1-T/fx2g4MMZENDhRhq+0MZ5yzHu4="
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+			"integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU="
 		},
 		"babel-plugin-transform-remove-console": {
 			"version": "6.10.0-alpha.f95869d4",
@@ -1404,11 +1404,11 @@
 			"integrity": "sha1-H8NcKcfAh4zzDlWKczZRkG6IjkQ="
 		},
 		"babel-plugin-transform-remove-undefined": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.4.1.tgz",
-			"integrity": "sha1-Y2x/KM66/Fpm+jT5TGCAR+r3508=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.4.3.tgz",
+			"integrity": "sha1-1AsNp/kcCMBsxyt2dHTAHEiU3gI=",
 			"requires": {
-				"babel-helper-evaluate-path": "^0.4.1"
+				"babel-helper-evaluate-path": "^0.4.3"
 			}
 		},
 		"babel-plugin-transform-simplify-comparison-operators": {
@@ -2563,11 +2563,11 @@
 			"dev": true
 		},
 		"feature-detect-es6": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
-			"integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.1.tgz",
+			"integrity": "sha512-iMxKpKdIBgcWiBPtz2qnEsNjCE2dBQvDyUqgrXLJboiaHwJa+2vDIZ8XbgNZGh1Rx1PUfZmI7uhG6Z4iQYWVjg==",
 			"requires": {
-				"array-back": "^1.0.3"
+				"array-back": "^1.0.4"
 			}
 		},
 		"filename-regex": {
@@ -5970,14 +5970,14 @@
 			"integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
 		},
 		"regenerate": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
 		},
 		"regenerate-unicode-properties": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-5.1.3.tgz",
-			"integrity": "sha512-Yjy6t7jFQczDhYE+WVm7pg6gWYE258q4sUkk9qDErwXJIqx7jU9jGrMFHutJK/SRfcg7MEkXjGaYiVlOZyev/A==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-6.0.0.tgz",
+			"integrity": "sha512-BvXxRS7RfVWxtm7vrq+0I0j7sqZ1zeSC+yzf5HS0qLnKcZPX541gFEGB39LvGuKHrkyKXrzXug+oC7xkM1Zovw==",
 			"requires": {
 				"regenerate": "^1.3.3"
 			}
@@ -6035,14 +6035,14 @@
 			}
 		},
 		"regexpu-core": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.3.tgz",
-			"integrity": "sha512-mB+njEzO7oezA57IbQxxd6fVPOeWKDmnGvJ485CwmfNchjHe5jWwqKepapmzUEj41yxIAqOg+C4LbXuJlkiO8A==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.1.5.tgz",
+			"integrity": "sha512-3xo5pFze1F8oR4F9x3aFbdtdxAxQ9WBX6gXfLgeBt7KpDI0+oDF7WVntnhsPKqobU/GAYc2pmx+y3z0JI1+z3w==",
 			"requires": {
-				"regenerate": "^1.3.3",
-				"regenerate-unicode-properties": "^5.1.1",
-				"regjsgen": "^0.3.0",
-				"regjsparser": "^0.2.1",
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^6.0.0",
+				"regjsgen": "^0.4.0",
+				"regjsparser": "^0.3.0",
 				"unicode-match-property-ecmascript": "^1.0.3",
 				"unicode-match-property-value-ecmascript": "^1.0.1"
 			}
@@ -6065,14 +6065,14 @@
 			}
 		},
 		"regjsgen": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.3.0.tgz",
-			"integrity": "sha1-DuSj6SdkMM2iXx54nqbBW4ewy0M="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+			"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
 		},
 		"regjsparser": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.2.1.tgz",
-			"integrity": "sha1-w3h1U/rwTndcMCEC7zRtmVAA7Bw=",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+			"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -6439,9 +6439,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-			"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -6463,9 +6463,9 @@
 			"dev": true
 		},
 		"sparkles": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
 			"dev": true
 		},
 		"spdx-correct": {
@@ -6940,17 +6940,17 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "8.10.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.14.tgz",
-					"integrity": "sha512-TKQqQIaYNO+8MrOsFgobkt3fbMzkfXhBFKcg20Nip5Omptw1HOY/IEvYiFtMwIbr7Me/Y2H/JO+TgNUMJ9NGjA==",
+					"version": "8.10.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
+					"integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
 					"dev": true
 				}
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -6974,9 +6974,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
@@ -7158,9 +7158,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.3.24",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.24.tgz",
-			"integrity": "sha512-hS7+TDiqIqvWScCcKRybCQzmMnEzJ4ryl9ErRmW4GFyG48p0/dKZiy/5mVLbsFzU8CCnCgQdxMiJzZythvLzCg==",
+			"version": "3.3.25",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.25.tgz",
+			"integrity": "sha512-hobogryjDV36VrLK3Y69ou4REyrTApzUblVFmdQOYRe8cYaSmFJXMb4dR9McdvYDSbeNdzUgYr2YVukJaErJcA==",
 			"requires": {
 				"commander": "~2.15.0",
 				"source-map": "~0.6.1"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -65,6 +65,7 @@
     "@types/vinyl": "^2.0.0",
     "@types/vinyl-fs": "^2.4.8",
     "babel-preset-minify": "=0.4.0-alpha.caaefb4c",
+    "babel-plugin-minify-guarded-expressions": "=0.4.1",
     "babylon": "^7.0.0-beta.42",
     "css-slam": "^2.1.1",
     "dom5": "^3.0.0",

--- a/packages/bundler/package-lock.json
+++ b/packages/bundler/package-lock.json
@@ -72,9 +72,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "8.10.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.14.tgz",
-			"integrity": "sha512-TKQqQIaYNO+8MrOsFgobkt3fbMzkfXhBFKcg20Nip5Omptw1HOY/IEvYiFtMwIbr7Me/Y2H/JO+TgNUMJ9NGjA==",
+			"version": "8.10.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
+			"integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
 			"dev": true
 		},
 		"@types/parse5": {
@@ -86,9 +86,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -977,11 +977,11 @@
 			"dev": true
 		},
 		"feature-detect-es6": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
-			"integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.1.tgz",
+			"integrity": "sha512-iMxKpKdIBgcWiBPtz2qnEsNjCE2dBQvDyUqgrXLJboiaHwJa+2vDIZ8XbgNZGh1Rx1PUfZmI7uhG6Z4iQYWVjg==",
 			"requires": {
-				"array-back": "^1.0.3"
+				"array-back": "^1.0.4"
 			}
 		},
 		"figures": {
@@ -2154,9 +2154,9 @@
 					"integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA=="
 				},
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -2465,9 +2465,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -2534,9 +2534,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -73,9 +73,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -99,9 +99,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -115,9 +115,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -147,9 +147,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -173,16 +173,16 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
 		"@types/node": {
-			"version": "8.10.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.14.tgz",
-			"integrity": "sha512-TKQqQIaYNO+8MrOsFgobkt3fbMzkfXhBFKcg20Nip5Omptw1HOY/IEvYiFtMwIbr7Me/Y2H/JO+TgNUMJ9NGjA==",
+			"version": "8.10.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
+			"integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
 			"dev": true
 		},
 		"@types/puppeteer": {
@@ -205,9 +205,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -220,9 +220,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -364,9 +364,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -379,9 +379,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -405,9 +405,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -422,9 +422,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -437,9 +437,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -2333,11 +2333,11 @@
 			}
 		},
 		"feature-detect-es6": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
-			"integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.1.tgz",
+			"integrity": "sha512-iMxKpKdIBgcWiBPtz2qnEsNjCE2dBQvDyUqgrXLJboiaHwJa+2vDIZ8XbgNZGh1Rx1PUfZmI7uhG6Z4iQYWVjg==",
 			"requires": {
-				"array-back": "^1.0.3"
+				"array-back": "^1.0.4"
 			}
 		},
 		"figures": {
@@ -6570,14 +6570,24 @@
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
 			"requires": {
 				"rx-lite": "*"
+			}
+		},
+		"rxjs": {
+			"version": "5.5.10",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+			"integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+			"requires": {
+				"symbol-observable": "1.0.1"
 			}
 		},
 		"safe-buffer": {
@@ -6855,9 +6865,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-			"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -6878,9 +6888,9 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"sparkles": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
 			"dev": true
 		},
 		"spawn-sync": {
@@ -7060,6 +7070,11 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 		},
+		"symbol-observable": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+		},
 		"table-layout": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
@@ -7096,15 +7111,15 @@
 			}
 		},
 		"tar-stream": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.0.tgz",
-			"integrity": "sha512-lh2iAPG/BHNmN6WB9Ybdynk9rEJ5GD/dy4zscHmVlwa1dq2tpE+BH78i5vjYwYVWEaOXGBjzxr89aVACF17Cpw==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+			"integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
 			"requires": {
 				"bl": "^1.0.0",
 				"buffer-alloc": "^1.1.0",
 				"end-of-stream": "^1.0.0",
 				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.0.0",
+				"readable-stream": "^2.3.0",
 				"to-buffer": "^1.1.0",
 				"xtend": "^4.0.0"
 			}
@@ -7309,9 +7324,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -7378,9 +7393,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
@@ -8375,41 +8390,21 @@
 						"locate-path": "^2.0.0"
 					}
 				},
-				"globby": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-						}
-					}
-				},
 				"inquirer": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 					"requires": {
 						"ansi-escapes": "^3.0.0",
 						"chalk": "^2.0.0",
 						"cli-cursor": "^2.1.0",
 						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.4",
+						"external-editor": "^2.1.0",
 						"figures": "^2.0.0",
 						"lodash": "^4.3.0",
 						"mute-stream": "0.0.7",
 						"run-async": "^2.2.0",
-						"rx-lite": "^4.0.8",
-						"rx-lite-aggregates": "^4.0.8",
+						"rxjs": "^5.5.2",
 						"string-width": "^2.1.0",
 						"strip-ansi": "^4.0.0",
 						"through": "^2.3.6"
@@ -8546,21 +8541,23 @@
 					"integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
 				},
 				"yeoman-environment": {
-					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
-					"integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.1.1.tgz",
+					"integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
 					"requires": {
 						"chalk": "^2.1.0",
+						"cross-spawn": "^6.0.5",
 						"debug": "^3.1.0",
 						"diff": "^3.3.1",
 						"escape-string-regexp": "^1.0.2",
-						"globby": "^6.1.0",
+						"globby": "^8.0.1",
 						"grouped-queue": "^0.3.3",
-						"inquirer": "^3.3.0",
+						"inquirer": "^5.2.0",
 						"is-scoped": "^1.0.0",
-						"lodash": "^4.17.4",
+						"lodash": "^4.17.10",
 						"log-symbols": "^2.1.0",
 						"mem-fs": "^1.1.0",
+						"strip-ansi": "^4.0.0",
 						"text-table": "^0.2.0",
 						"untildify": "^3.0.2"
 					}
@@ -8666,19 +8663,6 @@
 					"dev": true,
 					"requires": {
 						"samsam": "1.x"
-					}
-				},
-				"globby": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-					"dev": true,
-					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"inquirer": {
@@ -8821,24 +8805,49 @@
 					"dev": true
 				},
 				"yeoman-environment": {
-					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
-					"integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.1.1.tgz",
+					"integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.1.0",
+						"cross-spawn": "^6.0.5",
 						"debug": "^3.1.0",
 						"diff": "^3.3.1",
 						"escape-string-regexp": "^1.0.2",
-						"globby": "^6.1.0",
+						"globby": "^8.0.1",
 						"grouped-queue": "^0.3.3",
-						"inquirer": "^3.3.0",
+						"inquirer": "^5.2.0",
 						"is-scoped": "^1.0.0",
-						"lodash": "^4.17.4",
+						"lodash": "^4.17.10",
 						"log-symbols": "^2.1.0",
 						"mem-fs": "^1.1.0",
+						"strip-ansi": "^4.0.0",
 						"text-table": "^0.2.0",
 						"untildify": "^3.0.2"
+					},
+					"dependencies": {
+						"inquirer": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+							"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+							"dev": true,
+							"requires": {
+								"ansi-escapes": "^3.0.0",
+								"chalk": "^2.0.0",
+								"cli-cursor": "^2.1.0",
+								"cli-width": "^2.0.0",
+								"external-editor": "^2.1.0",
+								"figures": "^2.0.0",
+								"lodash": "^4.3.0",
+								"mute-stream": "0.0.7",
+								"run-async": "^2.2.0",
+								"rxjs": "^5.5.2",
+								"string-width": "^2.1.0",
+								"strip-ansi": "^4.0.0",
+								"through": "^2.3.6"
+							}
+						}
 					}
 				}
 			}

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -10,9 +10,9 @@
 			"integrity": "sha512-mQjDxyOM1Cpocd+vm1kZBP7smwKZ4TNokFeds9LV7OZibmPJFEzY3+xZMrKfUdNT71lv8GoCPD6upKwHxubClw=="
 		},
 		"@types/node": {
-			"version": "9.6.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.15.tgz",
-			"integrity": "sha512-16zIiQkIZBc1ZpfrOZZZ/6LKDixPiAIZq5q1YE1stxG4Ic1VmQlkNNWGBydqBFcX8eS+m/Dd4z5HzDa+q0b2Xg=="
+			"version": "9.6.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.16.tgz",
+			"integrity": "sha512-fwUW7S8gaSVNpPa1XUdzI0URY71xqXsc90S9vKr2uFIUpVCKV+8ysnN9vvAFK8np4H03A7QGRkHpQvgah0964Q=="
 		},
 		"acorn": {
 			"version": "5.5.3",
@@ -3942,9 +3942,9 @@
 			"dev": true
 		},
 		"sparkles": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
 		},
 		"spdx-correct": {
 			"version": "3.0.0",
@@ -4266,9 +4266,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -4329,9 +4329,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/editor-service/package-lock.json
+++ b/packages/editor-service/package-lock.json
@@ -39,9 +39,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "9.6.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.15.tgz",
-			"integrity": "sha512-16zIiQkIZBc1ZpfrOZZZ/6LKDixPiAIZq5q1YE1stxG4Ic1VmQlkNNWGBydqBFcX8eS+m/Dd4z5HzDa+q0b2Xg=="
+			"version": "9.6.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.16.tgz",
+			"integrity": "sha512-fwUW7S8gaSVNpPa1XUdzI0URY71xqXsc90S9vKr2uFIUpVCKV+8ysnN9vvAFK8np4H03A7QGRkHpQvgah0964Q=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -820,17 +820,17 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "8.10.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.14.tgz",
-					"integrity": "sha512-TKQqQIaYNO+8MrOsFgobkt3fbMzkfXhBFKcg20Nip5Omptw1HOY/IEvYiFtMwIbr7Me/Y2H/JO+TgNUMJ9NGjA==",
+					"version": "8.10.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
+					"integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
 					"dev": true
 				}
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -862,9 +862,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/esm-amd-loader/package-lock.json
+++ b/packages/esm-amd-loader/package-lock.json
@@ -231,15 +231,15 @@
 			}
 		},
 		"babel-helper-evaluate-path": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.4.1.tgz",
-			"integrity": "sha1-a3XB4OMPFmKfKoZFyjBeGo01iaY=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.4.3.tgz",
+			"integrity": "sha1-ComvcCwGshcCf6NxkI3UmJ0+Yz8=",
 			"dev": true
 		},
 		"babel-helper-flip-expressions": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.1.tgz",
-			"integrity": "sha1-zAPYBFjBA7n1BcHGpn++D1nKwyA=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+			"integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0=",
 			"dev": true
 		},
 		"babel-helper-is-nodes-equiv": {
@@ -249,37 +249,37 @@
 			"dev": true
 		},
 		"babel-helper-is-void-0": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.1.tgz",
-			"integrity": "sha1-ogu127ocMMSq/nPrMn0tGLKE7Ro=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+			"integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4=",
 			"dev": true
 		},
 		"babel-helper-mark-eval-scopes": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.1.tgz",
-			"integrity": "sha1-A/nMmN76R0fnQS5wD069D+1ktXE=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+			"integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI=",
 			"dev": true
 		},
 		"babel-helper-remove-or-void": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.1.tgz",
-			"integrity": "sha1-rdWwiBeFOVESpw8PHCWRebFSQmo=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+			"integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=",
 			"dev": true
 		},
 		"babel-helper-to-multiple-sequence-expressions": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.4.1.tgz",
-			"integrity": "sha1-FU7MOBGPXBybDp/CNd21OSFJvI8=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.4.3.tgz",
+			"integrity": "sha1-W1GLESf0ezA4dzOGoVYaK0jmMrY=",
 			"dev": true
 		},
 		"babel-minify": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-minify/-/babel-minify-0.4.1.tgz",
-			"integrity": "sha1-9+QHlrtavnPmbMl0Ipw3ZhP+Xsc=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-minify/-/babel-minify-0.4.3.tgz",
+			"integrity": "sha1-2Ufk7WtibcjCVofyQsJcvPbygaY=",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.0.0-beta.46",
-				"babel-preset-minify": "^0.4.1",
+				"babel-preset-minify": "^0.4.3",
 				"fs-readdir-recursive": "^1.1.0",
 				"mkdirp": "^0.5.1",
 				"util.promisify": "^1.0.0",
@@ -287,200 +287,200 @@
 			}
 		},
 		"babel-plugin-minify-builtins": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.4.1.tgz",
-			"integrity": "sha1-d6iMt2EO2SWxsCVKmQJAKR4LC+A=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.4.3.tgz",
+			"integrity": "sha1-nqPVn0rEp7uVjXEtKVVqH4b3+B4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-evaluate-path": "^0.4.1"
+				"babel-helper-evaluate-path": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-constant-folding": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.4.1.tgz",
-			"integrity": "sha1-LtT4Ow/yj01VU9CcXvyFtdti0RI=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.4.3.tgz",
+			"integrity": "sha1-MA+d6N2ghEoXaxk2U5YOJK0z4ZE=",
 			"dev": true,
 			"requires": {
-				"babel-helper-evaluate-path": "^0.4.1"
+				"babel-helper-evaluate-path": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-dead-code-elimination": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.4.1.tgz",
-			"integrity": "sha1-81/PNIk06wqslEUCrTA3KRgu6yE=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.4.3.tgz",
+			"integrity": "sha1-c2KCZYZPkAjQAnUG9Yq+s8HQLZg=",
 			"dev": true,
 			"requires": {
-				"babel-helper-evaluate-path": "^0.4.1",
-				"babel-helper-mark-eval-scopes": "^0.4.1",
-				"babel-helper-remove-or-void": "^0.4.1",
+				"babel-helper-evaluate-path": "^0.4.3",
+				"babel-helper-mark-eval-scopes": "^0.4.3",
+				"babel-helper-remove-or-void": "^0.4.3",
 				"lodash.some": "^4.6.0"
 			}
 		},
 		"babel-plugin-minify-flip-comparisons": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.1.tgz",
-			"integrity": "sha1-5wfl2rxpXJnNKSP+lw7ZrHjE5ws=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+			"integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
 			"dev": true,
 			"requires": {
-				"babel-helper-is-void-0": "^0.4.1"
+				"babel-helper-is-void-0": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-guarded-expressions": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.1.tgz",
-			"integrity": "sha1-ylpZoGvBwi3Vz9mWpnUWOm9hm30=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.3.tgz",
+			"integrity": "sha1-zHCbRFP9IbHzAod0RMifiEJ845c=",
 			"dev": true,
 			"requires": {
-				"babel-helper-flip-expressions": "^0.4.1"
+				"babel-helper-flip-expressions": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-infinity": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.1.tgz",
-			"integrity": "sha1-zJw33MFmbcB/HrR4wrchoRz7lJE=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+			"integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco=",
 			"dev": true
 		},
 		"babel-plugin-minify-mangle-names": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.4.1.tgz",
-			"integrity": "sha1-d76P7TUOkxo6qaCfl/KCYWgIMTM=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.4.3.tgz",
+			"integrity": "sha1-FvG/90t6fJPfwkHngx3V+0sCPvc=",
 			"dev": true,
 			"requires": {
-				"babel-helper-mark-eval-scopes": "^0.4.1"
+				"babel-helper-mark-eval-scopes": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-numeric-literals": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.1.tgz",
-			"integrity": "sha1-lktObMdIfG1KMalRl8P0IbYMmkc=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+			"integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw=",
 			"dev": true
 		},
 		"babel-plugin-minify-replace": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.4.1.tgz",
-			"integrity": "sha1-xRnYhYxiKySWo2SmE1rSd1V42UM=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.4.3.tgz",
+			"integrity": "sha1-nSifS6FdTmAR6HmfpfG6d+yBIZ0=",
 			"dev": true
 		},
 		"babel-plugin-minify-simplify": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.4.1.tgz",
-			"integrity": "sha1-XlX0ibLV8CyQjCswm/CBTxXHV74=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.4.3.tgz",
+			"integrity": "sha1-N3VthcYURktLCSfytOQXGR1Vc4o=",
 			"dev": true,
 			"requires": {
-				"babel-helper-flip-expressions": "^0.4.1",
+				"babel-helper-flip-expressions": "^0.4.3",
 				"babel-helper-is-nodes-equiv": "^0.0.1",
-				"babel-helper-to-multiple-sequence-expressions": "^0.4.1"
+				"babel-helper-to-multiple-sequence-expressions": "^0.4.3"
 			}
 		},
 		"babel-plugin-minify-type-constructors": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.1.tgz",
-			"integrity": "sha1-eSJNE0bDPk+kQnVqI0JkkVjvlEg=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+			"integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
 			"dev": true,
 			"requires": {
-				"babel-helper-is-void-0": "^0.4.1"
+				"babel-helper-is-void-0": "^0.4.3"
 			}
 		},
 		"babel-plugin-transform-inline-consecutive-adds": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.1.tgz",
-			"integrity": "sha1-F13t/odsL/enjHUe1NncBZfRFx0=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+			"integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE=",
 			"dev": true
 		},
 		"babel-plugin-transform-member-expression-literals": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.2.tgz",
-			"integrity": "sha1-Hzl6uWGlw6QB8qdHrwbnIASvy3Y=",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
+			"integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
 			"dev": true
 		},
 		"babel-plugin-transform-merge-sibling-variables": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.2.tgz",
-			"integrity": "sha1-mUqQBKecefDJHEluii28fptz97Q=",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
+			"integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
 			"dev": true
 		},
 		"babel-plugin-transform-minify-booleans": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.2.tgz",
-			"integrity": "sha1-z5lb4GegMDy1JlSfA9zZaCQZQw0=",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
+			"integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
 			"dev": true
 		},
 		"babel-plugin-transform-property-literals": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.2.tgz",
-			"integrity": "sha1-pY0Jls8q2vIk986EitHN5M2M8nU=",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
+			"integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2"
 			}
 		},
 		"babel-plugin-transform-regexp-constructors": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.1.tgz",
-			"integrity": "sha1-T/fx2g4MMZENDhRhq+0MZ5yzHu4=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+			"integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU=",
 			"dev": true
 		},
 		"babel-plugin-transform-remove-console": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.2.tgz",
-			"integrity": "sha1-6KDCfVbJUDyhbihPa2Tb1LldIek=",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+			"integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
 			"dev": true
 		},
 		"babel-plugin-transform-remove-debugger": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.2.tgz",
-			"integrity": "sha1-U2yHvbYgDRRgyZbdldF5zzjCTuE=",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
+			"integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
 			"dev": true
 		},
 		"babel-plugin-transform-remove-undefined": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.4.1.tgz",
-			"integrity": "sha1-Y2x/KM66/Fpm+jT5TGCAR+r3508=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.4.3.tgz",
+			"integrity": "sha1-1AsNp/kcCMBsxyt2dHTAHEiU3gI=",
 			"dev": true,
 			"requires": {
-				"babel-helper-evaluate-path": "^0.4.1"
+				"babel-helper-evaluate-path": "^0.4.3"
 			}
 		},
 		"babel-plugin-transform-simplify-comparison-operators": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.2.tgz",
-			"integrity": "sha1-DA6a+nMpJPA6qYL9Y8ktBAi9VlY=",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
+			"integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
 			"dev": true
 		},
 		"babel-plugin-transform-undefined-to-void": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.2.tgz",
-			"integrity": "sha1-Fl/eczkydr6gKnOWWIeNzO0Lnrs=",
+			"version": "6.9.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
+			"integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
 			"dev": true
 		},
 		"babel-preset-minify": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.1.tgz",
-			"integrity": "sha1-QOPtrXQ7sQfdY8fPshxgTczYNnQ=",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.3.tgz",
+			"integrity": "sha1-spw91pGJBThFmPCSuVUVLiah/g8=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-minify-builtins": "^0.4.1",
-				"babel-plugin-minify-constant-folding": "^0.4.1",
-				"babel-plugin-minify-dead-code-elimination": "^0.4.1",
-				"babel-plugin-minify-flip-comparisons": "^0.4.1",
-				"babel-plugin-minify-guarded-expressions": "^0.4.1",
-				"babel-plugin-minify-infinity": "^0.4.1",
-				"babel-plugin-minify-mangle-names": "^0.4.1",
-				"babel-plugin-minify-numeric-literals": "^0.4.1",
-				"babel-plugin-minify-replace": "^0.4.1",
-				"babel-plugin-minify-simplify": "^0.4.1",
-				"babel-plugin-minify-type-constructors": "^0.4.1",
-				"babel-plugin-transform-inline-consecutive-adds": "^0.4.1",
-				"babel-plugin-transform-member-expression-literals": "^6.9.2",
-				"babel-plugin-transform-merge-sibling-variables": "^6.9.2",
-				"babel-plugin-transform-minify-booleans": "^6.9.2",
-				"babel-plugin-transform-property-literals": "^6.9.2",
-				"babel-plugin-transform-regexp-constructors": "^0.4.1",
-				"babel-plugin-transform-remove-console": "^6.9.2",
-				"babel-plugin-transform-remove-debugger": "^6.9.2",
-				"babel-plugin-transform-remove-undefined": "^0.4.1",
-				"babel-plugin-transform-simplify-comparison-operators": "^6.9.2",
-				"babel-plugin-transform-undefined-to-void": "^6.9.2",
+				"babel-plugin-minify-builtins": "^0.4.3",
+				"babel-plugin-minify-constant-folding": "^0.4.3",
+				"babel-plugin-minify-dead-code-elimination": "^0.4.3",
+				"babel-plugin-minify-flip-comparisons": "^0.4.3",
+				"babel-plugin-minify-guarded-expressions": "^0.4.3",
+				"babel-plugin-minify-infinity": "^0.4.3",
+				"babel-plugin-minify-mangle-names": "^0.4.3",
+				"babel-plugin-minify-numeric-literals": "^0.4.3",
+				"babel-plugin-minify-replace": "^0.4.3",
+				"babel-plugin-minify-simplify": "^0.4.3",
+				"babel-plugin-minify-type-constructors": "^0.4.3",
+				"babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+				"babel-plugin-transform-member-expression-literals": "^6.9.4",
+				"babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+				"babel-plugin-transform-minify-booleans": "^6.9.4",
+				"babel-plugin-transform-property-literals": "^6.9.4",
+				"babel-plugin-transform-regexp-constructors": "^0.4.3",
+				"babel-plugin-transform-remove-console": "^6.9.4",
+				"babel-plugin-transform-remove-debugger": "^6.9.4",
+				"babel-plugin-transform-remove-undefined": "^0.4.3",
+				"babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+				"babel-plugin-transform-undefined-to-void": "^6.9.4",
 				"lodash.isplainobject": "^4.0.6"
 			}
 		},
@@ -1234,9 +1234,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -1260,9 +1260,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/esm-amd-loader/test/package-lock.json
+++ b/packages/esm-amd-loader/test/package-lock.json
@@ -318,9 +318,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -344,9 +344,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/linter/package-lock.json
+++ b/packages/linter/package-lock.json
@@ -43,9 +43,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "8.10.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.14.tgz",
-			"integrity": "sha512-TKQqQIaYNO+8MrOsFgobkt3fbMzkfXhBFKcg20Nip5Omptw1HOY/IEvYiFtMwIbr7Me/Y2H/JO+TgNUMJ9NGjA==",
+			"version": "8.10.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
+			"integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
 			"dev": true
 		},
 		"@types/parse5": {
@@ -57,9 +57,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "6.0.110",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-					"integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+					"version": "10.0.9",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+					"integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ=="
 				}
 			}
 		},
@@ -1042,9 +1042,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -1111,9 +1111,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/polyserve/package-lock.json
+++ b/packages/polyserve/package-lock.json
@@ -111,9 +111,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "9.6.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.15.tgz",
-			"integrity": "sha512-16zIiQkIZBc1ZpfrOZZZ/6LKDixPiAIZq5q1YE1stxG4Ic1VmQlkNNWGBydqBFcX8eS+m/Dd4z5HzDa+q0b2Xg=="
+			"version": "9.6.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.16.tgz",
+			"integrity": "sha512-fwUW7S8gaSVNpPa1XUdzI0URY71xqXsc90S9vKr2uFIUpVCKV+8ysnN9vvAFK8np4H03A7QGRkHpQvgah0964Q=="
 		},
 		"@types/opn": {
 			"version": "3.0.28",
@@ -806,11 +806,11 @@
 			}
 		},
 		"feature-detect-es6": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
-			"integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.1.tgz",
+			"integrity": "sha512-iMxKpKdIBgcWiBPtz2qnEsNjCE2dBQvDyUqgrXLJboiaHwJa+2vDIZ8XbgNZGh1Rx1PUfZmI7uhG6Z4iQYWVjg==",
 			"requires": {
-				"array-back": "^1.0.3"
+				"array-back": "^1.0.4"
 			}
 		},
 		"filename-regex": {
@@ -2151,17 +2151,17 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "8.10.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.14.tgz",
-					"integrity": "sha512-TKQqQIaYNO+8MrOsFgobkt3fbMzkfXhBFKcg20Nip5Omptw1HOY/IEvYiFtMwIbr7Me/Y2H/JO+TgNUMJ9NGjA==",
+					"version": "8.10.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
+					"integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
 					"dev": true
 				}
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -2193,9 +2193,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/project-config/package-lock.json
+++ b/packages/project-config/package-lock.json
@@ -17,9 +17,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "9.6.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.15.tgz",
-			"integrity": "sha512-16zIiQkIZBc1ZpfrOZZZ/6LKDixPiAIZq5q1YE1stxG4Ic1VmQlkNNWGBydqBFcX8eS+m/Dd4z5HzDa+q0b2Xg=="
+			"version": "9.6.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.16.tgz",
+			"integrity": "sha512-fwUW7S8gaSVNpPa1XUdzI0URY71xqXsc90S9vKr2uFIUpVCKV+8ysnN9vvAFK8np4H03A7QGRkHpQvgah0964Q=="
 		},
 		"@types/winston": {
 			"version": "2.3.9",
@@ -843,9 +843,9 @@
 			"dev": true
 		},
 		"source-map-support": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-			"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -934,9 +934,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -968,9 +968,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/packages/web-component-tester/package-lock.json
+++ b/packages/web-component-tester/package-lock.json
@@ -145,9 +145,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "8.10.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.14.tgz",
-			"integrity": "sha512-TKQqQIaYNO+8MrOsFgobkt3fbMzkfXhBFKcg20Nip5Omptw1HOY/IEvYiFtMwIbr7Me/Y2H/JO+TgNUMJ9NGjA==",
+			"version": "8.10.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
+			"integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
 			"dev": true
 		},
 		"@types/nomnom": {
@@ -278,9 +278,9 @@
 			"integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ="
 		},
 		"adm-zip": {
-			"version": "0.4.9",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.9.tgz",
-			"integrity": "sha512-eknaJ3Io/JasGGinVeqY5TsPlQgHbiNlHnK5zdFPRNs9XRggDykKz8zPesneOMEZJxWji7G3CfsUW0Ds9Dw0Bw==",
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+			"integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
 			"dev": true
 		},
 		"after": {
@@ -825,20 +825,20 @@
 			"integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
 		},
 		"body-parser": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
 			"requires": {
 				"bytes": "3.0.0",
 				"content-type": "~1.0.4",
 				"debug": "2.6.9",
-				"depd": "~1.1.1",
-				"http-errors": "~1.6.2",
-				"iconv-lite": "0.4.19",
+				"depd": "~1.1.2",
+				"http-errors": "~1.6.3",
+				"iconv-lite": "0.4.23",
 				"on-finished": "~2.3.0",
-				"qs": "6.5.1",
-				"raw-body": "2.3.2",
-				"type-is": "~1.6.15"
+				"qs": "6.5.2",
+				"raw-body": "2.3.3",
+				"type-is": "~1.6.16"
 			}
 		},
 		"boom": {
@@ -2110,6 +2110,67 @@
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
+				"body-parser": {
+					"version": "1.18.2",
+					"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+					"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+					"requires": {
+						"bytes": "3.0.0",
+						"content-type": "~1.0.4",
+						"debug": "2.6.9",
+						"depd": "~1.1.1",
+						"http-errors": "~1.6.2",
+						"iconv-lite": "0.4.19",
+						"on-finished": "~2.3.0",
+						"qs": "6.5.1",
+						"raw-body": "2.3.2",
+						"type-is": "~1.6.15"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.19",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+				},
+				"qs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+				},
+				"raw-body": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+					"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+					"requires": {
+						"bytes": "3.0.0",
+						"http-errors": "1.6.2",
+						"iconv-lite": "0.4.19",
+						"unpipe": "1.0.0"
+					},
+					"dependencies": {
+						"depd": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+							"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+						},
+						"http-errors": {
+							"version": "1.6.2",
+							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+							"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+							"requires": {
+								"depd": "1.1.1",
+								"inherits": "2.0.3",
+								"setprototypeof": "1.0.3",
+								"statuses": ">= 1.3.1 < 2"
+							}
+						},
+						"setprototypeof": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+							"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+						}
+					}
+				},
 				"send": {
 					"version": "0.16.2",
 					"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -3629,9 +3690,9 @@
 			}
 		},
 		"has-binary2": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
-			"integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+			"integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
 			"requires": {
 				"isarray": "2.0.1"
 			},
@@ -3770,9 +3831,12 @@
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
 		},
 		"import-lazy": {
 			"version": "2.1.0",
@@ -5516,9 +5580,9 @@
 			"integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
 		},
 		"qs": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
 		"randomatic": {
 			"version": "3.0.0",
@@ -5545,37 +5609,14 @@
 			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
 		},
 		"raw-body": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
 			"requires": {
 				"bytes": "3.0.0",
-				"http-errors": "1.6.2",
-				"iconv-lite": "0.4.19",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.23",
 				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-				},
-				"http-errors": {
-					"version": "1.6.2",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-					"requires": {
-						"depd": "1.1.1",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.0.3",
-						"statuses": ">= 1.3.1 < 2"
-					}
-				},
-				"setprototypeof": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
-				}
 			}
 		},
 		"rc": {
@@ -5897,6 +5938,11 @@
 			"requires": {
 				"ret": "~0.1.10"
 			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"samsam": {
 			"version": "1.3.0",
@@ -6626,9 +6672,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-			"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -6649,9 +6695,9 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"sparkles": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
 			"dev": true
 		},
 		"spdx-correct": {
@@ -6859,15 +6905,15 @@
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 		},
 		"tar-stream": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.0.tgz",
-			"integrity": "sha512-lh2iAPG/BHNmN6WB9Ybdynk9rEJ5GD/dy4zscHmVlwa1dq2tpE+BH78i5vjYwYVWEaOXGBjzxr89aVACF17Cpw==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+			"integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
 			"requires": {
 				"bl": "^1.0.0",
 				"buffer-alloc": "^1.1.0",
 				"end-of-stream": "^1.0.0",
 				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.0.0",
+				"readable-stream": "^2.3.0",
 				"to-buffer": "^1.1.0",
 				"xtend": "^4.0.0"
 			},
@@ -7084,9 +7130,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-			"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
 			"dev": true
 		},
 		"tslint": {
@@ -7153,9 +7199,9 @@
 			}
 		},
 		"tsutils": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-			"integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.0.tgz",
+			"integrity": "sha512-JcyX25oM9pFcb3zh60OqG1St8p/uSqC5Bgipdo3ieacB/Ao4dPhm7hAtKT9NrEu23CyYrrgJPV3CqYfo+/+T4w==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
@@ -7621,9 +7667,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "9.6.15",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.15.tgz",
-					"integrity": "sha512-16zIiQkIZBc1ZpfrOZZZ/6LKDixPiAIZq5q1YE1stxG4Ic1VmQlkNNWGBydqBFcX8eS+m/Dd4z5HzDa+q0b2Xg==",
+					"version": "9.6.16",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.16.tgz",
+					"integrity": "sha512-fwUW7S8gaSVNpPa1XUdzI0URY71xqXsc90S9vKr2uFIUpVCKV+8ysnN9vvAFK8np4H03A7QGRkHpQvgah0964Q==",
 					"dev": true
 				},
 				"ansi-styles": {


### PR DESCRIPTION
Latest version of this package `babel-plugin-minify-guarded-expressions` which is a dependency of `babel-preset-minify@0.4.0-alpha.caaefb4c` we have pinned will throw errors due to trying to get a parentPath from a path's parentPath in some cases where one does not exist and kills the entire optimize-streams.ts transform.