### PR TITLE
Fix audit warnings in editor-service

### DIFF
--- a/packages/editor-service/package-lock.json
+++ b/packages/editor-service/package-lock.json
@@ -4,17 +4,168 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+			"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.51"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+			"integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.5",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+			"integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+			"requires": {
+				"@babel/helper-get-function-arity": "7.0.0-beta.51",
+				"@babel/template": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+			"integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+			"integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+			"requires": {
+				"@babel/types": "7.0.0-beta.51"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+			"integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY="
+		},
+		"@babel/template": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+			"integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+			"integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.51",
+				"@babel/generator": "7.0.0-beta.51",
+				"@babel/helper-function-name": "7.0.0-beta.51",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.51",
+				"@babel/parser": "7.0.0-beta.51",
+				"@babel/types": "7.0.0-beta.51",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.17.5"
+			}
+		},
+		"@babel/types": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+			"integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.5",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@types/babel-generator": {
+			"version": "6.25.2",
+			"resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.2.tgz",
+			"integrity": "sha512-W7PQkeDlYOqJblfNeqZARwj4W8nO+ZhQQZksU8+wbaKuHeUdIVUAdREO/Qb0FfNr3CY5Sq1gNtqsyFeZfS3iSw==",
+			"requires": {
+				"@types/babel-types": "*"
+			}
+		},
+		"@types/babel-traverse": {
+			"version": "6.25.4",
+			"resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.4.tgz",
+			"integrity": "sha512-+/670NaZE7qPvdh8EtGds32/2uHFKE5JeS+7ePH6nGwF8Wj8r671/RkTiJQP2k22nFntWEb9xQ11MFj7xEqI0g==",
+			"requires": {
+				"@types/babel-types": "*"
+			}
+		},
+		"@types/babel-types": {
+			"version": "6.25.2",
+			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
+			"integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA=="
+		},
+		"@types/babylon": {
+			"version": "6.16.3",
+			"resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.3.tgz",
+			"integrity": "sha512-lyJ8sW1PbY3uwuvpOBZ9zMYKshMnQpXmeDHh8dj9j2nJm/xrW0FgB5gLSYOArj5X0IfaXnmhFoJnhS4KbqIMug==",
+			"requires": {
+				"@types/babel-types": "*"
+			}
+		},
 		"@types/chai": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.5.tgz",
-			"integrity": "sha512-ZC4tZU+3rDblhVy9cUQp5u+Zw9M0geGY8tzUQgc+4CMIWQLUFpgvrHhaYrSq1TK2m0DjaYIp9yJPyTHN+qhBZg==",
-			"dev": true
+			"integrity": "sha512-ZC4tZU+3rDblhVy9cUQp5u+Zw9M0geGY8tzUQgc+4CMIWQLUFpgvrHhaYrSq1TK2m0DjaYIp9yJPyTHN+qhBZg=="
+		},
+		"@types/chai-subset": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
+			"integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
+			"requires": {
+				"@types/chai": "*"
+			}
+		},
+		"@types/chalk": {
+			"version": "0.4.31",
+			"resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
+			"integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk="
 		},
 		"@types/clone": {
 			"version": "0.1.30",
 			"resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
-			"integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
-			"dev": true
+			"integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
 		},
 		"@types/command-line-args": {
 			"version": "5.0.0",
@@ -22,11 +173,31 @@
 			"integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
 			"dev": true
 		},
+		"@types/cssbeautify": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+			"integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8="
+		},
+		"@types/doctrine": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
+			"integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
+		},
+		"@types/fast-levenshtein": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.1.tgz",
+			"integrity": "sha1-OjYVzxc2Rcj8pY0FHk4ygk5L0oY="
+		},
 		"@types/fuzzaldrin": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@types/fuzzaldrin/-/fuzzaldrin-2.1.1.tgz",
 			"integrity": "sha512-KHKQApfuxY67bNVCvRYXEJA/8krvf27T4aA5dTQV8GBx19FKOhcvznbHBVqR7pFJhXZk/yYMWiPEPJ/JVdQ0jQ==",
 			"dev": true
+		},
+		"@types/is-windows": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+			"integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8="
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -46,10 +217,36 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/path-is-inside": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+			"integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw=="
+		},
+		"@types/resolve": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+			"integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/split": {
 			"version": "0.3.28",
 			"resolved": "https://registry.npmjs.org/@types/split/-/split-0.3.28.tgz",
 			"integrity": "sha1-ZtA2Hb2XFbCT1rJ6TJmF2q3Myew=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/ua-parser-js": {
+			"version": "0.7.32",
+			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
+			"integrity": "sha512-+z7Q72Mlnq6SFkQYHzLg2Z70pIsgRVzgx1b5PV8eUv5uaZ/zoqIs45XnhtToW4gTeX4FbjIP49nhIjyvPF4rPg=="
+		},
+		"@types/whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -60,6 +257,19 @@
 			"integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
 			"requires": {
 				"@types/node": "*"
+			}
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
 			}
 		},
 		"argv-tools": {
@@ -79,6 +289,11 @@
 				"typical": "^2.6.1"
 			}
 		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -89,6 +304,92 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
 			"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"requires": {
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"requires": {
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"babylon": {
+					"version": "6.18.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+				}
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+				}
+			}
+		},
+		"babylon": {
+			"version": "7.0.0-beta.47",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+			"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -102,6 +403,49 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"browser-capabilities": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-1.1.0.tgz",
+			"integrity": "sha512-D0AhTybfR0KbVxy1DShQut4eCeluMyJhbTgVTIxvItJKzEGG9pNvOBFZfpeCASo2z0XdfczuvSfNZe/vmNlqwQ==",
+			"requires": {
+				"@types/ua-parser-js": "^0.7.31",
+				"ua-parser-js": "^0.7.15"
+			}
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"camelcase": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+		},
+		"camelcase-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"requires": {
+				"camelcase": "^2.0.0",
+				"map-obj": "^1.0.0"
+			}
+		},
+		"cancel-token": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+			"integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+			"requires": {
+				"@types/node": "^4.0.30"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "4.2.23",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+					"integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w=="
+				}
 			}
 		},
 		"chai": {
@@ -123,6 +467,30 @@
 			"resolved": "https://registry.npmjs.org/chai-subset/-/chai-subset-1.6.0.tgz",
 			"integrity": "sha1-pdDKFOMpp5WW7XAFi2ZGvWmIz+k=",
 			"dev": true
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"requires": {
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
 		},
 		"check-error": {
 			"version": "1.0.2",
@@ -152,8 +520,20 @@
 		"clone": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-			"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-			"dev": true
+			"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+		},
+		"color-convert": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"requires": {
+				"color-name": "1.1.1"
+			}
+		},
+		"color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
 		},
 		"colors": {
 			"version": "1.0.3",
@@ -177,16 +557,52 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
+		"core-js": {
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
+		"css-what": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+		},
+		"cssbeautify": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
+			"integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
+		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"requires": {
+				"array-find-index": "^1.0.1"
+			}
+		},
 		"cycle": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
 			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"deep-eql": {
 			"version": "3.0.1",
@@ -197,10 +613,51 @@
 				"type-detect": "^4.0.0"
 			}
 		},
+		"doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"requires": {
+				"esutils": "^2.0.2"
+			}
+		},
+		"dom5": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.0.tgz",
+			"integrity": "sha512-PbE+7C4Sh1dHDTLNuSDaMUGD1ivDiSZw0L+a9xVUzUKeQ8w3vdzfKHRA07CxcrFZZOa1SGl2nIJ9T49j63q+bg==",
+			"requires": {
+				"@types/parse5": "^2.2.32",
+				"clone": "^2.1.0",
+				"parse5": "^4.0.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
 		"eyes": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
 			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"find-replace": {
 			"version": "2.0.1",
@@ -209,6 +666,15 @@
 			"requires": {
 				"array-back": "^2.0.0",
 				"test-value": "^3.0.0"
+			}
+		},
+		"find-up": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"requires": {
+				"path-exists": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"fs.realpath": {
@@ -228,6 +694,11 @@
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
 		},
+		"get-stdin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -240,6 +711,47 @@
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.7.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"hosted-git-info": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
+			"integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A=="
+		},
+		"indent": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
+			"integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
+		},
+		"indent-string": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+			"requires": {
+				"repeating": "^2.0.0"
 			}
 		},
 		"inflight": {
@@ -258,6 +770,50 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "^1.0.0"
+			}
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"requires": {
+				"number-is-nan": "^1.0.0"
+			}
+		},
+		"is-potential-custom-element-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+			"integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
 		"isarray": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -269,10 +825,77 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"jsesc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+		},
+		"jsonschema": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+		},
+		"load-json-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"log-symbols": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+			"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+			"requires": {
+				"chalk": "^1.0.0"
+			}
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"requires": {
+				"js-tokens": "^3.0.0"
+			}
+		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"requires": {
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
+			}
+		},
+		"map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 		},
 		"memory-streams": {
 			"version": "0.1.3",
@@ -283,6 +906,23 @@
 				"readable-stream": "~1.0.2"
 			}
 		},
+		"meow": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"requires": {
+				"camelcase-keys": "^2.0.0",
+				"decamelize": "^1.1.2",
+				"loud-rejection": "^1.0.0",
+				"map-obj": "^1.0.1",
+				"minimist": "^1.1.3",
+				"normalize-package-data": "^2.3.4",
+				"object-assign": "^4.0.1",
+				"read-pkg-up": "^1.0.1",
+				"redent": "^1.0.0",
+				"trim-newlines": "^1.0.0"
+			}
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -290,6 +930,45 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
+		},
+		"minimatch-all": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/minimatch-all/-/minimatch-all-1.1.0.tgz",
+			"integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
+			"requires": {
+				"minimatch": "^3.0.2"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -300,10 +979,26 @@
 				"wrappy": "1"
 			}
 		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "^1.2.0"
+			}
+		},
 		"parse5": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+		},
+		"path-exists": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"requires": {
+				"pinkie-promise": "^2.0.0"
+			}
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -311,17 +1006,49 @@
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-			"dev": true
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+		},
+		"path-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
+			}
 		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"requires": {
+				"pinkie": "^2.0.0"
+			}
 		},
 		"plylog": {
 			"version": "0.5.0",
@@ -340,6 +1067,108 @@
 				}
 			}
 		},
+		"polymer-analyzer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.1.tgz",
+			"integrity": "sha512-s1fEMUeUHs7EWZQ5cxL/RL6qzDcYnkJcLeQbNvVD1qOPtxRejGeonq5xsxmb8o7mstzSYb1x0Iba2Bdbfr+PAQ==",
+			"requires": {
+				"@babel/generator": "^7.0.0-beta.42",
+				"@babel/traverse": "^7.0.0-beta.42",
+				"@babel/types": "^7.0.0-beta.42",
+				"@types/babel-generator": "^6.25.1",
+				"@types/babel-traverse": "^6.25.2",
+				"@types/babel-types": "^6.25.1",
+				"@types/babylon": "^6.16.2",
+				"@types/chai-subset": "^1.3.0",
+				"@types/chalk": "^0.4.30",
+				"@types/clone": "^0.1.30",
+				"@types/cssbeautify": "^0.3.1",
+				"@types/doctrine": "^0.0.1",
+				"@types/is-windows": "^0.2.0",
+				"@types/minimatch": "^3.0.1",
+				"@types/node": "^9.6.4",
+				"@types/parse5": "^2.2.34",
+				"@types/path-is-inside": "^1.0.0",
+				"@types/resolve": "0.0.6",
+				"@types/whatwg-url": "^6.4.0",
+				"babylon": "^7.0.0-beta.42",
+				"cancel-token": "^0.1.1",
+				"chalk": "^1.1.3",
+				"clone": "^2.0.0",
+				"cssbeautify": "^0.3.1",
+				"doctrine": "^2.0.2",
+				"dom5": "^3.0.0",
+				"indent": "0.0.2",
+				"is-windows": "^1.0.2",
+				"jsonschema": "^1.1.0",
+				"minimatch": "^3.0.4",
+				"parse5": "^4.0.0",
+				"path-is-inside": "^1.0.2",
+				"resolve": "^1.5.0",
+				"shady-css-parser": "^0.1.0",
+				"stable": "^0.1.6",
+				"strip-indent": "^2.0.0",
+				"vscode-uri": "^1.0.1",
+				"whatwg-url": "^6.4.0"
+			}
+		},
+		"polymer-linter": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/polymer-linter/-/polymer-linter-3.0.0.tgz",
+			"integrity": "sha512-YM6+kE3DmTvVlyXJYDVfgvyi4ZUJIZYF3zl8BHx65SKtyjdRmweUQolB/dQuFiVAY29APyjAWSh/V7fVwgVF4g==",
+			"requires": {
+				"@types/fast-levenshtein": "0.0.1",
+				"@types/parse5": "^2.2.34",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"cancel-token": "^0.1.1",
+				"css-what": "^2.1.0",
+				"dom5": "^3.0.0",
+				"fast-levenshtein": "^2.0.6",
+				"parse5": "^4.0.0",
+				"polymer-analyzer": "^3.0.0",
+				"shady-css-parser": "^0.1.0",
+				"stable": "^0.1.6",
+				"strip-indent": "^2.0.0",
+				"validate-element-name": "^2.1.1"
+			}
+		},
+		"polymer-project-config": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-4.0.1.tgz",
+			"integrity": "sha512-NJjP5gf6tOQ5YY8u0UM3hzrXPF2hpNIIyXCtd5VNCYoRGJdT//UFubyWFDd9Aje09yNWjS1SAfjZIhMgZ5DESg==",
+			"requires": {
+				"@types/node": "^9.6.4",
+				"browser-capabilities": "^1.0.0",
+				"jsonschema": "^1.1.1",
+				"minimatch-all": "^1.1.0",
+				"plylog": "^0.5.0"
+			}
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+		},
+		"read-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"requires": {
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"requires": {
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
+			}
+		},
 		"readable-stream": {
 			"version": "1.0.34",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -352,11 +1181,42 @@
 				"string_decoder": "~0.10.x"
 			}
 		},
+		"redent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"requires": {
+				"indent-string": "^2.1.0",
+				"strip-indent": "^1.0.1"
+			},
+			"dependencies": {
+				"strip-indent": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+					"requires": {
+						"get-stdin": "^4.0.1"
+					}
+				}
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"requires": {
+				"is-finite": "^1.0.0"
+			}
+		},
 		"resolve": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
 			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -371,11 +1231,15 @@
 			"resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
 			"integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA=="
 		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-support": {
 			"version": "0.4.18",
@@ -386,6 +1250,34 @@
 				"source-map": "^0.5.6"
 			}
 		},
+		"spdx-correct": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -393,6 +1285,11 @@
 			"requires": {
 				"through": "2"
 			}
+		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
 		},
 		"stack-trace": {
 			"version": "0.0.10",
@@ -404,6 +1301,35 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
 			"dev": true
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "^0.2.0"
+			}
+		},
+		"strip-indent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+		},
+		"supports-color": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
 		},
 		"test-value": {
 			"version": "3.0.0",
@@ -418,6 +1344,29 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"trim-newlines": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"tsc-then": {
 			"version": "1.1.0",
@@ -447,6 +1396,30 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
 			"integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+		},
+		"ua-parser-js": {
+			"version": "0.7.18",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+		},
+		"validate-element-name": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/validate-element-name/-/validate-element-name-2.1.1.tgz",
+			"integrity": "sha1-j/dffaafc+fFEFiDYhMFCLesZE4=",
+			"requires": {
+				"is-potential-custom-element-name": "^1.0.0",
+				"log-symbols": "^1.0.0",
+				"meow": "^3.7.0"
+			}
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
 		},
 		"vscode-jsonrpc": {
 			"version": "3.6.2",
@@ -480,6 +1453,21 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.5.tgz",
 			"integrity": "sha1-O4majvccN/MFTXm9vdoxx7828g0="
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"whatwg-url": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
 		},
 		"winston": {
 			"version": "2.4.3",


### PR DESCRIPTION
You can verify that there are no audit warnings with the following command (make sure you ran `npm run bootstrap` again to get the correct versions):

```bash
npx lerna exec --stream --scope polymer-editor-service -- npm audit
```