### PR TITLE
Remove moduleScriptIdx option from JsTransformOptions.

### DIFF
--- a/packages/build/src/html-transform.ts
+++ b/packages/build/src/html-transform.ts
@@ -98,7 +98,6 @@ export function htmlTransform(
       !allScripts.some((node) => dom5.hasAttribute(node, 'nomodule'));
 
   let wctScript, firstModuleScript;
-  let moduleScriptIdx = 0;
 
   for (const script of allScripts) {
     const isModule = dom5.getAttribute(script, 'type') === 'module';
@@ -107,7 +106,7 @@ export function htmlTransform(
         firstModuleScript = script;
       }
       if (shouldTransformEsModuleToAmd) {
-        transformEsModuleToAmd(script, moduleScriptIdx++, options.js);
+        transformEsModuleToAmd(script, options.js);
         continue;  // Bypass the standard jsTransform below.
       }
     }
@@ -204,7 +203,7 @@ export function htmlTransform(
 }
 
 function transformEsModuleToAmd(
-    script: dom5.Node, idx: number, jsOptions: JsTransformOptions|undefined) {
+    script: dom5.Node, jsOptions: JsTransformOptions|undefined) {
   // We're not a module anymore.
   dom5.removeAttribute(script, 'type');
 
@@ -225,7 +224,6 @@ function transformEsModuleToAmd(
     const newJs = jsTransform(dom5.getTextContent(script), {
       ...jsOptions,
       transformModulesToAmd: true,
-      moduleScriptIdx: idx,
     });
     dom5.setTextContent(script, newJs);
   }

--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -159,13 +159,6 @@ export interface JsTransformOptions {
   // transform if the script contains any ES module import/export syntax.
   transformModulesToAmd?: boolean|'auto';
 
-  // If transformModulesToAmd is true, setting this option will update the
-  // generated AMD module to be 1) defined with an auto-generated name (instead
-  // of with no name), and 2) if > 0, to depend on the previously auto-generated
-  // module. This can be used to generate a dependency chain between module
-  // scripts.
-  moduleScriptIdx?: number;
-
   // If true, parsing of invalid JavaScript will not throw an exception.
   // Instead, a console error will be logged, and the original JavaScript will
   // be returned with no changes. Use with caution!

--- a/packages/build/src/optimize-streams.ts
+++ b/packages/build/src/optimize-streams.ts
@@ -137,14 +137,12 @@ export class JsTransform extends GenericOptimizeTransform {
 
     const transformer = (content: string, file: File) => {
       let transformModulesToAmd: boolean|'auto' = false;
-      let moduleScriptIdx;
 
       if (jsOptions.transformModulesToAmd) {
         if (isHtmlSplitterFile(file)) {
           // This is a type=module script in an HTML file. Definitely AMD
           // transform.
           transformModulesToAmd = file.isModule === true;
-          moduleScriptIdx = file.moduleScriptIdx;
         } else {
           // This is an external script file. Only AMD transform it if it looks
           // like a module.
@@ -160,7 +158,6 @@ export class JsTransform extends GenericOptimizeTransform {
         filePath: file.path,
         rootDir: options.rootDir,
         transformModulesToAmd,
-        moduleScriptIdx,
       });
     };
 


### PR DESCRIPTION
This option is no longer used because we order dependencies at runtime using our AMD loader instead.