### PR TITLE
fix link in README

### DIFF
--- a/packages/web-component-tester/README.md
+++ b/packages/web-component-tester/README.md
@@ -326,7 +326,7 @@ Alternatively, you can specify these options via the `clientOptions`
 key in `wct.conf.json`.
 
 A reference of the default configuration can be found at
-[browser/config.js](browser/config.js).
+[browser/config.ts](browser/config.ts).
 
 
 ## Gulp


### PR DESCRIPTION
### Summary
Fixes a link to _browser/config.ts_ in **web-component-tester** _README_

resolves issue: ???  (I thought I made an issue but I don't see it anymore?)