### PR TITLE
Fix audit warnings in wct-local

### DIFF
--- a/packages/wct-local/package-lock.json
+++ b/packages/wct-local/package-lock.json
@@ -215,6 +215,11 @@
 				"supports-color": "^5.3.0"
 			}
 		},
+		"cleankill": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
+			"integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE="
+		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",


### PR DESCRIPTION
You can verify that there are no audit warnings with the following command (make sure you ran `npm run bootstrap` again to get the correct versions):

```bash
npx lerna exec --stream --scope wct-local -- npm audit
```