### PR TITLE
Fix audit warnings in analyzer

### DIFF
--- a/packages/analyzer/package-lock.json
+++ b/packages/analyzer/package-lock.json
@@ -678,6 +678,16 @@
 				"esutils": "^2.0.2"
 			}
 		},
+		"dom5": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.0.tgz",
+			"integrity": "sha512-PbE+7C4Sh1dHDTLNuSDaMUGD1ivDiSZw0L+a9xVUzUKeQ8w3vdzfKHRA07CxcrFZZOa1SGl2nIJ9T49j63q+bg==",
+			"requires": {
+				"@types/parse5": "^2.2.32",
+				"clone": "^2.1.0",
+				"parse5": "^4.0.0"
+			}
+		},
 		"duplexer2": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",


### PR DESCRIPTION
You can verify that there are no audit warnings with the following command (make sure you ran `npm run bootstrap` again to get the correct versions):

```bash
npx lerna exec --stream --scope polymer-analyzer -- npm audit
```