### PR TITLE
[wct-browser-legacy] Updated `@webcomponents/webcomponentsjs` dependency to ^2.0.0 from ^1.0.7

### DIFF
--- a/packages/web-component-tester/wct-browser-legacy/CHANGELOG.md
+++ b/packages/web-component-tester/wct-browser-legacy/CHANGELOG.md
@@ -8,5 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ## Unreleased -->
 <!-- Add new, unreleased items here. -->
 
+## 1.0.1 - 2018-05-17
+* Update package.json to use `@webcomponents/webcomponentsjs@^2.0.0`.
+
 ## 1.0.0 - 2018-05-08
 * Officially released.

--- a/packages/web-component-tester/wct-browser-legacy/package-lock.json
+++ b/packages/web-component-tester/wct-browser-legacy/package-lock.json
@@ -1,426 +1,426 @@
 {
-	"name": "wct-browser-legacy",
-	"version": "1.0.0",
-	"lockfileVersion": 1,
-	"requires": true,
-	"dependencies": {
-		"@polymer/polymer": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.0.2.tgz",
-			"integrity": "sha512-ow8AAjTe9ps8bantY9IvL0PT+xHf5VN3Cjahfr7gBJAc0lv3jTwGBv7pso65SHyrUJEEHeakhx6iPMl7qY4tfw==",
-			"requires": {
-				"@webcomponents/shadycss": "^1.2.0"
-			}
-		},
-		"@polymer/sinonjs": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
-			"integrity": "sha512-/U8F/cOTrbF2iVVYgINYmvKbtbexs+89Q3v8AaHADRYabTg7aOZGOb0RyWpOI+sUJt04kj63U4FwMhzW5r4wZA=="
-		},
-		"@polymer/test-fixture": {
-			"version": "3.0.0-pre.19",
-			"resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-3.0.0-pre.19.tgz",
-			"integrity": "sha512-oyltfPEEPF8gzLxSv/CjieO9n0Uani567pcpmAk3IZeOMsFh9OFddZDYCwKx1e9I6lFe9557MaxQHM7EGhLaOQ=="
-		},
-		"@webcomponents/shadycss": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.2.1.tgz",
-			"integrity": "sha512-ZnjFb1Wf81CqMgs1dbT6JT6N4nY32bs2r5YC/5GSIb/ozJGR+UYs3ldJxtk1v5uZzPRIsAWv7wYSJcCp6ml8+A=="
-		},
-		"@webcomponents/webcomponentsjs": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.2.0.tgz",
-			"integrity": "sha512-P9JWydfpBR+CK12UwtBaoD/lYF3PR9XBArAWk5J9nfPaJwA3OUox4StZmyFSVDLsvpFq5HsEtxU/OdHAlAWPnw=="
-		},
-		"accessibility-developer-tools": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
-			"integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ="
-		},
-		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-		},
-		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
-		},
-		"async": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-		},
-		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"browser-stdout": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
-		},
-		"chai": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-			"requires": {
-				"assertion-error": "^1.0.1",
-				"deep-eql": "^0.1.3",
-				"type-detect": "^1.0.0"
-			}
-		},
-		"chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
-		"commander": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-			"requires": {
-				"graceful-readlink": ">= 1.0.0"
-			}
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"debug": {
-			"version": "2.6.8",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-			"requires": {
-				"ms": "2.0.0"
-			}
-		},
-		"deep-eql": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-			"requires": {
-				"type-detect": "0.1.1"
-			},
-			"dependencies": {
-				"type-detect": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
-				}
-			}
-		},
-		"diff": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
-		"formatio": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-			"integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-			"requires": {
-				"samsam": "~1.1"
-			}
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.2",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"graceful-readlink": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-		},
-		"growl": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
-		},
-		"has-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-		},
-		"he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-		},
-		"json3": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
-		},
-		"lodash": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-			"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-		},
-		"lodash._baseassign": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-			"requires": {
-				"lodash._basecopy": "^3.0.0",
-				"lodash.keys": "^3.0.0"
-			}
-		},
-		"lodash._basecopy": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-		},
-		"lodash._basecreate": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-			"integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
-		},
-		"lodash._getnative": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-		},
-		"lodash._isiterateecall": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-		},
-		"lodash.create": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-			"requires": {
-				"lodash._baseassign": "^3.0.0",
-				"lodash._basecreate": "^3.0.0",
-				"lodash._isiterateecall": "^3.0.0"
-			}
-		},
-		"lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-		},
-		"lodash.isarray": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-		},
-		"lodash.keys": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"requires": {
-				"lodash._getnative": "^3.0.0",
-				"lodash.isarguments": "^3.0.0",
-				"lodash.isarray": "^3.0.0"
-			}
-		},
-		"lolex": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-			"integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE="
-		},
-		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-		},
-		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"requires": {
-				"minimist": "0.0.8"
-			}
-		},
-		"mocha": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-			"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
-			"requires": {
-				"browser-stdout": "1.3.0",
-				"commander": "2.9.0",
-				"debug": "2.6.8",
-				"diff": "3.2.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.1",
-				"growl": "1.9.2",
-				"he": "1.1.1",
-				"json3": "3.3.2",
-				"lodash.create": "3.1.1",
-				"mkdirp": "0.5.1",
-				"supports-color": "3.1.2"
-			}
-		},
-		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"samsam": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-			"integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
-		},
-		"sinon": {
-			"version": "1.17.7",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-			"integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-			"requires": {
-				"formatio": "1.1.1",
-				"lolex": "1.3.2",
-				"samsam": "1.1.2",
-				"util": ">=0.10.3 <1"
-			}
-		},
-		"sinon-chai": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
-		},
-		"stacky": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
-			"integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
-			"requires": {
-				"chalk": "^1.1.1",
-				"lodash": "^3.0.0"
-			}
-		},
-		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
-		},
-		"supports-color": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-			"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-			"requires": {
-				"has-flag": "^1.0.0"
-			}
-		},
-		"type-detect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
-		},
-		"util": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-			"requires": {
-				"inherits": "2.0.1"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-				}
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		}
-	}
+  "name": "wct-browser-legacy",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@polymer/polymer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.0.2.tgz",
+      "integrity": "sha512-ow8AAjTe9ps8bantY9IvL0PT+xHf5VN3Cjahfr7gBJAc0lv3jTwGBv7pso65SHyrUJEEHeakhx6iPMl7qY4tfw==",
+      "requires": {
+        "@webcomponents/shadycss": "^1.2.0"
+      }
+    },
+    "@polymer/sinonjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
+      "integrity": "sha512-/U8F/cOTrbF2iVVYgINYmvKbtbexs+89Q3v8AaHADRYabTg7aOZGOb0RyWpOI+sUJt04kj63U4FwMhzW5r4wZA=="
+    },
+    "@polymer/test-fixture": {
+      "version": "3.0.0-pre.19",
+      "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-3.0.0-pre.19.tgz",
+      "integrity": "sha512-oyltfPEEPF8gzLxSv/CjieO9n0Uani567pcpmAk3IZeOMsFh9OFddZDYCwKx1e9I6lFe9557MaxQHM7EGhLaOQ=="
+    },
+    "@webcomponents/shadycss": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.2.1.tgz",
+      "integrity": "sha512-ZnjFb1Wf81CqMgs1dbT6JT6N4nY32bs2r5YC/5GSIb/ozJGR+UYs3ldJxtk1v5uZzPRIsAWv7wYSJcCp6ml8+A=="
+    },
+    "@webcomponents/webcomponentsjs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.0.tgz",
+      "integrity": "sha512-f6izmesHd8E+rL32tftlXZmz1EAL+lLn8AUex0mJFLe39z53iTFNCqxAYsMmCA/QSGP+8X6D1it/JbuVl1jOHA=="
+    },
+    "accessibility-developer-tools": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+        }
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "requires": {
+        "samsam": "~1.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lolex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "samsam": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
+    },
+    "sinon": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": ">=0.10.3 <1"
+      }
+    },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
+    },
+    "stacky": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+      "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
+      "requires": {
+        "chalk": "^1.1.1",
+        "lodash": "^3.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "requires": {
+        "has-flag": "^1.0.0"
+      }
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
 }

--- a/packages/web-component-tester/wct-browser-legacy/package.json
+++ b/packages/web-component-tester/wct-browser-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wct-browser-legacy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Client-side dependencies for web-component-tester tests installed via npm.",
   "main": "browser.js",
   "license": "http://polymer.github.io/LICENSE.txt",
@@ -25,10 +25,10 @@
   },
   "homepage": "https://github.com/polymer/web-component-tester#readme",
   "dependencies": {
-    "@polymer/polymer": "^3.0.0-pre.1",
+    "@polymer/polymer": "^3.0.0",
     "@polymer/sinonjs": "^1.14.1",
     "@polymer/test-fixture": "^3.0.0-pre.1",
-    "@webcomponents/webcomponentsjs": "^1.0.7",
+    "@webcomponents/webcomponentsjs": "^2.0.0",
     "accessibility-developer-tools": "^2.12.0",
     "async": "^1.5.2",
     "chai": "^3.5.0",


### PR DESCRIPTION
**This is a RELEASE PR for wct-browser-legacy 1.0.1**

Addressing an oversight that it should have been released with `@webcomponents/webcomponentsjs` v2 already.

