### PR TITLE
[analyzer] Resolve `as` style module exports

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Better support for resolving `export {foo as bar}` statements.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.1] - 2018-05-11

--- a/packages/analyzer/src/model/reference.ts
+++ b/packages/analyzer/src/model/reference.ts
@@ -122,6 +122,17 @@ function resolveScopedAt<K extends keyof FeatureKindMap>(
     const exportedIdentifier = getExportedIdentifier(path.node, identifier);
     return resolveThroughImport(path, exportedIdentifier, document, kind);
   }
+
+  // Handle cases like `export {Foo as Bar}`.
+  if (babel.isExportNamedDeclaration(path.node) && !path.node.source) {
+    for (const specifier of path.node.specifiers) {
+      if (specifier.exported.name !== specifier.local.name &&
+          specifier.exported.name === identifier) {
+        return resolveScopedAt(path, specifier.local.name, document, kind);
+      }
+    }
+  }
+
   const statement = esutil.getCanonicalStatement(path);
   if (statement === undefined) {
     return {successful: false, error: undefined};

--- a/packages/analyzer/src/model/reference.ts
+++ b/packages/analyzer/src/model/reference.ts
@@ -123,11 +123,12 @@ function resolveScopedAt<K extends keyof FeatureKindMap>(
     return resolveThroughImport(path, exportedIdentifier, document, kind);
   }
 
-  // Handle cases like `export {Foo as Bar}`.
   if (babel.isExportNamedDeclaration(path.node) && !path.node.source) {
     for (const specifier of path.node.specifiers) {
       if (specifier.exported.name !== specifier.local.name &&
           specifier.exported.name === identifier) {
+        // In cases like `export {foo as bar}`, we need to look for a feature
+        // called `foo` instead of `bar`.
         return resolveScopedAt(path, specifier.local.name, document, kind);
       }
     }

--- a/packages/analyzer/src/test/model/reference_test.ts
+++ b/packages/analyzer/src/test/model/reference_test.ts
@@ -32,7 +32,7 @@ suite('ScannedReference', () => {
     analyzer = (await createForDirectory(fixtureDir)).analyzer;
   });
 
-  test.skip('resolves exports', async () => {
+  test('resolves exports', async () => {
     const filename = 'javascript/exported-class.js';
 
     const analysis = await analyzer.analyze([filename]);
@@ -63,6 +63,7 @@ suite('ScannedReference', () => {
     assert.deepEqual(actual, [
       ['Foo', 'Foo'],
       ['FooAlias', 'Foo'],
+      ['Bar', 'Bar'],
     ]);
   });
 });

--- a/packages/analyzer/src/test/static/javascript/exported-class.js
+++ b/packages/analyzer/src/test/static/javascript/exported-class.js
@@ -1,3 +1,7 @@
 export class Foo {}
 
 export {Foo as FooAlias};
+
+class Bar {}
+
+export {Bar};


### PR DESCRIPTION
Resolves what `foo` is in `export {foo as bar}`.