### PR TITLE
Don't try to run Sauce from forked/community PRs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,4 +54,8 @@ matrix:
       sauce_connect: true
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
-    - WCT_SAUCE=true
+    # We can't run Sauce without credentials. PRs from forks don't get secure
+    # environment variables. Only run Sauce if we have those vars. Note this
+    # means that community PRs never run on Sauce, even when the builds show
+    # all green.
+    - WCT_SAUCE=$TRAVIS_SECURE_ENV_VARS

--- a/packages/esm-amd-loader/test/run-wct.sh
+++ b/packages/esm-amd-loader/test/run-wct.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -n "$WCT_SAUCE" ]; then
+if [ "$WCT_SAUCE" = "true" ]; then
   npx wct --plugin local --plugin sauce
 else
   npx wct --plugin local

--- a/packages/web-component-tester/test/integration/browser.ts
+++ b/packages/web-component-tester/test/integration/browser.ts
@@ -49,7 +49,7 @@ function loadOptionsFile(dir: string): config.Config {
 
 const testLocalBrowsers = !process.env.SKIP_LOCAL_BROWSERS;
 const testLocalBrowsersList = parseList(process.env.TEST_LOCAL_BROWSERS);
-const testRemoteBrowsers = process.env.WCT_SAUCE;
+const testRemoteBrowsers = process.env.WCT_SAUCE === 'true';
 if (testRemoteBrowsers &&
     !(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY)) {
   throw new Error(


### PR DESCRIPTION
We can't because secure environment variables aren't available. This was already happening before https://github.com/Polymer/tools/pull/441 but in a slightly different way. Without this change, community PRs will always fail on Travis.