### PR TITLE
Remove unused callback argument to wct.cli.run and wct.cli.startSauceTunnel

### DIFF
--- a/packages/web-component-tester/bin/wct
+++ b/packages/web-component-tester/bin/wct
@@ -14,9 +14,7 @@ process.title = 'wct';
 
 resolve('web-component-tester', {basedir: process.cwd()}, function(error, path) {
   var wct = path ? require(path) : require('..');
-  var promise = wct.cli.run(process.env, process.argv.slice(2), process.stdout, function (error) {
-    process.exit(error ? 1 : 0);
-  });
+  var promise = wct.cli.run(process.env, process.argv.slice(2), process.stdout);
   if (promise) {
     promise.then(() => process.exit(0), () => process.exit(1));
   }

--- a/packages/web-component-tester/bin/wct-st
+++ b/packages/web-component-tester/bin/wct-st
@@ -14,10 +14,5 @@ process.title = 'wct-st';
 
 resolve('web-component-tester', {basedir: process.cwd()}, function(error, path) {
   var wct = path ? require(path) : require('..');
-  var promise = wct.cli.runSauceTunnel(process.env, process.argv.slice(2), process.stdout, function (error) {
-    process.exit(error ? 1 : 0);
-  });
-  if (promise) {
-    promise.then(() => process.exit(0), () => process.exit(1));
-  }
+  wct.cli.runSauceTunnel(process.env, process.argv.slice(2), process.stdout);
 });

--- a/packages/web-component-tester/runner/cli.ts
+++ b/packages/web-component-tester/runner/cli.ts
@@ -110,6 +110,7 @@ async function _runSauceTunnel(args: string[], output: NodeJS.WritableStream) {
       'To use this tunnel for other WCT runs, export the following:\n');
   output.write('\n');
   output.write(chalk.cyan('export SAUCE_TUNNEL_ID=' + tunnelId) + '\n');
+  output.write('Press CTRL+C to close the sauce tunnel\n');
 }
 
 async function wrapResult(


### PR DESCRIPTION
Also remove promise in wct-st, as the promise resolves immediately on
sauce tunnel creation, killing the new sauce tunnel

Fixes #438