### PR TITLE
Release [cli] 1.7.2 and [build] 3.0.1

### DIFF
--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
+<!-- Add new, unreleased changes here. -->
+
+## [3.0.1] - 2018-05-14
 * Pin dependency babel-plugin-minify-guarded-expressions of
   babel-preset-minify to known working version 0.4.1.
-<!-- Add new, unreleased changes here. -->
 
 ## [3.0.0] - 2018-05-08
 * Updated dependencies.

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-build",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A library of Gulp build tasks",
   "homepage": "https://github.com/Polymer/tools/tree/master/packages/build",
   "repository": "github:Polymer/tools",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,7 +62,7 @@
     "mz": "^2.6.0",
     "plylog": "^0.5.0",
     "polymer-analyzer": "^3.0.1",
-    "polymer-build": "^3.0.0",
+    "polymer-build": "^3.0.1",
     "polymer-bundler": "^4.0.1",
     "polymer-linter": "^3.0.0",
     "polymer-project-config": "^4.0.1",


### PR DESCRIPTION
- [ ] polymer-build@3.0.1
  - pin dep for babel-preset-minify's minify-guarded-exceptions plugin because of errors)
- [ ] polymer-cli@1.7.2
  - Fix bug in polymer-3-element init template where polymer/dom-module.js
could be loaded twice when serving from the polyserve /components/
directory.
  - Fix names of uncompiled-bundled and uncompiled-unbundled build presets.