### PR TITLE
Fix audit warnings in dom5

### DIFF
--- a/packages/dom5/package-lock.json
+++ b/packages/dom5/package-lock.json
@@ -71,6 +71,12 @@
 				"concat-map": "0.0.1"
 			}
 		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
+		},
 		"chai": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
@@ -99,9 +105,9 @@
 			"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
 		},
 		"commander": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-			"integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
 			"dev": true
 		},
 		"concat-map": {
@@ -111,12 +117,12 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-			"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 			"dev": true,
 			"requires": {
-				"ms": "0.7.1"
+				"ms": "2.0.0"
 			}
 		},
 		"deep-eql": {
@@ -137,15 +143,15 @@
 			}
 		},
 		"diff": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
 		},
 		"escape-string-regexp": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-			"integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
 		"fs.realpath": {
@@ -169,9 +175,21 @@
 			}
 		},
 		"growl": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
 			"dev": true
 		},
 		"inflight": {
@@ -188,36 +206,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
-		},
-		"jade": {
-			"version": "0.26.3",
-			"resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-			"integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-			"dev": true,
-			"requires": {
-				"commander": "0.6.1",
-				"mkdirp": "0.3.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-					"integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-					"integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-					"dev": true
-				}
-			}
-		},
-		"lru-cache": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-			"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
 			"dev": true
 		},
 		"minimatch": {
@@ -245,49 +233,28 @@
 			}
 		},
 		"mocha": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-			"integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
 			"dev": true,
 			"requires": {
-				"commander": "2.3.0",
-				"debug": "2.2.0",
-				"diff": "1.4.0",
-				"escape-string-regexp": "1.0.2",
-				"glob": "3.2.11",
-				"growl": "1.9.2",
-				"jade": "0.26.3",
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.5",
+				"he": "1.1.1",
+				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
-				"supports-color": "1.2.0",
-				"to-iso-string": "0.0.2"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "3.2.11",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-					"dev": true,
-					"requires": {
-						"inherits": "2",
-						"minimatch": "0.3"
-					}
-				},
-				"minimatch": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "2",
-						"sigmund": "~1.0.0"
-					}
-				}
+				"supports-color": "5.4.0"
 			}
 		},
 		"ms": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-			"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
 		"once": {
@@ -331,23 +298,14 @@
 			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
 			"dev": true
 		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-			"dev": true
-		},
 		"supports-color": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-			"integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-			"dev": true
-		},
-		"to-iso-string": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-			"integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-			"dev": true
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
 		},
 		"tsc-then": {
 			"version": "1.1.0",

--- a/packages/dom5/package.json
+++ b/packages/dom5/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^6.0.0",
     "chai": "^3.3.0",
     "clang-format": "=1.0.49",
-    "mocha": "^2.0.1",
+    "mocha": "^5.2.0",
     "tsc-then": "^1.1.0"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
You can verify that there are no audit warnings with the following command (make sure you ran `npm run bootstrap` again to get the correct versions):

```bash
npx lerna exec --stream --scope dom5 -- npm audit
```