### PR TITLE
Update build and linter tsconfig.json because ua-parser-js issues.

### DIFF
--- a/packages/build/tsconfig.json
+++ b/packages/build/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "extends": "../../tsconfig-base.json",
   "compilerOptions": {
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "baseUrl": "./",
+    "paths": {
+      "ua-parser-js": [
+        "node_modules/@types/ua-parser-js",
+        "*"
+      ]
+    }
   },
   "include": [
     "custom_typings/**/*.d.ts",

--- a/packages/linter/tsconfig.json
+++ b/packages/linter/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "extends": "../../tsconfig-base.json",
   "compilerOptions": {
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "baseUrl": "./",
+    "paths": {
+      "ua-parser-js": [
+        "node_modules/@types/ua-parser-js",
+        "*"
+      ]
+    }
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
After an `npm run nuke` and `npm run build` I was getting errors in `polymer-linter` and `polymer-build` about the line in `@types/ua-parser-js` re-declaring an identifier `exported` in the line `export = exported` and it turns out there's a fix for this we had to do in `polyserve` to counter the same problem.  This fix should probably be globally applied in the `tsconfig-base.json` but that turns out to be problematic because of the way paths are calculated and inherited, so for now we'll have this particular patch in 3 places, up until the point they are no longer needed at all, we figure out how to do it in the base config, or we need to add it to yet-another tsconfig.