### PR TITLE
Fix audit warnings in build

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -773,6 +773,35 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@polymer/esm-amd-loader": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.1.tgz",
+			"integrity": "sha512-yqa8Go1CJ07sTdjYXzl4cBa9W4MoTdwF1We94P/nENWCCVWMItWQmUKmKEpQBJOYWd6DZSgEOdVEXa4HS2QAkA=="
+		},
+		"@types/acorn": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.3.tgz",
+			"integrity": "sha512-gou/kWQkGPMZjdCKNZGDpqxLm9+ErG/pFZKPX4tvCjr0Xf4FCYYX3nAsu7aDVKJV3KUe27+mvqqyWT/9VZoM/A==",
+			"requires": {
+				"@types/estree": "*"
+			}
+		},
+		"@types/babel-generator": {
+			"version": "6.25.2",
+			"resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.2.tgz",
+			"integrity": "sha512-W7PQkeDlYOqJblfNeqZARwj4W8nO+ZhQQZksU8+wbaKuHeUdIVUAdREO/Qb0FfNr3CY5Sq1gNtqsyFeZfS3iSw==",
+			"requires": {
+				"@types/babel-types": "*"
+			}
+		},
+		"@types/babel-traverse": {
+			"version": "6.25.4",
+			"resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.4.tgz",
+			"integrity": "sha512-+/670NaZE7qPvdh8EtGds32/2uHFKE5JeS+7ePH6nGwF8Wj8r671/RkTiJQP2k22nFntWEb9xQ11MFj7xEqI0g==",
+			"requires": {
+				"@types/babel-types": "*"
+			}
+		},
 		"@types/babel-types": {
 			"version": "6.25.2",
 			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
@@ -789,13 +818,45 @@
 		"@types/chai": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
-			"integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
-			"dev": true
+			"integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4="
+		},
+		"@types/chai-subset": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
+			"integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
+			"requires": {
+				"@types/chai": "*"
+			}
+		},
+		"@types/chalk": {
+			"version": "0.4.31",
+			"resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
+			"integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk="
 		},
 		"@types/clean-css": {
 			"version": "3.4.30",
 			"resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-3.4.30.tgz",
 			"integrity": "sha1-AFLBNvUkgAJCjjY4s33ko5gYZB0="
+		},
+		"@types/clone": {
+			"version": "0.1.30",
+			"resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
+			"integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
+		},
+		"@types/cssbeautify": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+			"integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8="
+		},
+		"@types/doctrine": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
+			"integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
+		},
+		"@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
 		},
 		"@types/events": {
 			"version": "1.2.0",
@@ -880,6 +941,11 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/path-is-inside": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+			"integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw=="
+		},
 		"@types/relateurl": {
 			"version": "0.2.28",
 			"resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
@@ -898,6 +964,11 @@
 			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-1.16.36.tgz",
 			"integrity": "sha1-dLtu15KFl8Gz+xsAkAXpTcbq41c=",
 			"dev": true
+		},
+		"@types/ua-parser-js": {
+			"version": "0.7.32",
+			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
+			"integrity": "sha512-+z7Q72Mlnq6SFkQYHzLg2Z70pIsgRVzgx1b5PV8eUv5uaZ/zoqIs45XnhtToW4gTeX4FbjIP49nhIjyvPF4rPg=="
 		},
 		"@types/uglify-js": {
 			"version": "3.0.2",
@@ -940,6 +1011,14 @@
 				"@types/vinyl": "*"
 			}
 		},
+		"@types/whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/winston": {
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.9.tgz",
@@ -953,6 +1032,34 @@
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
 			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
 			"dev": true
+		},
+		"acorn": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+			"integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
+		},
+		"acorn-import-meta": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/acorn-import-meta/-/acorn-import-meta-0.2.1.tgz",
+			"integrity": "sha512-+KB5Q0P0Q/XpsPHgnLx4XbCGqMogw4yiJJjYsbzPCNrE/IoX+c6J4C+BFcwdWh3CD1zLzMxPITN1jzHd+NiS3w==",
+			"requires": {
+				"acorn": "^5.4.1"
+			}
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"requires": {
+				"acorn": "^3.0.4"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+				}
+			}
 		},
 		"align-text": {
 			"version": "0.1.4",
@@ -988,6 +1095,24 @@
 			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 			"requires": {
 				"string-width": "^2.0.0"
+			}
+		},
+		"ansi-escape-sequences": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
+			"integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
+			"requires": {
+				"array-back": "^1.0.3"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+					"requires": {
+						"typical": "^2.6.0"
+					}
+				}
 			}
 		},
 		"ansi-regex": {
@@ -1084,7 +1209,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
@@ -1094,20 +1218,17 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -1120,7 +1241,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -1128,8 +1248,29 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"requires": {
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 				}
 			}
 		},
@@ -1172,7 +1313,6 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -1356,7 +1496,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -1366,7 +1505,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-messages": "^6.23.0",
@@ -1382,14 +1520,12 @@
 				"babylon": {
 					"version": "6.18.0",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-					"dev": true
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -1397,8 +1533,7 @@
 				"globals": {
 					"version": "9.18.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-					"dev": true
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 				}
 			}
 		},
@@ -1406,7 +1541,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"esutils": "^2.0.2",
@@ -1417,8 +1551,7 @@
 				"to-fast-properties": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-					"dev": true
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 				}
 			}
 		},
@@ -1539,6 +1672,15 @@
 				}
 			}
 		},
+		"browser-capabilities": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-1.1.0.tgz",
+			"integrity": "sha512-D0AhTybfR0KbVxy1DShQut4eCeluMyJhbTgVTIxvItJKzEGG9pNvOBFZfpeCASo2z0XdfczuvSfNZe/vmNlqwQ==",
+			"requires": {
+				"@types/ua-parser-js": "^0.7.31",
+				"ua-parser-js": "^0.7.15"
+			}
+		},
 		"buffer-from": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
@@ -1587,6 +1729,21 @@
 			"requires": {
 				"camelcase": "^2.0.0",
 				"map-obj": "^1.0.0"
+			}
+		},
+		"cancel-token": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+			"integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+			"requires": {
+				"@types/node": "^4.0.30"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "4.2.23",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+					"integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w=="
+				}
 			}
 		},
 		"capture-stack-trace": {
@@ -1848,8 +2005,7 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1890,6 +2046,11 @@
 				"parse5": "^4.0.0",
 				"shady-css-parser": "^0.1.0"
 			}
+		},
+		"cssbeautify": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
+			"integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -1941,23 +2102,6 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
-		},
-		"defaults": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"dev": true,
-			"requires": {
-				"clone": "^1.0.2"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-					"dev": true
-				}
-			}
 		},
 		"define-property": {
 			"version": "2.0.2",
@@ -2034,6 +2178,22 @@
 			"resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
 			"integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=",
 			"dev": true
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"requires": {
+				"repeating": "^2.0.0"
+			}
+		},
+		"doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"requires": {
+				"esutils": "^2.0.2"
+			}
 		},
 		"dom-urls": {
 			"version": "1.1.0",
@@ -2145,6 +2305,15 @@
 						"amdefine": ">=0.0.4"
 					}
 				}
+			}
+		},
+		"espree": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"requires": {
+				"acorn": "^5.5.0",
+				"acorn-jsx": "^3.0.0"
 			}
 		},
 		"esprima": {
@@ -2358,6 +2527,24 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"feature-detect-es6": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.1.tgz",
+			"integrity": "sha512-iMxKpKdIBgcWiBPtz2qnEsNjCE2dBQvDyUqgrXLJboiaHwJa+2vDIZ8XbgNZGh1Rx1PUfZmI7uhG6Z4iQYWVjg==",
+			"requires": {
+				"array-back": "^1.0.4"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+					"requires": {
+						"typical": "^2.6.0"
+					}
+				}
+			}
+		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -2383,12 +2570,6 @@
 					}
 				}
 			}
-		},
-		"find-index": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-			"integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-			"dev": true
 		},
 		"find-replace": {
 			"version": "2.0.1",
@@ -2463,15 +2644,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"gaze": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-			"integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-			"dev": true,
-			"requires": {
-				"globule": "~0.1.0"
-			}
 		},
 		"get-caller-file": {
 			"version": "1.0.2",
@@ -2693,24 +2865,6 @@
 				}
 			}
 		},
-		"glob-watcher": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-			"integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-			"dev": true,
-			"requires": {
-				"gaze": "^0.5.1"
-			}
-		},
-		"glob2base": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-			"integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-			"dev": true,
-			"requires": {
-				"find-index": "^0.1.1"
-			}
-		},
 		"global-dirs": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -2723,64 +2877,6 @@
 			"version": "11.7.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
 			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
-		},
-		"globule": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-			"integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-			"dev": true,
-			"requires": {
-				"glob": "~3.1.21",
-				"lodash": "~1.0.1",
-				"minimatch": "~0.2.11"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "3.1.21",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-					"integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "~1.2.0",
-						"inherits": "1",
-						"minimatch": "~0.2.11"
-					}
-				},
-				"graceful-fs": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-					"integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-					"dev": true
-				},
-				"inherits": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-					"integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-					"dev": true
-				},
-				"lodash": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-					"integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-					"dev": true
-				},
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-					"dev": true
-				},
-				"minimatch": {
-					"version": "0.2.14",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-					"integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "2",
-						"sigmund": "~1.0.0"
-					}
-				}
-			}
 		},
 		"got": {
 			"version": "6.7.1",
@@ -2928,7 +3024,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			},
@@ -2936,8 +3031,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				}
 			}
 		},
@@ -3008,6 +3102,11 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"indent": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
+			"integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
 		},
 		"indent-string": {
 			"version": "2.1.0",
@@ -3412,6 +3511,11 @@
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
+		"jsonschema": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+		},
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -3529,6 +3633,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
 			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
 		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
 		"lodash.template": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
@@ -3592,6 +3701,14 @@
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
+			}
+		},
+		"magic-string": {
+			"version": "0.22.5",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+			"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+			"requires": {
+				"vlq": "^0.2.2"
 			}
 		},
 		"make-dir": {
@@ -3708,6 +3825,14 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
+		"minimatch-all": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/minimatch-all/-/minimatch-all-1.1.0.tgz",
+			"integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
+			"requires": {
+				"minimatch": "^3.0.2"
+			}
+		},
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -3789,12 +3914,6 @@
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
 			}
-		},
-		"natives": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-			"integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
-			"dev": true
 		},
 		"no-case": {
 			"version": "2.3.2",
@@ -4166,6 +4285,236 @@
 				}
 			}
 		},
+		"polymer-analyzer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.1.tgz",
+			"integrity": "sha512-s1fEMUeUHs7EWZQ5cxL/RL6qzDcYnkJcLeQbNvVD1qOPtxRejGeonq5xsxmb8o7mstzSYb1x0Iba2Bdbfr+PAQ==",
+			"requires": {
+				"@babel/generator": "^7.0.0-beta.42",
+				"@babel/traverse": "^7.0.0-beta.42",
+				"@babel/types": "^7.0.0-beta.42",
+				"@types/babel-generator": "^6.25.1",
+				"@types/babel-traverse": "^6.25.2",
+				"@types/babel-types": "^6.25.1",
+				"@types/babylon": "^6.16.2",
+				"@types/chai-subset": "^1.3.0",
+				"@types/chalk": "^0.4.30",
+				"@types/clone": "^0.1.30",
+				"@types/cssbeautify": "^0.3.1",
+				"@types/doctrine": "^0.0.1",
+				"@types/is-windows": "^0.2.0",
+				"@types/minimatch": "^3.0.1",
+				"@types/node": "^9.6.4",
+				"@types/parse5": "^2.2.34",
+				"@types/path-is-inside": "^1.0.0",
+				"@types/resolve": "0.0.6",
+				"@types/whatwg-url": "^6.4.0",
+				"babylon": "^7.0.0-beta.42",
+				"cancel-token": "^0.1.1",
+				"chalk": "^1.1.3",
+				"clone": "^2.0.0",
+				"cssbeautify": "^0.3.1",
+				"doctrine": "^2.0.2",
+				"dom5": "^3.0.0",
+				"indent": "0.0.2",
+				"is-windows": "^1.0.2",
+				"jsonschema": "^1.1.0",
+				"minimatch": "^3.0.4",
+				"parse5": "^4.0.0",
+				"path-is-inside": "^1.0.2",
+				"resolve": "^1.5.0",
+				"shady-css-parser": "^0.1.0",
+				"stable": "^0.1.6",
+				"strip-indent": "^2.0.0",
+				"vscode-uri": "^1.0.1",
+				"whatwg-url": "^6.4.0"
+			},
+			"dependencies": {
+				"@types/resolve": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+					"integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"polymer-bundler": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.1.tgz",
+			"integrity": "sha512-nG+mpWn5h6nflOqZwtcpIKlYxXMznKFODa5XMQsUgD2126BT5cdznbMXCkH9vCIpbV5iBm5lCunmTyoYF+3BqA==",
+			"requires": {
+				"@types/acorn": "^4.0.3",
+				"@types/babel-generator": "^6.25.1",
+				"@types/babel-traverse": "^6.25.3",
+				"acorn-import-meta": "^0.2.1",
+				"babel-generator": "^6.26.1",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"clone": "^2.1.0",
+				"command-line-args": "^3.0.1",
+				"command-line-usage": "^3.0.3",
+				"dom5": "^2.2.0",
+				"espree": "^3.5.2",
+				"magic-string": "^0.22.4",
+				"mkdirp": "^0.5.1",
+				"parse5": "^2.2.2",
+				"polymer-analyzer": "^3.0.1",
+				"rollup": "^0.58.2",
+				"source-map": "^0.5.6",
+				"vscode-uri": "^1.0.1"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "6.0.113",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.113.tgz",
+					"integrity": "sha512-f9XXUWFqryzjkZA1EqFvJHSFyqyasV17fq8zCDIzbRV4ctL7RrJGKvG+lcex86Rjbzd1GrER9h9VmF5sSjV0BQ=="
+				},
+				"array-back": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+					"requires": {
+						"typical": "^2.6.0"
+					}
+				},
+				"command-line-args": {
+					"version": "3.0.5",
+					"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
+					"integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
+					"requires": {
+						"array-back": "^1.0.4",
+						"feature-detect-es6": "^1.3.1",
+						"find-replace": "^1.0.2",
+						"typical": "^2.6.0"
+					}
+				},
+				"command-line-usage": {
+					"version": "3.0.8",
+					"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
+					"integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
+					"requires": {
+						"ansi-escape-sequences": "^3.0.0",
+						"array-back": "^1.0.3",
+						"feature-detect-es6": "^1.3.1",
+						"table-layout": "^0.3.0",
+						"typical": "^2.6.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+					"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+				},
+				"dom5": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
+					"integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
+					"requires": {
+						"@types/clone": "^0.1.29",
+						"@types/node": "^6.0.0",
+						"@types/parse5": "^2.2.32",
+						"clone": "^2.1.0",
+						"parse5": "^2.2.2"
+					}
+				},
+				"find-replace": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
+					"integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+					"requires": {
+						"array-back": "^1.0.4",
+						"test-value": "^2.1.0"
+					}
+				},
+				"parse5": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+					"integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY="
+				},
+				"table-layout": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
+					"integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
+					"requires": {
+						"array-back": "^1.0.3",
+						"core-js": "^2.4.1",
+						"deep-extend": "~0.4.1",
+						"feature-detect-es6": "^1.3.1",
+						"typical": "^2.6.0",
+						"wordwrapjs": "^2.0.0-0"
+					}
+				},
+				"test-value": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+					"integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+					"requires": {
+						"array-back": "^1.0.3",
+						"typical": "^2.6.0"
+					}
+				},
+				"wordwrapjs": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
+					"integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
+					"requires": {
+						"array-back": "^1.0.3",
+						"feature-detect-es6": "^1.3.1",
+						"reduce-flatten": "^1.0.1",
+						"typical": "^2.6.0"
+					}
+				}
+			}
+		},
+		"polymer-project-config": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-4.0.1.tgz",
+			"integrity": "sha512-NJjP5gf6tOQ5YY8u0UM3hzrXPF2hpNIIyXCtd5VNCYoRGJdT//UFubyWFDd9Aje09yNWjS1SAfjZIhMgZ5DESg==",
+			"requires": {
+				"@types/node": "^9.6.4",
+				"browser-capabilities": "^1.0.0",
+				"jsonschema": "^1.1.1",
+				"minimatch-all": "^1.1.0",
+				"plylog": "^0.5.0"
+			}
+		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -4206,6 +4555,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"randomatic": {
 			"version": "3.0.0",
@@ -4470,6 +4824,22 @@
 			"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
 			"dev": true
 		},
+		"rollup": {
+			"version": "0.58.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.58.2.tgz",
+			"integrity": "sha512-RZVvCWm9BHOYloaE6LLiE/ibpjv1CmI8F8k0B0Cp+q1eezo3cswszJH1DN0djgzSlo0hjuuCmyeI+1XOYLl4wg==",
+			"requires": {
+				"@types/estree": "0.0.38",
+				"@types/node": "*"
+			},
+			"dependencies": {
+				"@types/estree": {
+					"version": "0.0.38",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
+					"integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA=="
+				}
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -4551,12 +4921,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -4762,6 +5126,11 @@
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+		},
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -4849,8 +5218,7 @@
 		"strip-indent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-			"dev": true
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -5041,6 +5409,14 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -5088,6 +5464,11 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
 			"integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+		},
+		"ua-parser-js": {
+			"version": "0.7.18",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
 		},
 		"uglify-js": {
 			"version": "3.3.28",
@@ -5354,156 +5735,36 @@
 				"vinyl": "^1.0.0"
 			}
 		},
-		"vinyl-fs-fake": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/vinyl-fs-fake/-/vinyl-fs-fake-1.1.0.tgz",
-			"integrity": "sha1-BfGxQrrKoUXDH6E4zi+gv9aLXwI=",
-			"dev": true,
-			"requires": {
-				"through2": "^0.6.3",
-				"vinyl": "^0.4.6",
-				"vinyl-fs": "^0.3.13"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-					"dev": true
-				},
-				"glob": {
-					"version": "4.5.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-					"dev": true,
-					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^2.0.1",
-						"once": "^1.3.0"
-					}
-				},
-				"glob-stream": {
-					"version": "3.1.18",
-					"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-					"integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-					"dev": true,
-					"requires": {
-						"glob": "^4.3.1",
-						"glob2base": "^0.0.12",
-						"minimatch": "^2.0.1",
-						"ordered-read-streams": "^0.1.0",
-						"through2": "^0.6.1",
-						"unique-stream": "^1.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "3.0.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-					"integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-					"dev": true,
-					"requires": {
-						"natives": "^1.1.0"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"minimatch": {
-					"version": "2.0.10",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.0.0"
-					}
-				},
-				"ordered-read-streams": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-					"integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				},
-				"strip-bom": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-					"integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-					"dev": true,
-					"requires": {
-						"first-chunk-stream": "^1.0.0",
-						"is-utf8": "^0.2.0"
-					}
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
-					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
-					}
-				},
-				"unique-stream": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-					"integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-					"dev": true
-				},
-				"vinyl": {
-					"version": "0.4.6",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-					"dev": true,
-					"requires": {
-						"clone": "^0.2.0",
-						"clone-stats": "^0.0.1"
-					}
-				},
-				"vinyl-fs": {
-					"version": "0.3.14",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-					"integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
-					"dev": true,
-					"requires": {
-						"defaults": "^1.0.0",
-						"glob-stream": "^3.1.5",
-						"glob-watcher": "^0.0.6",
-						"graceful-fs": "^3.0.0",
-						"mkdirp": "^0.5.0",
-						"strip-bom": "^1.0.0",
-						"through2": "^0.6.1",
-						"vinyl": "^0.4.0"
-					}
-				}
-			}
+		"vlq": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
+		},
+		"vscode-uri": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.5.tgz",
+			"integrity": "sha1-O4majvccN/MFTXm9vdoxx7828g0="
 		},
 		"walkdir": {
 			"version": "0.0.11",
 			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
 			"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
 			"dev": true
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"whatwg-url": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
 		},
 		"which": {
 			"version": "1.3.1",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -101,7 +101,6 @@
     "source-map-support": "^0.5.4",
     "strip-indent": "^2.0.0",
     "temp": "^0.8.3",
-    "tsc-then": "^1.1.0",
-    "vinyl-fs-fake": "^1.1.0"
+    "tsc-then": "^1.1.0"
   }
 }


### PR DESCRIPTION
You can verify that there are no audit warnings with the following command (make sure you ran `npm run bootstrap` again to get the correct versions):

```bash
npx lerna exec --stream --scope polymer-build -- npm audit
```

**Note: This PR audit fails, as the latest version of polymer-bundler is not released yet.**
In https://github.com/Polymer/tools/commit/28403ca7d838dde3960fcd62063565c209a67c7d#diff-c7860144f1c9fb836793e097691c5a56 the vulnerable package `command-line-args` was updated, but it was not included in the latest release (https://github.com/Polymer/tools/commit/4d137fd44fdf3054c7ab6eed63e46a683656bc1e). Therefore, running the above command results in 1 vulnerability. Releasing a new version of `polymer-bundler` will resolve that.