### PR TITLE
Fix audit warnings in common

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -86,6 +86,295 @@
 			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
 			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
 		},
+		"anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
+			"requires": {
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			},
+			"dependencies": {
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"dev": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				}
+			}
+		},
+		"append-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+			"integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+			"dev": true,
+			"requires": {
+				"buffer-equal": "^1.0.0"
+			}
+		},
 		"archy": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
@@ -105,10 +394,28 @@
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
 			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
+		"arr-filter": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
+			"integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+			"dev": true,
+			"requires": {
+				"make-iterator": "^1.0.0"
+			}
+		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
+			"integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+			"dev": true,
+			"requires": {
+				"make-iterator": "^1.0.0"
+			}
 		},
 		"arr-union": {
 			"version": "3.1.0",
@@ -126,11 +433,65 @@
 			"integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
 			"dev": true
 		},
+		"array-initial": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
+			"integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+			"dev": true,
+			"requires": {
+				"array-slice": "^1.0.0",
+				"is-number": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"dev": true
+				}
+			}
+		},
+		"array-last": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+			"integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+			"dev": true,
+			"requires": {
+				"is-number": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"dev": true
+				}
+			}
+		},
 		"array-slice": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
 			"integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
 			"dev": true
+		},
+		"array-sort": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+			"integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+			"dev": true,
+			"requires": {
+				"default-compare": "^1.0.0",
+				"get-value": "^2.0.6",
+				"kind-of": "^5.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
 		},
 		"array-union": {
 			"version": "1.0.2",
@@ -165,6 +526,41 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
 			"dev": true
+		},
+		"async-done": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
+			"integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.2",
+				"process-nextick-args": "^1.0.7",
+				"stream-exhaust": "^1.0.1"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+					"dev": true
+				}
+			}
+		},
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true
+		},
+		"async-settle": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
+			"integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+			"dev": true,
+			"requires": {
+				"async-done": "^1.2.2"
+			}
 		},
 		"atob": {
 			"version": "2.1.1",
@@ -230,6 +626,23 @@
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
 			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+		},
+		"bach": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
+			"integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+			"dev": true,
+			"requires": {
+				"arr-filter": "^1.1.1",
+				"arr-flatten": "^1.0.1",
+				"arr-map": "^2.0.0",
+				"array-each": "^1.0.0",
+				"array-initial": "^1.0.0",
+				"array-last": "^1.1.1",
+				"async-done": "^1.2.2",
+				"async-settle": "^1.0.0",
+				"now-and-later": "^2.0.0"
+			}
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -302,6 +715,12 @@
 			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
 			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
 		},
+		"binary-extensions": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -322,9 +741,15 @@
 			}
 		},
 		"browser-stdout": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+		},
+		"buffer-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+			"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.0",
@@ -387,6 +812,98 @@
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+		},
+		"chokidar": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+			"dev": true,
+			"requires": {
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.0",
+				"braces": "^2.3.0",
+				"fsevents": "^1.2.2",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"lodash.debounce": "^4.0.8",
+				"normalize-path": "^2.1.1",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0",
+				"upath": "^1.0.5"
+			},
+			"dependencies": {
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				}
+			}
 		},
 		"circular-json": {
 			"version": "0.3.3",
@@ -467,10 +984,27 @@
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
 			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 		},
+		"clone-buffer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+			"dev": true
+		},
 		"clone-stats": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
 			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+		},
+		"cloneable-readable": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"process-nextick-args": "^2.0.0",
+				"readable-stream": "^2.3.5"
+			}
 		},
 		"co": {
 			"version": "4.6.0",
@@ -481,6 +1015,28 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"collection-map": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
+			"integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+			"dev": true,
+			"requires": {
+				"arr-map": "^2.0.2",
+				"for-own": "^1.0.0",
+				"make-iterator": "^1.0.0"
+			},
+			"dependencies": {
+				"for-own": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+					"dev": true,
+					"requires": {
+						"for-in": "^1.0.1"
+					}
+				}
+			}
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -511,12 +1067,9 @@
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
 		},
 		"commander": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-			"requires": {
-				"graceful-readlink": ">= 1.0.0"
-			}
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
 		"component-emitter": {
 			"version": "1.2.1",
@@ -551,6 +1104,16 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
+		"copy-props": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
+			"integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
+			"dev": true,
+			"requires": {
+				"each-props": "^1.3.0",
+				"is-plain-object": "^2.0.1"
+			}
+		},
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
@@ -569,6 +1132,15 @@
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			}
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"dev": true,
+			"requires": {
+				"es5-ext": "^0.10.9"
 			}
 		},
 		"dargs": {
@@ -605,13 +1177,37 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
-		"defaults": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+		"default-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+			"integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
 			"dev": true,
 			"requires": {
-				"clone": "^1.0.2"
+				"kind-of": "^5.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
+		},
+		"default-resolution": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
+			"integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+			"dev": true
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
+			"requires": {
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
 			}
 		},
 		"define-property": {
@@ -698,12 +1294,6 @@
 			"resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
 			"integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg="
 		},
-		"deprecated": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-			"integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
-			"dev": true
-		},
 		"deps-regex": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
@@ -716,9 +1306,9 @@
 			"dev": true
 		},
 		"diff": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"doctrine": {
 			"version": "2.1.0",
@@ -770,6 +1360,16 @@
 				"stream-shift": "^1.0.0"
 			}
 		},
+		"each-props": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.2.tgz",
+			"integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
+			"dev": true,
+			"requires": {
+				"is-plain-object": "^2.0.1",
+				"object.defaults": "^1.1.0"
+			}
+		},
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -784,6 +1384,50 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"requires": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es5-ext": {
+			"version": "0.10.45",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+			"integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+			"dev": true,
+			"requires": {
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.1",
+				"next-tick": "1"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"dev": true,
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"dev": true,
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.14",
+				"es6-iterator": "^2.0.1",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -1090,12 +1734,6 @@
 					}
 				}
 			}
-		},
-		"find-index": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-			"integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-			"dev": true
 		},
 		"find-up": {
 			"version": "2.1.0",
@@ -1422,6 +2060,16 @@
 				"write": "^0.2.1"
 			}
 		},
+		"flush-write-stream": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.4"
+			}
+		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1434,6 +2082,12 @@
 			"requires": {
 				"for-in": "^1.0.1"
 			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -1454,24 +2108,560 @@
 				"universalify": "^0.1.0"
 			}
 		},
+		"fs-mkdirp-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+			"integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"through2": "^2.0.3"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
+		"fsevents": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"aproba": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"chownr": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"fs-minipass": {
+					"version": "1.2.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"iconv-lite": {
+					"version": "0.4.21",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safer-buffer": "^2.1.0"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true
+				},
+				"minipass": {
+					"version": "2.2.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"needle": {
+					"version": "2.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.10.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1",
+						"osenv": "^0.1.4"
+					}
+				},
+				"npm-bundled": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.7",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "^0.5.1",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "4.4.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"string-width": "^1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				}
+			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
 		"functional-red-black-tree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
-		},
-		"gaze": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-			"integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-			"dev": true,
-			"requires": {
-				"globule": "~0.1.0"
-			}
 		},
 		"get-caller-file": {
 			"version": "1.0.2",
@@ -1603,21 +2793,15 @@
 			}
 		},
 		"glob-watcher": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-			"integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.1.tgz",
+			"integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
 			"dev": true,
 			"requires": {
-				"gaze": "^0.5.1"
-			}
-		},
-		"glob2base": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-			"integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-			"dev": true,
-			"requires": {
-				"find-index": "^0.1.1"
+				"async-done": "^1.2.0",
+				"chokidar": "^2.0.0",
+				"just-debounce": "^1.0.0",
+				"object.defaults": "^1.1.0"
 			}
 		},
 		"global-modules": {
@@ -1662,64 +2846,6 @@
 				"pinkie-promise": "^2.0.0"
 			}
 		},
-		"globule": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-			"integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-			"dev": true,
-			"requires": {
-				"glob": "~3.1.21",
-				"lodash": "~1.0.1",
-				"minimatch": "~0.2.11"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "3.1.21",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-					"integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "~1.2.0",
-						"inherits": "1",
-						"minimatch": "~0.2.11"
-					}
-				},
-				"graceful-fs": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-					"integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-					"dev": true
-				},
-				"inherits": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-					"integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-					"dev": true
-				},
-				"lodash": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-					"integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-					"dev": true
-				},
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-					"dev": true
-				},
-				"minimatch": {
-					"version": "0.2.14",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-					"integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "2",
-						"sigmund": "~1.0.0"
-					}
-				}
-			}
-		},
 		"glogg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
@@ -1733,179 +2859,282 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
-		"graceful-readlink": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-		},
 		"growl": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
 		},
 		"gulp": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-			"integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.0.tgz",
+			"integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
 			"dev": true,
 			"requires": {
-				"archy": "^1.0.0",
-				"chalk": "^1.0.0",
-				"deprecated": "^0.0.1",
-				"gulp-util": "^3.0.0",
-				"interpret": "^1.0.0",
-				"liftoff": "^2.1.0",
-				"minimist": "^1.1.0",
-				"orchestrator": "^0.3.0",
-				"pretty-hrtime": "^1.0.0",
-				"semver": "^4.1.0",
-				"tildify": "^1.0.0",
-				"v8flags": "^2.0.2",
-				"vinyl-fs": "^0.3.0"
+				"glob-watcher": "^5.0.0",
+				"gulp-cli": "^2.0.0",
+				"undertaker": "^1.0.0",
+				"vinyl-fs": "^3.0.0"
 			},
 			"dependencies": {
-				"clone": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+				"camelcase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
 					"dev": true
 				},
-				"glob": {
-					"version": "4.5.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+				"clone": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+					"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+					"dev": true
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+					"dev": true
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^2.0.1",
-						"once": "^1.3.0"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"glob-stream": {
-					"version": "3.1.18",
-					"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-					"integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+					"integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
 					"dev": true,
 					"requires": {
-						"glob": "^4.3.1",
-						"glob2base": "^0.0.12",
-						"minimatch": "^2.0.1",
-						"ordered-read-streams": "^0.1.0",
-						"through2": "^0.6.1",
-						"unique-stream": "^1.0.0"
+						"extend": "^3.0.0",
+						"glob": "^7.1.1",
+						"glob-parent": "^3.1.0",
+						"is-negated-glob": "^1.0.0",
+						"ordered-read-streams": "^1.0.0",
+						"pumpify": "^1.3.5",
+						"readable-stream": "^2.1.5",
+						"remove-trailing-separator": "^1.0.1",
+						"to-absolute-glob": "^2.0.0",
+						"unique-stream": "^2.0.2"
 					}
 				},
-				"graceful-fs": {
-					"version": "3.0.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-					"integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+				"gulp-cli": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
+					"integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
 					"dev": true,
 					"requires": {
-						"natives": "^1.1.0"
+						"ansi-colors": "^1.0.1",
+						"archy": "^1.0.0",
+						"array-sort": "^1.0.0",
+						"color-support": "^1.1.3",
+						"concat-stream": "^1.6.0",
+						"copy-props": "^2.0.1",
+						"fancy-log": "^1.3.2",
+						"gulplog": "^1.0.0",
+						"interpret": "^1.1.0",
+						"isobject": "^3.0.1",
+						"liftoff": "^2.5.0",
+						"matchdep": "^2.0.0",
+						"mute-stdout": "^1.0.0",
+						"pretty-hrtime": "^1.0.0",
+						"replace-homedir": "^1.0.0",
+						"semver-greatest-satisfied-range": "^1.1.0",
+						"v8flags": "^3.0.1",
+						"yargs": "^7.1.0"
 					}
 				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+				"is-valid-glob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+					"integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
 					"dev": true
 				},
-				"minimatch": {
-					"version": "2.0.10",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
 				},
 				"ordered-read-streams": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-					"integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+					"integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
+						"readable-stream": "^2.0.1"
 					}
 				},
-				"semver": {
-					"version": "4.3.6",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-					"integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
-					"dev": true
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				},
-				"strip-bom": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-					"integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+				"os-locale": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"dev": true,
 					"requires": {
-						"first-chunk-stream": "^1.0.0",
+						"lcid": "^1.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					}
+				},
+				"replace-ext": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
 						"is-utf8": "^0.2.0"
 					}
 				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+				"to-absolute-glob": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+					"integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
 					"dev": true,
 					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
+						"is-absolute": "^1.0.0",
+						"is-negated-glob": "^1.0.0"
 					}
 				},
-				"unique-stream": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-					"integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
-					"dev": true
-				},
 				"vinyl": {
-					"version": "0.4.6",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
 					"dev": true,
 					"requires": {
-						"clone": "^0.2.0",
-						"clone-stats": "^0.0.1"
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				},
 				"vinyl-fs": {
-					"version": "0.3.14",
-					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-					"integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+					"integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
 					"dev": true,
 					"requires": {
-						"defaults": "^1.0.0",
-						"glob-stream": "^3.1.5",
-						"glob-watcher": "^0.0.6",
-						"graceful-fs": "^3.0.0",
-						"mkdirp": "^0.5.0",
-						"strip-bom": "^1.0.0",
-						"through2": "^0.6.1",
-						"vinyl": "^0.4.0"
+						"fs-mkdirp-stream": "^1.0.0",
+						"glob-stream": "^6.1.0",
+						"graceful-fs": "^4.0.0",
+						"is-valid-glob": "^1.0.0",
+						"lazystream": "^1.0.0",
+						"lead": "^1.0.0",
+						"object.assign": "^4.0.4",
+						"pumpify": "^1.3.5",
+						"readable-stream": "^2.3.3",
+						"remove-bom-buffer": "^3.0.0",
+						"remove-bom-stream": "^1.2.0",
+						"resolve-options": "^1.1.0",
+						"through2": "^2.0.0",
+						"to-through": "^2.0.0",
+						"value-or-function": "^3.0.0",
+						"vinyl": "^2.0.0",
+						"vinyl-sourcemap": "^1.1.0"
+					}
+				},
+				"which-module": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+					"dev": true
+				},
+				"yargs": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^5.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -1921,30 +3150,51 @@
 			}
 		},
 		"gulp-mocha": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-4.3.1.tgz",
-			"integrity": "sha1-d5ULQ7z/gWWVdnwHNOD9p9Fz3Nk=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-6.0.0.tgz",
+			"integrity": "sha512-FfBldW5ttnDpKf4Sg6/BLOOKCCbr5mbixDGK1t02/8oSrTCwNhgN/mdszG3cuQuYNzuouUdw4EH/mlYtgUscPg==",
 			"requires": {
 				"dargs": "^5.1.0",
-				"execa": "^0.6.0",
-				"gulp-util": "^3.0.0",
-				"mocha": "^3.0.0",
+				"execa": "^0.10.0",
+				"mocha": "^5.2.0",
 				"npm-run-path": "^2.0.2",
+				"plugin-error": "^1.0.1",
+				"supports-color": "^5.4.0",
 				"through2": "^2.0.3"
 			},
 			"dependencies": {
-				"execa": {
-					"version": "0.6.3",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
-					"integrity": "sha1-V7aaWU8IF1nGnlNw8NF7nLEWWP4=",
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"requires": {
-						"cross-spawn": "^5.0.1",
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+					"requires": {
+						"cross-spawn": "^6.0.0",
 						"get-stream": "^3.0.0",
 						"is-stream": "^1.1.0",
 						"npm-run-path": "^2.0.0",
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -2098,6 +3348,12 @@
 			"requires": {
 				"sparkles": "^1.0.0"
 			}
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -2313,6 +3569,15 @@
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "^1.0.0"
+			}
+		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -2395,6 +3660,12 @@
 			"requires": {
 				"is-extglob": "^2.1.0"
 			}
+		},
+		"is-negated-glob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
+			"dev": true
 		},
 		"is-number": {
 			"version": "2.1.0",
@@ -2556,11 +3827,6 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
 		},
-		"json3": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
-		},
 		"jsonfile": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
@@ -2574,12 +3840,28 @@
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
+		"just-debounce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
+			"integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
+			"dev": true
+		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
 				"is-buffer": "^1.1.5"
+			}
+		},
+		"last-run": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
+			"integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
+			"dev": true,
+			"requires": {
+				"default-resolution": "^2.0.0",
+				"es6-weak-map": "^2.0.1"
 			}
 		},
 		"lazystream": {
@@ -2596,6 +3878,15 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
 				"invert-kv": "^1.0.0"
+			}
+		},
+		"lead": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+			"integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+			"dev": true,
+			"requires": {
+				"flush-write-stream": "^1.0.2"
 			}
 		},
 		"levn": {
@@ -2648,24 +3939,10 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
 			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
-		"lodash._baseassign": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-			"requires": {
-				"lodash._basecopy": "^3.0.0",
-				"lodash.keys": "^3.0.0"
-			}
-		},
 		"lodash._basecopy": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
 			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-		},
-		"lodash._basecreate": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-			"integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
 		},
 		"lodash._basetostring": {
 			"version": "3.0.1",
@@ -2707,15 +3984,11 @@
 			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
 			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
 		},
-		"lodash.create": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-			"requires": {
-				"lodash._baseassign": "^3.0.0",
-				"lodash._basecreate": "^3.0.0",
-				"lodash._isiterateecall": "^3.0.0"
-			}
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+			"dev": true
 		},
 		"lodash.escape": {
 			"version": "3.2.0",
@@ -2834,6 +4107,288 @@
 				"object-visit": "^1.0.0"
 			}
 		},
+		"matchdep": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+			"integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+			"dev": true,
+			"requires": {
+				"findup-sync": "^2.0.0",
+				"micromatch": "^3.0.4",
+				"resolve": "^1.4.0",
+				"stack-trace": "0.0.10"
+			},
+			"dependencies": {
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+					"dev": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				}
+			}
+		},
 		"math-random": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -2935,56 +4490,37 @@
 			}
 		},
 		"mocha": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-			"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
 			"requires": {
-				"browser-stdout": "1.3.0",
-				"commander": "2.9.0",
-				"debug": "2.6.8",
-				"diff": "3.2.0",
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
 				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.1",
-				"growl": "1.9.2",
+				"glob": "7.1.2",
+				"growl": "1.10.5",
 				"he": "1.1.1",
-				"json3": "3.3.2",
-				"lodash.create": "3.1.1",
+				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
-				"supports-color": "3.1.2"
+				"supports-color": "5.4.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.8",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
-				"glob": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.2",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"supports-color": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -3002,10 +4538,23 @@
 				"duplexer2": "0.0.2"
 			}
 		},
+		"mute-stdout": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.0.tgz",
+			"integrity": "sha1-WzLqB+tDyd7WEwQ0z5JvRrKn/U0=",
+			"dev": true
+		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+		},
+		"nan": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+			"dev": true,
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.9",
@@ -3041,16 +4590,21 @@
 				}
 			}
 		},
-		"natives": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-			"integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
-			"dev": true
-		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
 		},
 		"normalize-package-data": {
 			"version": "2.4.0",
@@ -3069,6 +4623,15 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"now-and-later": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+			"integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.2"
 			}
 		},
 		"npm-run-path": {
@@ -3111,6 +4674,12 @@
 				}
 			}
 		},
+		"object-keys": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+			"dev": true
+		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -3118,6 +4687,18 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
+			}
+		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
 			}
 		},
 		"object.defaults": {
@@ -3189,6 +4770,27 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"object.reduce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-1.0.1.tgz",
+			"integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
+			"dev": true,
+			"requires": {
+				"for-own": "^1.0.0",
+				"make-iterator": "^1.0.0"
+			},
+			"dependencies": {
+				"for-own": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+					"dev": true,
+					"requires": {
+						"for-in": "^1.0.1"
+					}
+				}
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3218,37 +4820,6 @@
 				"wordwrap": "~1.0.0"
 			}
 		},
-		"orchestrator": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-			"integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-			"dev": true,
-			"requires": {
-				"end-of-stream": "~0.1.5",
-				"sequencify": "~0.0.7",
-				"stream-consume": "~0.1.0"
-			},
-			"dependencies": {
-				"end-of-stream": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-					"integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-					"dev": true,
-					"requires": {
-						"once": "~1.3.0"
-					}
-				},
-				"once": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-					"integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-					"dev": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				}
-			}
-		},
 		"ordered-read-streams": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
@@ -3257,12 +4828,6 @@
 				"is-stream": "^1.0.1",
 				"readable-stream": "^2.0.1"
 			}
-		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
 		},
 		"os-locale": {
 			"version": "2.1.0",
@@ -3487,6 +5052,27 @@
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"pumpify": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"dev": true,
+			"requires": {
+				"duplexify": "^3.6.0",
+				"inherits": "^2.0.3",
+				"pump": "^2.0.0"
+			}
+		},
 		"randomatic": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
@@ -3542,6 +5128,18 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
+		"readdirp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
+			}
+		},
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -3579,6 +5177,27 @@
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
 			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
 		},
+		"remove-bom-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+			"integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+			"dev": true,
+			"requires": {
+				"is-buffer": "^1.1.5",
+				"is-utf8": "^0.2.1"
+			}
+		},
+		"remove-bom-stream": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+			"integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+			"dev": true,
+			"requires": {
+				"remove-bom-buffer": "^3.0.0",
+				"safe-buffer": "^5.1.0",
+				"through2": "^2.0.3"
+			}
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -3598,6 +5217,17 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
 			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+		},
+		"replace-homedir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+			"integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+			"dev": true,
+			"requires": {
+				"homedir-polyfill": "^1.0.1",
+				"is-absolute": "^1.0.0",
+				"remove-trailing-separator": "^1.1.0"
+			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -3646,6 +5276,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
 			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+		},
+		"resolve-options": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+			"integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+			"dev": true,
+			"requires": {
+				"value-or-function": "^3.0.0"
+			}
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -3730,16 +5369,25 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
 			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
 		},
-		"sequencify": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-			"integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
-			"dev": true
+		"semver-greatest-satisfied-range": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+			"integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+			"dev": true,
+			"requires": {
+				"sver-compat": "^1.5.0"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true
 		},
 		"set-value": {
 			"version": "2.0.0",
@@ -3782,12 +5430,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -3988,6 +5630,12 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"dev": true
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -4009,10 +5657,10 @@
 				}
 			}
 		},
-		"stream-consume": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-			"integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
+		"stream-exhaust": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
+			"integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
 			"dev": true
 		},
 		"stream-shift": {
@@ -4104,6 +5752,16 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 		},
+		"sver-compat": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+			"integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+			"dev": true,
+			"requires": {
+				"es6-iterator": "^2.0.1",
+				"es6-symbol": "^3.1.1"
+			}
+		},
 		"table": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -4171,15 +5829,6 @@
 			"requires": {
 				"through2": "~2.0.0",
 				"xtend": "~4.0.0"
-			}
-		},
-		"tildify": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-			"integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-			"dev": true,
-			"requires": {
-				"os-homedir": "^1.0.0"
 			}
 		},
 		"time-stamp": {
@@ -4265,6 +5914,15 @@
 				}
 			}
 		},
+		"to-through": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+			"integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+			"dev": true,
+			"requires": {
+				"through2": "^2.0.3"
+			}
+		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -4282,6 +5940,29 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
 			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+			"dev": true
+		},
+		"undertaker": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.0.tgz",
+			"integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "^1.0.1",
+				"arr-map": "^2.0.0",
+				"bach": "^1.0.0",
+				"collection-map": "^1.0.0",
+				"es6-weak-map": "^2.0.1",
+				"last-run": "^1.1.0",
+				"object.defaults": "^1.0.0",
+				"object.reduce": "^1.0.0",
+				"undertaker-registry": "^1.0.0"
+			}
+		},
+		"undertaker-registry": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
+			"integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
 			"dev": true
 		},
 		"union-value": {
@@ -4379,6 +6060,12 @@
 				}
 			}
 		},
+		"upath": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"dev": true
+		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -4402,24 +6089,18 @@
 				}
 			}
 		},
-		"user-home": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-			"dev": true
-		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"v8flags": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
+			"integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
 			"dev": true,
 			"requires": {
-				"user-home": "^1.1.1"
+				"homedir-polyfill": "^1.0.1"
 			}
 		},
 		"vali-date": {
@@ -4435,6 +6116,12 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
+		},
+		"value-or-function": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+			"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+			"dev": true
 		},
 		"vinyl": {
 			"version": "0.5.3",
@@ -4486,6 +6173,55 @@
 						"clone": "^1.0.0",
 						"clone-stats": "^0.0.1",
 						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vinyl-sourcemap": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+			"integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+			"dev": true,
+			"requires": {
+				"append-buffer": "^1.0.2",
+				"convert-source-map": "^1.5.0",
+				"graceful-fs": "^4.1.6",
+				"normalize-path": "^2.1.1",
+				"now-and-later": "^2.0.0",
+				"remove-bom-buffer": "^3.0.0",
+				"vinyl": "^2.0.0"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+					"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+					"dev": true
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+					"dev": true
+				},
+				"replace-ext": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+					"dev": true
+				},
+				"vinyl": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+					"dev": true,
+					"requires": {
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -23,17 +23,17 @@
     "depcheck": "^0.6.0",
     "fs-extra": "^3.0.0",
     "gulp-eslint": "^4.0.0",
-    "gulp-mocha": "^4.0.0",
+    "gulp-mocha": "^6.0.0",
     "gulp-tslint": "^8.0.0",
     "gulp-typescript": "^3.0.0",
     "merge-stream": "^1.0.0",
     "run-sequence": "^1.0.0"
   },
   "peerDependencies": {
-    "gulp": "^3.9.1"
+    "gulp": "^4.0.0"
   },
   "devDependencies": {
     "clang-format": "1.0.46",
-    "gulp": "^3.9.1"
+    "gulp": "^4.0.0"
   }
 }


### PR DESCRIPTION
You can verify that there are no audit warnings with the following command (make sure you ran `npm run bootstrap` again to get the correct versions):

```bash
npx lerna exec --stream --scope @polymer/tools-common -- npm audit
```