### PR TITLE
Allow minify skipping by file glob.

### DIFF
--- a/packages/cli/src/build/build.ts
+++ b/packages/cli/src/build/build.ts
@@ -83,22 +83,6 @@ export async function build(
                 }));
   }
 
-  if (bundled) {
-    // Polymer 1.x and Polymer 2.x deal with relative urls in dom-module
-    // templates differently.  Polymer CLI will attempt to provide a sensible
-    // default value for the `rewriteUrlsInTemplates` option passed to
-    // `polymer-bundler` based on the version of Polymer found in the project's
-    // folders.  We will default to Polymer 1.x behavior unless 2.x is found.
-    const polymerVersion = await getPolymerVersion();
-    const bundlerOptions = {
-      rewriteUrlsInTemplates: !polymerVersion.startsWith('2.')
-    };
-    if (typeof options.bundle === 'object') {
-      Object.assign(bundlerOptions, options.bundle);
-    }
-    buildStream = buildStream.pipe(polymerProject.bundler(bundlerOptions));
-  }
-
   const htmlSplitter = new HtmlSplitter();
 
   buildStream = pipeStreams([
@@ -127,6 +111,22 @@ export async function build(
     logger.info(`(${buildName}) Building...`);
   });
 
+  if (bundled) {
+    // Polymer 1.x and Polymer 2.x deal with relative urls in dom-module
+    // templates differently.  Polymer CLI will attempt to provide a sensible
+    // default value for the `rewriteUrlsInTemplates` option passed to
+    // `polymer-bundler` based on the version of Polymer found in the project's
+    // folders.  We will default to Polymer 1.x behavior unless 2.x is found.
+    const polymerVersion = await getPolymerVersion();
+    const bundlerOptions = {
+      rewriteUrlsInTemplates: !polymerVersion.startsWith('2.')
+    };
+    if (typeof options.bundle === 'object') {
+      Object.assign(bundlerOptions, options.bundle);
+    }
+    buildStream = buildStream.pipe(polymerProject.bundler(bundlerOptions));
+  }
+  
   if (options.basePath) {
     let basePath = options.basePath === true ? buildName : options.basePath;
     if (!basePath.startsWith('/')) {

--- a/packages/cli/src/build/build.ts
+++ b/packages/cli/src/build/build.ts
@@ -84,7 +84,6 @@ export async function build(
   }
 
   const htmlSplitter = new HtmlSplitter();
-
   buildStream = pipeStreams([
     buildStream,
     htmlSplitter.split(),
@@ -103,14 +102,6 @@ export async function build(
     htmlSplitter.rejoin()
   ]);
 
-  if (options.insertPrefetchLinks) {
-    buildStream = buildStream.pipe(polymerProject.addPrefetchLinks());
-  }
-
-  buildStream.once('data', () => {
-    logger.info(`(${buildName}) Building...`);
-  });
-
   if (bundled) {
     // Polymer 1.x and Polymer 2.x deal with relative urls in dom-module
     // templates differently.  Polymer CLI will attempt to provide a sensible
@@ -126,7 +117,15 @@ export async function build(
     }
     buildStream = buildStream.pipe(polymerProject.bundler(bundlerOptions));
   }
-  
+
+  if (options.insertPrefetchLinks) {
+    buildStream = buildStream.pipe(polymerProject.addPrefetchLinks());
+  }
+
+  buildStream.once('data', () => {
+    logger.info(`(${buildName}) Building...`);
+  });
+
   if (options.basePath) {
     let basePath = options.basePath === true ? buildName : options.basePath;
     if (!basePath.startsWith('/')) {


### PR DESCRIPTION
Allow JS files to be see as `isInline === false` so that they will skip the minifier.

When working with a Polymer 2 project that includes the Firebase and PolymerFire code, the minification processing delivers those projects with errors. This can be avoided by not minifying those files. With the updates to support Polymer 3, all files were being viewed as `isInline` and as such were not being tested for whether they should or shouldn't be minified. This corrects the code order so that files that are not `isInline` can be seen as such and can be tested for exclusion from the minification pipeline.

Fixes https://github.com/Polymer/tools/issues/279