### PR TITLE
Prepare esm-amd-loader 1.0.2

### DIFF
--- a/packages/esm-amd-loader/CHANGELOG.md
+++ b/packages/esm-amd-loader/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- # Unreleased -->
 <!-- Add new, unreleased changes here. -->
 
+## [1.0.2] - 2018-06-28
+* Update minimized version for latest minifier changes.
+
 ## [1.0.1] - 2018-06-11
 * `import.meta.url` is now correct for scripts defined in HTML imports.
 * Executing the loader twice will no longer invalidate its global state.

--- a/packages/esm-amd-loader/README.md
+++ b/packages/esm-amd-loader/README.md
@@ -2,7 +2,7 @@
 
 # @polymer/esm-amd-loader
 
-A JavaScript library which loads AMD-style modules in the browser in 1.3 KB.
+A JavaScript library which loads AMD-style modules in the browser in 1.4 KB.
 
 ## Contents
 
@@ -110,7 +110,7 @@ Corresponds to an ES module's [`import.meta`][5].
 
 ## Differences from AMD/RequireJS
 
-- Minified and compressed size is 1.3 KB, vs 6.6 KB for RequireJS.
+- Minified and compressed size is 1.4 KB, vs 6.6 KB for RequireJS.
 
 - Only supports specifying dependencies as paths, and does not support
   explicitly naming modules.

--- a/packages/esm-amd-loader/package.json
+++ b/packages/esm-amd-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymer/esm-amd-loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Minimal AMD-style loader for replicating ES module behavior.",
   "homepage": "https://github.com/Polymer/tools/tree/master/packages/esm-amd-loader",
   "repository": "github:Polymer/tools",


### PR DESCRIPTION
Looks like some recent updates in our babel minify dependencies changed our minified output very slightly.

This caused the polyserve test I was running as part of its release in https://github.com/Polymer/tools/pull/558 to fail, since we have a brittle test there that relies on the exact contents. We should make that test less brittle, but in the meantime I'm just going to release the loader first.

Also update the documented size (which is actually due to a recent PR, not the minification change).