### PR TITLE
[WCT] Corrected environment scripts handling

### DIFF
--- a/packages/web-component-tester/runner/webserver.ts
+++ b/packages/web-component-tester/runner/webserver.ts
@@ -95,14 +95,12 @@ export function webserver(wct: Context): void {
       const packageName = getPackageName(options);
       const isPackageScoped = packageName && packageName[0] === '@';
 
-      // concat options.clientOptions.environmentScripts with resolved
+      // Use options.clientOptions.environmentScripts or resolved
       // ENVIRONMENT_SCRIPTS
       options.clientOptions = options.clientOptions || {};
       options.clientOptions.environmentScripts =
-          options.clientOptions.environmentScripts || [];
-      options.clientOptions.environmentScripts =
-          options.clientOptions.environmentScripts.concat(
-              resolveWctNpmEntrypointNames(options, ENVIRONMENT_SCRIPTS));
+        options.clientOptions.environmentScripts ||
+        resolveWctNpmEntrypointNames(options, ENVIRONMENT_SCRIPTS);
 
       if (isPackageScoped) {
         browserScript = `../${browserScript}`;


### PR DESCRIPTION
Fixes [#525](https://github.com/Polymer/tools/issues/525)

Default scripts are not concatened anymore, they are just used if no other scripts are specified.