### PR TITLE
[gen-typescript-declarations] Some incremental modules improvements.

### DIFF
--- a/packages/gen-typescript-declarations/package.json
+++ b/packages/gen-typescript-declarations/package.json
@@ -52,6 +52,6 @@
     "test:unit": "npm run lint && npm run test:setup && npm run build && mocha",
     "test:watch": "tsc-then -- mocha --color",
     "test:setup": "bash scripts/setup-fixtures.sh",
-    "test:make-goldens": "npm run build && scripts/make-goldens.js"
+    "update-goldens": "npm run build && scripts/update-goldens.js"
   }
 }

--- a/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
+++ b/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
@@ -13,7 +13,7 @@
 # installs them for testing.
 #
 # To add a new repo for testing, add it to `fixtures.txt`, run `npm run
-# test:setup && npm run test:make-goldens`.
+# test:setup && npm run update-goldens`.
 
 set -e
 

--- a/packages/gen-typescript-declarations/scripts/update-goldens.js
+++ b/packages/gen-typescript-declarations/scripts/update-goldens.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * This script should be run from `npm run test:make-goldens`. It runs the
+ * This script should be run from `npm run update-goldens`. It runs the
  * TypeScript declarations generator across all repos in the
  * `test/src/fixtures` directory, and writes the output to
  * `test/src/goldens/<fixture>/expected.d.ts`. The results of this script

--- a/packages/gen-typescript-declarations/src/es-modules.ts
+++ b/packages/gen-typescript-declarations/src/es-modules.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import * as analyzer from 'polymer-analyzer';
+
+/**
+ * Return whether an Analyzer document is a JavaScript document which was parsed
+ * as a module.
+ */
+export function isEsModuleDocument(doc: analyzer.Document):
+    doc is analyzer.Document<analyzer.ParsedJavaScriptDocument> {
+  return doc.type === 'js' &&
+      (doc.parsedDocument as analyzer.ParsedJavaScriptDocument)
+          .parsedAsSourceType === 'module';
+}

--- a/packages/gen-typescript-declarations/src/gen-ts.ts
+++ b/packages/gen-typescript-declarations/src/gen-ts.ts
@@ -249,7 +249,7 @@ function handleDocument(
       handleFunction(feature as AnalyzerFunction, root);
     } else if (feature.kinds.has('namespace')) {
       handleNamespace(feature as analyzer.Namespace, root);
-    } else if (feature.kinds.has('import')) {
+    } else if (feature.kinds.has('html-import')) {
       // Sometimes an Analyzer document includes an import feature that is
       // inbound (things that depend on me) instead of outbound (things I
       // depend on). For example, if an HTML file has a <script> tag for a JS

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-button-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-button-behavior.d.ts
@@ -8,8 +8,6 @@
  *   paper-button-behavior.js
  */
 
-/// <reference path="paper-ripple-behavior.d.ts" />
-
 declare namespace Polymer {
 
   interface PaperButtonBehavior {

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-button-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-button-behavior.d.ts
@@ -64,3 +64,5 @@ interface PaperButtonBehavior extends IronButtonState, IronControlState, PaperRi
 }
 
 const PaperButtonBehavior: object;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-checked-element-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-checked-element-behavior.d.ts
@@ -44,3 +44,5 @@ declare function _checkedChanged(): void;
  *    
  */
 declare function _buttonStateChanged(): void;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-checked-element-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-checked-element-behavior.d.ts
@@ -8,9 +8,6 @@
  *   paper-checked-element-behavior.js
  */
 
-/// <reference path="paper-inky-focus-behavior.d.ts" />
-/// <reference path="paper-ripple-behavior.d.ts" />
-
 declare namespace Polymer {
 
   /**

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-inky-focus-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-inky-focus-behavior.d.ts
@@ -8,8 +8,6 @@
  *   paper-inky-focus-behavior.js
  */
 
-/// <reference path="paper-ripple-behavior.d.ts" />
-
 declare namespace Polymer {
 
   /**

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-inky-focus-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-inky-focus-behavior.d.ts
@@ -25,3 +25,5 @@ declare namespace Polymer {
 declare function _focusedChanged(): void;
 
 declare function _createRipple(): any;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-ripple-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-ripple-behavior.d.ts
@@ -122,3 +122,5 @@ declare function hasRipple(): boolean;
 declare function _createRipple(): PaperRippleElement;
 
 declare function _noinkChanged(): void;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-button-3/paper-button.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-button-3/paper-button.d.ts
@@ -23,3 +23,5 @@ declare global {
     "paper-button": PaperButtonElement;
   }
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-button-3/paper-button.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-button-3/paper-button.d.ts
@@ -17,6 +17,9 @@ interface PaperButtonElement extends Polymer.Element, PaperButtonBehavior {
   _calculateElevation(): void;
 }
 
-interface HTMLElementTagNameMap {
-  "paper-button": PaperButtonElement;
+declare global {
+
+  interface HTMLElementTagNameMap {
+    "paper-button": PaperButtonElement;
+  }
 }

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button-animations.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button-animations.d.ts
@@ -12,11 +12,14 @@ interface PaperMenuGrowHeightAnimationElement extends Polymer.Element, NeonAnima
   configure(config: any): any;
 }
 
-interface HTMLElementTagNameMap {
-  "paper-menu-grow-height-animation": PaperMenuGrowHeightAnimationElement;
-  "paper-menu-grow-width-animation": PaperMenuGrowWidthAnimationElement;
-  "paper-menu-shrink-width-animation": PaperMenuShrinkWidthAnimationElement;
-  "paper-menu-shrink-height-animation": PaperMenuShrinkHeightAnimationElement;
+declare global {
+
+  interface HTMLElementTagNameMap {
+    "paper-menu-grow-height-animation": PaperMenuGrowHeightAnimationElement;
+    "paper-menu-grow-width-animation": PaperMenuGrowWidthAnimationElement;
+    "paper-menu-shrink-width-animation": PaperMenuShrinkWidthAnimationElement;
+    "paper-menu-shrink-height-animation": PaperMenuShrinkHeightAnimationElement;
+  }
 }
 
 interface PaperMenuGrowWidthAnimationElement extends Polymer.Element, NeonAnimationBehavior {

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button-animations.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button-animations.d.ts
@@ -33,3 +33,5 @@ interface PaperMenuShrinkWidthAnimationElement extends Polymer.Element, NeonAnim
 interface PaperMenuShrinkHeightAnimationElement extends Polymer.Element, NeonAnimationBehavior {
   configure(config: any): any;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button.d.ts
@@ -8,8 +8,6 @@
  *   paper-menu-button.js
  */
 
-/// <reference path="paper-menu-button-animations.d.ts" />
-
 declare function value(): any;
 
 declare function value(): any;

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button.d.ts
@@ -68,3 +68,5 @@ declare function _openedChanged(opened: boolean, oldOpened: boolean): void;
  * dropdown.
  */
 declare function _disabledChanged(disabled: boolean): void;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/array-selector.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/array-selector.d.ts
@@ -186,6 +186,9 @@ declare class ArraySelector extends
   Polymer.Element) {
 }
 
-interface HTMLElementTagNameMap {
-  "array-selector": ArraySelector;
+declare global {
+
+  interface HTMLElementTagNameMap {
+    "array-selector": ArraySelector;
+  }
 }

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/array-selector.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/array-selector.d.ts
@@ -8,11 +8,6 @@
  *   lib/elements/array-selector.js
  */
 
-/// <reference path="../../polymer-element.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-/// <reference path="../utils/array-splice.d.ts" />
-/// <reference path="../mixins/element-mixin.d.ts" />
-
 
 /**
  * Element mixin for recording dynamic associations between item paths in a

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/array-selector.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/array-selector.d.ts
@@ -192,3 +192,5 @@ declare global {
     "array-selector": ArraySelector;
   }
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/custom-style.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/custom-style.d.ts
@@ -8,8 +8,6 @@
  *   lib/elements/custom-style.js
  */
 
-/// <reference path="../utils/style-gather.d.ts" />
-
 /**
  * Custom element for defining styles in the main document that can take
  * advantage of [shady DOM](https://github.com/webcomponents/shadycss) shims

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/custom-style.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/custom-style.d.ts
@@ -61,6 +61,9 @@ declare class CustomStyle extends HTMLElement {
   getStyle(): HTMLStyleElement|null;
 }
 
-interface HTMLElementTagNameMap {
-  "custom-style": CustomStyle;
+declare global {
+
+  interface HTMLElementTagNameMap {
+    "custom-style": CustomStyle;
+  }
 }

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/custom-style.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/custom-style.d.ts
@@ -67,3 +67,5 @@ declare global {
     "custom-style": CustomStyle;
   }
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-bind.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-bind.d.ts
@@ -34,6 +34,9 @@ declare class DomBind extends
   render(): void;
 }
 
-interface HTMLElementTagNameMap {
-  "dom-bind": DomBind;
+declare global {
+
+  interface HTMLElementTagNameMap {
+    "dom-bind": DomBind;
+  }
 }

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-bind.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-bind.d.ts
@@ -40,3 +40,5 @@ declare global {
     "dom-bind": DomBind;
   }
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-bind.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-bind.d.ts
@@ -8,11 +8,6 @@
  *   lib/elements/dom-bind.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../mixins/property-effects.d.ts" />
-/// <reference path="../mixins/mutable-data.d.ts" />
-/// <reference path="../mixins/gesture-event-listeners.d.ts" />
-
 /**
  * Custom element to allow using Polymer's template features (data binding,
  * declarative event listeners, etc.) in the main document without defining

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-if.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-if.d.ts
@@ -8,13 +8,6 @@
  *   lib/elements/dom-if.js
  */
 
-/// <reference path="../../polymer-element.d.ts" />
-/// <reference path="../utils/templatize.d.ts" />
-/// <reference path="../utils/debounce.d.ts" />
-/// <reference path="../utils/flush.d.ts" />
-/// <reference path="../utils/async.d.ts" />
-/// <reference path="../utils/path.d.ts" />
-
 /**
  * The `<dom-if>` element will stamp a light-dom `<template>` child when
  * the `if` property becomes truthy, and the template can use Polymer

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-if.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-if.d.ts
@@ -58,6 +58,9 @@ declare class DomIf extends PolymerElement {
   _showHideChildren(): void;
 }
 
-interface HTMLElementTagNameMap {
-  "dom-if": DomIf;
+declare global {
+
+  interface HTMLElementTagNameMap {
+    "dom-if": DomIf;
+  }
 }

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-if.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-if.d.ts
@@ -64,3 +64,5 @@ declare global {
     "dom-if": DomIf;
   }
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-module.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-module.d.ts
@@ -78,3 +78,5 @@ declare global {
     "dom-module": DomModule;
   }
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-module.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-module.d.ts
@@ -72,6 +72,9 @@ declare class DomModule extends HTMLElement {
   register(id?: string): void;
 }
 
-interface HTMLElementTagNameMap {
-  "dom-module": DomModule;
+declare global {
+
+  interface HTMLElementTagNameMap {
+    "dom-module": DomModule;
+  }
 }

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-module.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-module.d.ts
@@ -8,9 +8,6 @@
  *   lib/elements/dom-module.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/resolve-url.d.ts" />
-
 /**
  * The `dom-module` element registers the dom it contains to the name given
  * by the module's id attribute. It provides a unified database of dom

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-repeat.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-repeat.d.ts
@@ -267,6 +267,9 @@ declare class DomRepeat extends
   modelForElement(el: HTMLElement): TemplateInstanceBase|null;
 }
 
-interface HTMLElementTagNameMap {
-  "dom-repeat": DomRepeat;
+declare global {
+
+  interface HTMLElementTagNameMap {
+    "dom-repeat": DomRepeat;
+  }
 }

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-repeat.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-repeat.d.ts
@@ -8,14 +8,6 @@
  *   lib/elements/dom-repeat.js
  */
 
-/// <reference path="../../polymer-element.d.ts" />
-/// <reference path="../utils/templatize.d.ts" />
-/// <reference path="../utils/debounce.d.ts" />
-/// <reference path="../utils/flush.d.ts" />
-/// <reference path="../mixins/mutable-data.d.ts" />
-/// <reference path="../utils/path.d.ts" />
-/// <reference path="../utils/async.d.ts" />
-
 /**
  * The `<dom-repeat>` element will automatically stamp and binds one instance
  * of template content to each object in a user-provided array.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-repeat.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-repeat.d.ts
@@ -273,3 +273,5 @@ declare global {
     "dom-repeat": DomRepeat;
   }
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/class.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/class.d.ts
@@ -8,9 +8,6 @@
  *   lib/legacy/class.js
  */
 
-/// <reference path="legacy-element-mixin.d.ts" />
-/// <reference path="../elements/dom-module.d.ts" />
-
 
 /**
  * Applies a "legacy" behavior or array of behaviors to the provided class.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/class.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/class.d.ts
@@ -108,3 +108,5 @@ declare class PolymerGenerated {
  * @returns Generated class
  */
 declare function Class(info: PolymerInit): {new(): HTMLElement};
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
@@ -602,3 +602,5 @@ interface LegacyElementMixin {
    */
   _logf(methodName: string, ...args: any[]): any[]|null;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
@@ -8,18 +8,6 @@
  *   lib/legacy/legacy-element-mixin.js
  */
 
-/// <reference path="../mixins/element-mixin.d.ts" />
-/// <reference path="../mixins/gesture-event-listeners.d.ts" />
-/// <reference path="../mixins/dir-mixin.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-/// <reference path="../utils/render-status.d.ts" />
-/// <reference path="../utils/unresolved.d.ts" />
-/// <reference path="polymer.dom.d.ts" />
-/// <reference path="../utils/gestures.d.ts" />
-/// <reference path="../utils/debounce.d.ts" />
-/// <reference path="../utils/async.d.ts" />
-/// <reference path="../utils/path.d.ts" />
-
 
 /**
  * Element class mixin that provides Polymer's "legacy" API intended to be

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/mutable-data-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/mutable-data-behavior.d.ts
@@ -160,3 +160,5 @@ const OptionalMutableDataBehavior: object;
  * @returns Whether the property should be considered a change
  */
 declare function _shouldPropertyChange(property: string, value: any, old: any): boolean;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/mutable-data-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/mutable-data-behavior.d.ts
@@ -8,8 +8,6 @@
  *   lib/legacy/mutable-data-behavior.js
  */
 
-/// <reference path="../mixins/mutable-data.d.ts" />
-
 /**
  * Legacy element behavior to skip strict dirty-checking for objects and arrays,
  * (always consider them to be "dirty") for use on legacy API Polymer elements.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer-fn.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer-fn.d.ts
@@ -23,3 +23,5 @@
  * @returns Generated class
  */
 declare function Polymer(info: PolymerInit): {new(): HTMLElement};
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer-fn.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer-fn.d.ts
@@ -8,9 +8,6 @@
  *   lib/legacy/polymer-fn.js
  */
 
-/// <reference path="class.d.ts" />
-/// <reference path="../utils/boot.d.ts" />
-
 
 /**
  * Legacy class factory and registration helper for defining Polymer

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer.dom.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer.dom.d.ts
@@ -8,11 +8,6 @@
  *   lib/legacy/polymer.dom.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/settings.d.ts" />
-/// <reference path="../utils/flattened-nodes-observer.d.ts" />
-/// <reference path="../utils/flush.d.ts" />
-
 
 /**
  * Cross-platform `element.matches` shim.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer.dom.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer.dom.d.ts
@@ -163,3 +163,5 @@ declare class EventApi {
  * @returns Wrapper providing either node API or event API
  */
 declare function dom(obj?: Node|Event|null): DomApi|EventApi;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/templatizer-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/templatizer-behavior.d.ts
@@ -144,3 +144,5 @@ declare function stamp(model?: object|null): TemplateInstanceBase|null;
  *   the element.
  */
 declare function modelForElement(el: HTMLElement|null): TemplateInstanceBase|null;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/templatizer-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/templatizer-behavior.d.ts
@@ -8,8 +8,6 @@
  *   lib/legacy/templatizer-behavior.js
  */
 
-/// <reference path="../utils/templatize.d.ts" />
-
 /**
  * The `Templatizer` behavior adds methods to generate instances of
  * templates that are each managed by an anonymous `PropertyEffects`

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/dir-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/dir-mixin.d.ts
@@ -48,3 +48,5 @@ interface DirMixin {
   connectedCallback(): void;
   disconnectedCallback(): void;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/dir-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/dir-mixin.d.ts
@@ -8,9 +8,6 @@
  *   lib/mixins/dir-mixin.js
  */
 
-/// <reference path="property-accessors.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-
 
 /**
  * Element class mixin that allows elements to use the `:dir` CSS Selector to

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/disable-upgrade-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/disable-upgrade-mixin.d.ts
@@ -8,9 +8,6 @@
  *   lib/mixins/disable-upgrade-mixin.js
  */
 
-/// <reference path="element-mixin.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-
 
 /**
  * Element class mixin that allows the element to boot up in a non-enabled

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/disable-upgrade-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/disable-upgrade-mixin.d.ts
@@ -42,3 +42,5 @@ interface DisableUpgradeMixin {
   connectedCallback(): void;
   disconnectedCallback(): void;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
@@ -240,3 +240,5 @@ declare function dumpRegistrations(): void;
  * These properties are retained unless a value of `null` is set.
  */
 declare function updateStyles(props?: object|null): void;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
@@ -8,15 +8,6 @@
  *   lib/mixins/element-mixin.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/settings.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-/// <reference path="../utils/style-gather.d.ts" />
-/// <reference path="../utils/resolve-url.d.ts" />
-/// <reference path="../elements/dom-module.d.ts" />
-/// <reference path="property-effects.d.ts" />
-/// <reference path="properties-mixin.d.ts" />
-
 
 /**
  * Element class mixin that provides the core API for Polymer's meta-programming

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/gesture-event-listeners.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/gesture-event-listeners.d.ts
@@ -8,10 +8,6 @@
  *   lib/mixins/gesture-event-listeners.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-/// <reference path="../utils/gestures.d.ts" />
-
 
 /**
  * Element class mixin that provides API for adding Polymer's cross-platform

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/gesture-event-listeners.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/gesture-event-listeners.d.ts
@@ -44,3 +44,5 @@ interface GestureEventListeners {
    */
   _removeEventListenerFromNode(node: Node, eventName: string, handler: (p0: Event) => void): void;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/mutable-data.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/mutable-data.d.ts
@@ -140,3 +140,5 @@ interface OptionalMutableData {
    */
   _shouldPropertyChange(property: string, value: any, old: any): boolean;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/mutable-data.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/mutable-data.d.ts
@@ -8,8 +8,6 @@
  *   lib/mixins/mutable-data.js
  */
 
-/// <reference path="../utils/mixin.d.ts" />
-
 
 /**
  * Element class mixin to skip strict dirty-checking for objects and arrays

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-changed.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-changed.d.ts
@@ -8,10 +8,6 @@
  *   lib/mixins/properties-changed.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-/// <reference path="../utils/async.d.ts" />
-
 
 /**
  * Element class mixin that provides basic meta-programming for creating one

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-changed.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-changed.d.ts
@@ -296,3 +296,5 @@ interface PropertiesChanged {
    */
   _deserializeValue(value: string|null, type?: any): any;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-mixin.d.ts
@@ -8,10 +8,6 @@
  *   lib/mixins/properties-mixin.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-/// <reference path="properties-changed.d.ts" />
-
 
 /**
  * Mixin that provides a minimal starting point to using the PropertiesChanged

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-mixin.d.ts
@@ -70,3 +70,5 @@ interface PropertiesMixin {
    */
   disconnectedCallback(): void;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-accessors.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-accessors.d.ts
@@ -142,3 +142,5 @@ interface PropertyAccessors {
    */
   _isPropertyPending(prop: string): boolean;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-accessors.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-accessors.d.ts
@@ -8,11 +8,6 @@
  *   lib/mixins/property-accessors.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-/// <reference path="../utils/case-map.d.ts" />
-/// <reference path="properties-changed.d.ts" />
-
 
 /**
  * Element class mixin that provides basic meta-programming for creating one

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
@@ -840,3 +840,5 @@ interface PropertyEffects {
    */
   _removeBoundDom(dom: StampedTemplate): void;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
@@ -8,14 +8,6 @@
  *   lib/mixins/property-effects.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-/// <reference path="../utils/path.d.ts" />
-/// <reference path="../utils/case-map.d.ts" />
-/// <reference path="property-accessors.d.ts" />
-/// <reference path="template-stamp.d.ts" />
-/// <reference path="../utils/settings.d.ts" />
-
 
 /**
  * Element class mixin that provides meta-programming for Polymer's template

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/strict-binding-parser.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/strict-binding-parser.d.ts
@@ -8,11 +8,6 @@
  *   lib/mixins/strict-binding-parser.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/path.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-/// <reference path="property-effects.d.ts" />
-
 
 /**
  * Mixin that parses binding expressions and generates corresponding metadata.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/strict-binding-parser.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/strict-binding-parser.d.ts
@@ -57,3 +57,5 @@ interface StrictBindingParserConstructor {
 
 interface StrictBindingParser {
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
@@ -250,3 +250,5 @@ interface TemplateStamp {
    */
   _removeEventListenerFromNode(node: Node|null, eventName: string, handler: (p0: Event) => void): void;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
@@ -8,9 +8,6 @@
  *   lib/mixins/template-stamp.js
  */
 
-/// <reference path="../utils/boot.d.ts" />
-/// <reference path="../utils/mixin.d.ts" />
-
 
 /**
  * Element mixin that provides basic template parsing and stamping, including

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/array-splice.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/array-splice.d.ts
@@ -36,3 +36,5 @@
  * of items added at this location.
  */
 declare function calculateSplices(current: any[], previous: any[]): any[];
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/array-splice.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/array-splice.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/array-splice.js
  */
 
-/// <reference path="boot.d.ts" />
-
 
 /**
  * Returns an array of splice records indicating the minimum edits required

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/async.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/async.d.ts
@@ -103,3 +103,5 @@ declare namespace microTask {
    */
   function cancel(handle: number): void;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/async.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/async.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/async.js
  */
 
-/// <reference path="boot.d.ts" />
-
 /**
  * Async interface wrapper around `setTimeout`.
  */

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/case-map.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/case-map.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/case-map.js
  */
 
-/// <reference path="boot.d.ts" />
-
 
 /**
  * Converts "dash-case" identifier (e.g. `foo-bar-baz`) to "camelCase"

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/case-map.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/case-map.d.ts
@@ -25,3 +25,5 @@ declare function dashToCamelCase(dash: string): string;
  * @returns Dash-case representation of the identifier
  */
 declare function camelToDashCase(camel: string): string;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/debounce.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/debounce.d.ts
@@ -8,10 +8,6 @@
  *   lib/utils/debounce.js
  */
 
-/// <reference path="boot.d.ts" />
-/// <reference path="mixin.d.ts" />
-/// <reference path="async.d.ts" />
-
 declare class Debouncer {
   constructor();
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/debounce.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/debounce.d.ts
@@ -74,3 +74,5 @@ declare class Debouncer {
    */
   isActive(): boolean;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flattened-nodes-observer.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flattened-nodes-observer.d.ts
@@ -94,3 +94,5 @@ declare class FlattenedNodesObserver {
    */
   flush(): boolean;
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flattened-nodes-observer.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flattened-nodes-observer.d.ts
@@ -8,10 +8,6 @@
  *   lib/utils/flattened-nodes-observer.js
  */
 
-/// <reference path="boot.d.ts" />
-/// <reference path="array-splice.d.ts" />
-/// <reference path="async.d.ts" />
-
 /**
  * Class that listens for changes (additions or removals) to
  * "flattened nodes" on a given `node`. The list of flattened nodes consists

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flush.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flush.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/flush.js
  */
 
-/// <reference path="boot.d.ts" />
-
 
 /**
  * Adds a `Debouncer` to a list of globally flushable tasks.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flush.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flush.d.ts
@@ -21,3 +21,5 @@ declare function enqueueDebouncer(debouncer: Debouncer): void;
  * - ShadyDOM distribution
  */
 declare function flush(): void;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/gestures.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/gestures.d.ts
@@ -67,3 +67,5 @@ declare function prevent(evName: string): void;
  * Calling this method in production may cause duplicate taps or other Gestures.
  */
 declare function resetMouseCanceller(): void;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/gestures.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/gestures.d.ts
@@ -8,11 +8,6 @@
  *   lib/utils/gestures.js
  */
 
-/// <reference path="boot.d.ts" />
-/// <reference path="async.d.ts" />
-/// <reference path="debounce.d.ts" />
-/// <reference path="settings.d.ts" />
-
 
 /**
  * Finds the element rendered on the screen at the provided coordinates.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/html-tag.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/html-tag.d.ts
@@ -82,3 +82,5 @@ declare function html(strings: TemplateStringsArray, ...values: any[]): HTMLTemp
  * @returns Constructed literal string
  */
 declare function htmlLiteral(strings: TemplateStringsArray, ...values: any[]): LiteralString;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/html-tag.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/html-tag.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/html-tag.js
  */
 
-/// <reference path="boot.d.ts" />
-
 /**
  * Class representing a static string value which can be used to filter
  * strings by asseting that they have been created via this class. The

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/mixin.d.ts
@@ -15,3 +15,5 @@
  * applications.
  */
 declare function dedupingMixin<T>(mixin: T): T;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/mixin.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/mixin.js
  */
 
-/// <reference path="boot.d.ts" />
-
 
 /**
  * Wraps an ES6 class expression mixin such that the mixin is only applied

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/path.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/path.d.ts
@@ -144,3 +144,5 @@ declare function get(root: object|null, path: string|Array<string|number>, info?
  * @returns The normalized version of the input path
  */
 declare function set(root: object|null, path: string|Array<string|number>, value: any): string|undefined;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/path.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/path.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/path.js
  */
 
-/// <reference path="boot.d.ts" />
-
 
 /**
  * Returns true if the given string is a structured data path (has dots).

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/render-status.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/render-status.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/render-status.js
  */
 
-/// <reference path="boot.d.ts" />
-
 
 /**
  * Enqueues a callback which will be run before the next render, at

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/render-status.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/render-status.d.ts
@@ -32,3 +32,5 @@ declare function beforeNextRender(context: any, callback: (...p0: any[]) => void
  * event listeners and aria attributes.
  */
 declare function afterNextRender(context: any, callback: (...p0: any[]) => void, args?: any[]): void;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/resolve-url.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/resolve-url.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/resolve-url.js
  */
 
-/// <reference path="boot.d.ts" />
-
 
 /**
  * Resolves the given URL against the provided `baseUri'.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/resolve-url.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/resolve-url.d.ts
@@ -37,3 +37,5 @@ declare function resolveCss(cssText: string, baseURI: string): string;
  * @returns resolved path
  */
 declare function pathFromUrl(url: string): string;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/settings.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/settings.d.ts
@@ -8,9 +8,6 @@
  *   lib/utils/settings.js
  */
 
-/// <reference path="boot.d.ts" />
-/// <reference path="resolve-url.d.ts" />
-
 
 /**
  * Sets the global rootPath property used by `ElementMixin` and

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/settings.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/settings.d.ts
@@ -27,3 +27,5 @@ declare function setSanitizeDOMValue(newSanitizeDOMValue: ((p0: any, p1: string,
  * Sets `passiveTouchGestures` globally for all elements using Polymer Gestures.
  */
 declare function setPassiveTouchGestures(usePassive: boolean): void;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/style-gather.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/style-gather.d.ts
@@ -87,3 +87,5 @@ declare function cssFromTemplate(template: HTMLTemplateElement, baseURI: string)
  * @returns Concatenated CSS content from links in specified `dom-module`
  */
 declare function cssFromModuleImports(moduleId: string): string;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/style-gather.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/style-gather.d.ts
@@ -8,8 +8,6 @@
  *   lib/utils/style-gather.js
  */
 
-/// <reference path="resolve-url.d.ts" />
-
 
 /**
  * Returns a list of <style> elements in a space-separated list of `dom-module`s.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/templatize.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/templatize.d.ts
@@ -173,3 +173,5 @@ declare function templatize(template: HTMLTemplateElement, owner?: Polymer.Prope
  *   binding scope for the element
  */
 declare function modelForElement(template: HTMLTemplateElement|null, node?: Node|null): TemplateInstanceBase|null;
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/templatize.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/templatize.d.ts
@@ -8,10 +8,6 @@
  *   lib/utils/templatize.js
  */
 
-/// <reference path="boot.d.ts" />
-/// <reference path="../mixins/property-effects.d.ts" />
-/// <reference path="../mixins/mutable-data.d.ts" />
-
 declare class TemplateInstanceBase extends
   PropertyEffects(
   Polymer.Element) {

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/polymer-element.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/polymer-element.d.ts
@@ -17,3 +17,5 @@ declare class PolymerElement extends
   ElementMixin(
   HTMLElement) {
 }
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/polymer-element.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/polymer-element.d.ts
@@ -8,9 +8,6 @@
  *   polymer-element.js
  */
 
-/// <reference path="lib/mixins/element-mixin.d.ts" />
-/// <reference path="lib/utils/html-tag.d.ts" />
-
 /**
  * Base class that provides the core API for Polymer's meta-programming
  * features including template stamping, data-binding, attribute deserialization,

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/polymer-legacy.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/polymer-legacy.d.ts
@@ -8,14 +8,3 @@
  *   polymer-legacy.js
  */
 
-/// <reference path="lib/legacy/legacy-element-mixin.d.ts" />
-/// <reference path="lib/legacy/polymer-fn.d.ts" />
-/// <reference path="lib/legacy/templatizer-behavior.d.ts" />
-/// <reference path="lib/elements/dom-bind.d.ts" />
-/// <reference path="lib/elements/dom-repeat.d.ts" />
-/// <reference path="lib/elements/dom-if.d.ts" />
-/// <reference path="lib/elements/array-selector.d.ts" />
-/// <reference path="lib/elements/custom-style.d.ts" />
-/// <reference path="lib/legacy/mutable-data-behavior.d.ts" />
-/// <reference path="lib/utils/html-tag.d.ts" />
-

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/polymer-legacy.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/polymer-legacy.d.ts
@@ -8,3 +8,5 @@
  *   polymer-legacy.js
  */
 
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/serialize_test.ts
+++ b/packages/gen-typescript-declarations/src/test/serialize_test.ts
@@ -203,4 +203,25 @@ declare class MyClass {
 }
 `);
   });
+
+  suite('export', () => {
+    test('locals with aliases', () => {
+      const n = new ts.Export({
+        identifiers: [
+          {identifier: 'Foo'},
+          {identifier: 'Bar', alias: 'BarAlias'},
+          {identifier: 'Baz', alias: 'Baz'},
+        ]
+      });
+      assert.equal(n.serialize(), `export {Foo, Bar as BarAlias, Baz};\n`);
+    });
+
+    test('re-export all', () => {
+      const n = new ts.Export({
+        identifiers: ts.AllIdentifiers,
+        fromModuleSpecifier: './foo.js',
+      });
+      assert.equal(n.serialize(), `export * from './foo.js';\n`);
+    });
+  });
 });

--- a/packages/gen-typescript-declarations/src/ts-ast/declarations.ts
+++ b/packages/gen-typescript-declarations/src/ts-ast/declarations.ts
@@ -14,7 +14,7 @@ import {Node} from './index';
 import {anyType, ParamType, Type} from './types';
 
 // An AST node that can appear directly in a document or namespace.
-export type Declaration = Namespace|Class|Interface|Function|ConstValue;
+export type Declaration = Namespace|Class|Interface|Function|ConstValue|Export;
 
 export class Namespace {
   readonly kind = 'namespace';
@@ -371,5 +371,57 @@ export class ConstValue {
 
   serialize(depth: number = 0): string {
     return `${indent(depth)}const ${this.name}: ${this.type.serialize()};\n`;
+  }
+}
+
+/**
+ * An identifier that is imported or exported, possibly with a different name.
+ */
+export interface ImportExportIdentifier {
+  identifier: string;
+  alias?: string;
+}
+
+/**
+ * The "*" token in an import or export.
+ */
+export const AllIdentifiers = Symbol('*');
+
+/**
+ * A JavaScript module export.
+ */
+export class Export {
+  readonly kind = 'export';
+  identifiers: ImportExportIdentifier[]|typeof AllIdentifiers;
+  fromModuleSpecifier: string;
+
+  constructor(data: {
+    identifiers: ImportExportIdentifier[]|typeof AllIdentifiers,
+    fromModuleSpecifier?: string
+  }) {
+    this.identifiers = data.identifiers;
+    this.fromModuleSpecifier = data.fromModuleSpecifier || '';
+  }
+
+  * traverse(): Iterable<Node> {
+    yield this;
+  }
+
+  serialize(_depth: number = 0): string {
+    let out = 'export ';
+    if (this.identifiers === AllIdentifiers) {
+      out += '*';
+    } else {
+      const specifiers = this.identifiers.map(({identifier, alias}) => {
+        return identifier +
+            (alias !== undefined && alias !== identifier ? ` as ${alias}` : '');
+      });
+      out += `{${specifiers.join(', ')}}`;
+    }
+    if (this.fromModuleSpecifier !== '') {
+      out += ` from '${this.fromModuleSpecifier}'`;
+    }
+    out += ';\n';
+    return out;
   }
 }

--- a/packages/gen-typescript-declarations/src/ts-ast/declarations.ts
+++ b/packages/gen-typescript-declarations/src/ts-ast/declarations.ts
@@ -13,8 +13,34 @@ import {formatComment, indent, quotePropertyName} from './formatting';
 import {Node} from './index';
 import {anyType, ParamType, Type} from './types';
 
-// An AST node that can appear directly in a document or namespace.
-export type Declaration = Namespace|Class|Interface|Function|ConstValue|Export;
+/** An AST node that can appear directly in a document or namespace. */
+export type Declaration =
+    GlobalNamespace|Namespace|Class|Interface|Function|ConstValue|Export;
+
+export class GlobalNamespace {
+  readonly kind = 'globalNamespace';
+  members: Declaration[];
+
+  constructor(members?: Declaration[]) {
+    this.members = members || [];
+  }
+
+  * traverse(): Iterable<Node> {
+    for (const m of this.members) {
+      yield* m.traverse();
+    }
+    yield this;
+  }
+
+  serialize(_depth: number = 0): string {
+    let out = `declare global {\n`;
+    for (const member of this.members) {
+      out += '\n' + member.serialize(1);
+    }
+    out += `}\n`;
+    return out;
+  }
+}
 
 export class Namespace {
   readonly kind = 'namespace';

--- a/packages/gen-typescript-declarations/src/ts-ast/document.ts
+++ b/packages/gen-typescript-declarations/src/ts-ast/document.ts
@@ -11,7 +11,7 @@
 
 import {Declaration} from './declarations';
 import {formatComment} from './formatting';
-import {Node} from './index';
+import {Export, Node} from './index';
 
 export class Document {
   readonly kind = 'document';
@@ -69,6 +69,13 @@ export class Document {
       out += '\n';
     }
     out += this.members.map((m) => m.serialize()).join('\n');
+    // If these are typings for an ES module, we want to be sure that TypeScript
+    // will treat them as one too, which requires at least one import or export.
+    // TODO(aomarks) Also check for imports when defined.
+    if (this.isEsModule === true &&
+        !this.members.some((m) => m.kind === 'export')) {
+      out += '\n' + (new Export({identifiers: []})).serialize();
+    }
     return out;
   }
 }

--- a/packages/gen-typescript-declarations/src/ts-ast/document.ts
+++ b/packages/gen-typescript-declarations/src/ts-ast/document.ts
@@ -19,17 +19,20 @@ export class Document {
   members: Declaration[];
   referencePaths: Set<string>;
   header: string;
+  isEsModule: boolean;
 
   constructor(data: {
     path: string,
     members?: Declaration[],
     referencePaths?: Iterable<string>,
-    header?: string
+    header?: string,
+    isEsModule?: boolean,
   }) {
     this.path = data.path;
     this.members = data.members || [];
     this.referencePaths = new Set(Array.from(data.referencePaths || []));
     this.header = data.header || '';
+    this.isEsModule = data.isEsModule || false;
   }
 
   /**


### PR DESCRIPTION
- Support serializing export declarations.
- Don't treat ES module imports as HTML imports.
- Rename `update-goldens` script so it runs at top-level.
- Declare `HTMLElementTagNameMap` in global namespace for modules.