### PR TITLE
Add bower_components to list of module directories

### DIFF
--- a/packages/analyzer/src/javascript/resolve-specifier-node.ts
+++ b/packages/analyzer/src/javascript/resolve-specifier-node.ts
@@ -48,6 +48,7 @@ export const resolve =
 
       const dependencyFilepath = nodeResolve.sync(specifier, {
         basedir: dirname(importerFilepath),
+        moduleDirectory: ['bower_components', 'node_modules'],
 
         // It's invalid to load a .json or .node file as a module on the web,
         // but this is what Node's resolution algorithm does

--- a/packages/analyzer/src/test/javascript/resolve-specifier-node_test.ts
+++ b/packages/analyzer/src/test/javascript/resolve-specifier-node_test.ts
@@ -61,6 +61,12 @@ suite('resolve', () => {
         './node_modules/@scope/scoped/scoped.js');
   });
 
+  test('non-component bower dependency', async () => {
+    assert.equal(
+        resolve('bower_dep', rootMain),
+        './bower_components/bower_dep/bower_dep.js');
+  });
+
   test('shallow dep to scoped dep', async () => {
     assert.equal(
         resolve('@scope/scoped', shallowDepMain, shallowRootComponentInfo),

--- a/packages/analyzer/src/test/static/javascript/resolve-specifier-node/bower_components/bower_dep/package.json
+++ b/packages/analyzer/src/test/static/javascript/resolve-specifier-node/bower_components/bower_dep/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "bower_dep",
+  "version": "1.0.0",
+  "main": "bower_dep.js"
+}


### PR DESCRIPTION
The resolve module only resolves modules from the node_modules directory. Adding bower_components to it let's us use modules with bower, and matches the behavior of tools like Typescript.

Fixes https://github.com/Polymer/tools/issues/521