### PR TITLE
Polymer-Cli  && Google Cloud Shell

### DIFF
--- a/packages/cli/templates/application/polymer-3.x/index.html
+++ b/packages/cli/templates/application/polymer-3.x/index.html
@@ -14,7 +14,7 @@
 
     <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 
-    <script type="module" src="/src/<%= elementName %>/<%= elementName %>.js"></script>
+    <script type="module" src="/src/<%= elementName %>/<%= elementName %>.js" crossorigin></script>
   </head>
   <body>
     <<%= elementName %>></<%= elementName %>>


### PR DESCRIPTION
Purpose: Add crossorigin into scritp type=module tag inside  polymer-cli application template polymer-3.x to address issue with cli not working out of the box in Google Cloud Shell.

Reason: Lately, I've been doing some web dev on my chromebook and have been using Google Cloud Shell and Google Cloud Shell editor a lot. Whenever I've used polymer-cli to generate a project, I've had to make the above change to get it to work in the Web Previewer in Google Cloud Shell. I figured by throwing out a PR  I could save someone else a little bit of time.

I noticed a similar PR [here](https://github.com/Polymer/pwa-starter-kit/pull/105) with the associated issue and discussion [here](https://github.com/Polymer/pwa-starter-kit/issues/89). I assume that the same points about this not being a security concern are valid here as well. If it is a concern I'd love to hear why and learn something new.