### PR TITLE
Add browser-capabilities entry for Chrome on iOS.

### DIFF
--- a/packages/browser-capabilities/CHANGELOG.md
+++ b/packages/browser-capabilities/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-<!-- ## Unreleased -->
+## Unreleased
+* Chrome for iOS is now handled correctly, by delegating to the corresponding
+  Safari feature matrix.
+* Safari for iOS is handled more accurately, using iOS version.
 <!-- Add new, unreleased changes here. -->
 
 ## [1.1.0] - 2018-05-03

--- a/packages/browser-capabilities/src/browser-capabilities.ts
+++ b/packages/browser-capabilities/src/browser-capabilities.ts
@@ -51,17 +51,6 @@ const browserPredicates: {
   'Chrome': chrome,
   'Chromium': chrome,
   'Chrome Headless': chrome,
-  'ChromeiOS': {
-    // TODO(aomarks) Capabilities for Chrome on iOS. We probably need to use the
-    // WebKit version (engine) rather than the Chrome version. Or both.
-    es2015: () => false,
-    es2016: () => false,
-    es2017: () => false,
-    es2018: () => false,
-    push: () => false,
-    serviceworker: () => false,
-    modules: () => false,
-  },
   'OPR': {
     es2015: since(36),
     es2016: since(45),
@@ -86,16 +75,13 @@ const browserPredicates: {
   // least the OS bit). Be sure to actually test real user agents rather than
   // making assumptions based on release notes.
   'Mobile Safari': {
-    es2015: since(10),
-    es2016: since(10, 3),
-    es2017: since(10, 3),
+    es2015: sinceOS(10),
+    es2016: sinceOS(10, 3),
+    es2017: sinceOS(10, 3),
     es2018: () => false,  // No async iterators
-    push: since(9, 2),
-    serviceworker: since(11, 3),
-    modules: (ua) => {
-      return versionAtLeast([11], parseVersion(ua.getBrowser().version)) &&
-          versionAtLeast([11, 3], parseVersion(ua.getOS().version));
-    },
+    push: sinceOS(9, 2),
+    serviceworker: sinceOS(11, 3),
+    modules: sinceOS(11, 3),
   },
   'Safari': {
     es2015: since(10),
@@ -146,8 +132,8 @@ export function browserCapabilities(userAgent: string): Set<BrowserCapability> {
   const capabilities = new Set<BrowserCapability>();
   let browserName = ua.getBrowser().name || '';
   if (browserName === 'Chrome' && ua.getOS().name === 'iOS') {
-    // Chrome on iOS is really Safari and needs its own entry.
-    browserName = 'ChromeiOS';
+    // Chrome on iOS is really Safari.
+    browserName = 'Mobile Safari';
   }
   const predicates = browserPredicates[browserName] || {};
   for (const capability of Object.keys(predicates) as BrowserCapability[]) {
@@ -194,4 +180,11 @@ export function versionAtLeast(atLeast: number[], version: number[]): boolean {
  */
 function since(...atLeast: number[]): UserAgentPredicate {
   return (ua) => versionAtLeast(atLeast, parseVersion(ua.getBrowser().version));
+}
+
+/**
+ * Make a predicate that checks if the OS version is at least this high.
+ */
+function sinceOS(...atLeast: number[]): UserAgentPredicate {
+  return (ua) => versionAtLeast(atLeast, parseVersion(ua.getOS().version));
 }

--- a/packages/browser-capabilities/src/browser-capabilities.ts
+++ b/packages/browser-capabilities/src/browser-capabilities.ts
@@ -51,6 +51,17 @@ const browserPredicates: {
   'Chrome': chrome,
   'Chromium': chrome,
   'Chrome Headless': chrome,
+  'ChromeiOS': {
+    // TODO(aomarks) Capabilities for Chrome on iOS. We probably need to use the
+    // WebKit version (engine) rather than the Chrome version. Or both.
+    es2015: () => false,
+    es2016: () => false,
+    es2017: () => false,
+    es2018: () => false,
+    push: () => false,
+    serviceworker: () => false,
+    modules: () => false,
+  },
   'OPR': {
     es2015: since(36),
     es2016: since(45),
@@ -133,7 +144,12 @@ const browserPredicates: {
 export function browserCapabilities(userAgent: string): Set<BrowserCapability> {
   const ua = new UAParser(userAgent);
   const capabilities = new Set<BrowserCapability>();
-  const predicates = browserPredicates[ua.getBrowser().name || ''] || {};
+  let browserName = ua.getBrowser().name || '';
+  if (browserName === 'Chrome' && ua.getOS().name === 'iOS') {
+    // Chrome on iOS is really Safari and needs its own entry.
+    browserName = 'ChromeiOS';
+  }
+  const predicates = browserPredicates[browserName] || {};
   for (const capability of Object.keys(predicates) as BrowserCapability[]) {
     if (predicates[capability](ua)) {
       capabilities.add(capability);

--- a/packages/browser-capabilities/src/test/browser-capabilities_test.ts
+++ b/packages/browser-capabilities/src/test/browser-capabilities_test.ts
@@ -77,8 +77,14 @@ suite('capabilities', function() {
 
   test('chrome on iOS is treated like safari mobile', () => {
     assertBrowserCapabilities(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_3 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) CriOS/62.0.3202.70 Mobile/13G34 Safari/601.1.46 ',
+        ['push']);
+    assertBrowserCapabilities(
         'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1',
         ['es2015', 'es2016', 'es2017', 'push']);
+    assertBrowserCapabilities(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) CriOS/63.0.3239.73 Mobile/15E5167f Safari/604.1',
+        ['es2015', 'es2016', 'es2017', 'push', 'serviceworker', 'modules']);
   });
 
   test('parseVersion parses with fallback to -1', () => {

--- a/packages/browser-capabilities/src/test/browser-capabilities_test.ts
+++ b/packages/browser-capabilities/src/test/browser-capabilities_test.ts
@@ -75,13 +75,10 @@ suite('capabilities', function() {
         ['es2015', 'es2016', 'es2017', 'push']);
   });
 
-  test('safari mobile modules capability is predicated on iOS version', () => {
+  test('chrome on iOS is treated like safari mobile', () => {
     assertBrowserCapabilities(
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1',
         ['es2015', 'es2016', 'es2017', 'push']);
-    assertBrowserCapabilities(
-        'Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1',
-        ['es2015', 'es2016', 'es2017', 'push', 'modules']);
   });
 
   test('parseVersion parses with fallback to -1', () => {


### PR DESCRIPTION
Treat Safari on iOS as though it were Safari Mobile. Also use iOS version, instead of Safari version, to better handle Safari Mobile.