### PR TITLE
[gen-typescript-declarations] More progress towards Polymer 3.0 typings.

### DIFF
--- a/packages/gen-typescript-declarations/CHANGELOG.md
+++ b/packages/gen-typescript-declarations/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Warnings are now printed with file names, line numbers, and code snippets.
 - Add `autoImport` config option to automatically add ES module imports when
   particular identifiers are referenced.
+- Automatically detect if a project uses NPM or Bower and configure module
+  resolution settings accordingly.
 
 ## [1.3.0] - 2018-06-29
 - Generate typings for class constructors.

--- a/packages/gen-typescript-declarations/CHANGELOG.md
+++ b/packages/gen-typescript-declarations/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   particular identifiers are referenced.
 - Automatically detect if a project uses NPM or Bower and configure module
   resolution settings accordingly.
+- Automatically import/export synthetic mixin constructor interfaces.
 
 ## [1.3.0] - 2018-06-29
 - Generate typings for class constructors.

--- a/packages/gen-typescript-declarations/CHANGELOG.md
+++ b/packages/gen-typescript-declarations/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Support for ES module imports and exports.
 - Warnings are now printed with file names, line numbers, and code snippets.
+- Add `autoImport` config option to automatically add ES module imports when
+  particular identifiers are referenced.
 
 ## [1.3.0] - 2018-06-29
 - Generate typings for class constructors.

--- a/packages/gen-typescript-declarations/scripts/fixtures.txt
+++ b/packages/gen-typescript-declarations/scripts/fixtures.txt
@@ -5,4 +5,4 @@ https://github.com/PolymerElements/paper-button.git e29e692e00839adcd94cfa08a3cd
 https://github.com/PolymerElements/paper-menu-button.git v2.0.0 paper-menu-button-2
 https://github.com/PolymerElements/paper-menu-button.git 4dd8ac9107c25340b77c2ad27f8f11660eddb661 paper-menu-button-3
 https://github.com/Polymer/polymer.git v2.5.0 polymer-2
-https://github.com/Polymer/polymer.git v3.0.2 polymer-3
+https://github.com/Polymer/polymer.git 0c465776b78a571393e6e25fb1949674175d80bd polymer-3

--- a/packages/gen-typescript-declarations/scripts/fixtures.txt
+++ b/packages/gen-typescript-declarations/scripts/fixtures.txt
@@ -1,8 +1,8 @@
 https://github.com/PolymerElements/paper-behaviors.git v2.0.1 paper-behaviors-2
-https://github.com/PolymerElements/paper-behaviors.git __auto_generated_3.0_preview paper-behaviors-3
+https://github.com/PolymerElements/paper-behaviors.git 28cf765323b8c7fe4440752968c651ccc1b16768 paper-behaviors-3
 https://github.com/PolymerElements/paper-button.git v2.0.0 paper-button-2
-https://github.com/PolymerElements/paper-button.git __auto_generated_3.0_preview paper-button-3
+https://github.com/PolymerElements/paper-button.git e29e692e00839adcd94cfa08a3cd6b4165f3619e paper-button-3
 https://github.com/PolymerElements/paper-menu-button.git v2.0.0 paper-menu-button-2
-https://github.com/PolymerElements/paper-menu-button.git __auto_generated_3.0_preview paper-menu-button-3
+https://github.com/PolymerElements/paper-menu-button.git 4dd8ac9107c25340b77c2ad27f8f11660eddb661 paper-menu-button-3
 https://github.com/Polymer/polymer.git v2.5.0 polymer-2
 https://github.com/Polymer/polymer.git v3.0.2 polymer-3

--- a/packages/gen-typescript-declarations/scripts/fixtures.txt
+++ b/packages/gen-typescript-declarations/scripts/fixtures.txt
@@ -5,4 +5,4 @@ https://github.com/PolymerElements/paper-button.git e29e692e00839adcd94cfa08a3cd
 https://github.com/PolymerElements/paper-menu-button.git v2.0.0 paper-menu-button-2
 https://github.com/PolymerElements/paper-menu-button.git 4dd8ac9107c25340b77c2ad27f8f11660eddb661 paper-menu-button-3
 https://github.com/Polymer/polymer.git v2.5.0 polymer-2
-https://github.com/Polymer/polymer.git 0c465776b78a571393e6e25fb1949674175d80bd polymer-3
+https://github.com/Polymer/polymer.git b33c934b9e38a268524f8281b2205d2a18b613a3 polymer-3

--- a/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
+++ b/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
@@ -21,10 +21,12 @@ cd src/test
 mkdir -p fixtures
 cd fixtures
 
-while read -r repo tag dir; do
+while read -r repo commitish dir; do
   if [ -d $dir ]; then continue; fi  # Already set up.
-  git clone $repo --single-branch --depth 1 --branch $tag $dir
+  # Note you can't do a shallow clone of a SHA.
+  git clone $repo $dir
   cd $dir
+  git checkout $commitish
   if [ -e package.json ]; then
     npm install --production
   elif [ -e bower.json ]; then

--- a/packages/gen-typescript-declarations/src/gen-ts.ts
+++ b/packages/gen-typescript-declarations/src/gen-ts.ts
@@ -538,8 +538,7 @@ class TypeGenerator {
         new ts.NameType('T'),
         new ts.NameType(constructorName),
         ...[...transitiveMixins].map(
-            (mixin) =>
-                new ts.NameType([...mixin.identifiers][0] + 'Constructor'))
+            (mixin) => new ts.NameType(mixin.name + 'Constructor'))
       ]),
     }));
 
@@ -561,8 +560,7 @@ class TypeGenerator {
         const fromModuleSpecifier =
             fileRelative.startsWith('.') ? fileRelative : './' + fileRelative;
         this.root.members.push(new ts.Import({
-          identifiers:
-              [{identifier: [...mixin.identifiers][0] + 'Constructor'}],
+          identifiers: [{identifier: mixin.name + 'Constructor'}],
           fromModuleSpecifier,
         }));
       }

--- a/packages/gen-typescript-declarations/src/gen-ts.ts
+++ b/packages/gen-typescript-declarations/src/gen-ts.ts
@@ -11,6 +11,7 @@
 
 import * as babel from '@babel/types';
 import * as jsdoc from 'doctrine';
+import * as fsExtra from 'fs-extra';
 import * as minimatch from 'minimatch';
 import * as path from 'path';
 import * as analyzer from 'polymer-analyzer';
@@ -87,9 +88,17 @@ const defaultExclude = [
  */
 export async function generateDeclarations(
     rootDir: string, config: Config): Promise<Map<string, string>> {
+  // Note that many Bower projects also have a node_modules/, but the reverse is
+  // unlikely.
+  const isBowerProject =
+      await fsExtra.pathExists(path.join(rootDir, 'bower_components')) === true;
   const a = new analyzer.Analyzer({
     urlLoader: new analyzer.FsUrlLoader(rootDir),
-    urlResolver: new analyzer.PackageUrlResolver({packageDir: rootDir}),
+    urlResolver: new analyzer.PackageUrlResolver({
+      packageDir: rootDir,
+      componentDir: isBowerProject ? 'bower_components/' : 'node_modules/',
+    }),
+    moduleResolution: isBowerProject ? undefined : 'node',
   });
   const analysis = await a.analyzePackage();
   const outFiles = new Map<string, string>();

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-button-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-button-behavior.d.ts
@@ -8,7 +8,11 @@
  *   paper-button-behavior.js
  */
 
+import {IronButtonStateImpl, IronButtonState} from '@polymer/iron-behaviors/iron-button-state.js';
+
 import {PaperRippleBehavior} from './paper-ripple-behavior.js';
+
+import {IronControlState} from '@polymer/iron-behaviors/iron-control-state.js';
 
 export {PaperButtonBehaviorImpl};
 

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-button-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-button-behavior.d.ts
@@ -73,4 +73,4 @@ export {PaperButtonBehavior};
 interface PaperButtonBehavior extends IronButtonState, IronControlState, PaperRippleBehavior, PaperButtonBehaviorImpl {
 }
 
-const PaperButtonBehavior: object;
+declare const PaperButtonBehavior: object;

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-checked-element-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-checked-element-behavior.d.ts
@@ -8,6 +8,8 @@
  *   paper-checked-element-behavior.js
  */
 
+import {IronCheckedElementBehaviorImpl} from '@polymer/iron-checked-element-behavior/iron-checked-element-behavior.js';
+
 import {PaperRippleBehavior} from './paper-ripple-behavior.js';
 
 export {PaperCheckedElementBehaviorImpl};

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-inky-focus-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-inky-focus-behavior.d.ts
@@ -8,7 +8,11 @@
  *   paper-inky-focus-behavior.js
  */
 
+import {IronButtonState} from '@polymer/iron-behaviors/iron-button-state.js';
+
 import {PaperRippleBehavior} from './paper-ripple-behavior.js';
+
+import {IronControlState} from '@polymer/iron-behaviors/iron-control-state.js';
 
 export {PaperInkyFocusBehaviorImpl};
 

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-ripple-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-behaviors-3/paper-ripple-behavior.d.ts
@@ -8,6 +8,10 @@
  *   paper-ripple-behavior.js
  */
 
+import {IronButtonStateImpl} from '@polymer/iron-behaviors/iron-button-state.js';
+
+import {dom} from '@polymer/polymer/lib/legacy/polymer.dom.js';
+
 export {PaperRippleBehavior};
 
 declare namespace Polymer {

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-button-3/paper-button.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-button-3/paper-button.d.ts
@@ -8,6 +8,10 @@
  *   paper-button.js
  */
 
+import {PaperButtonBehavior, PaperButtonBehaviorImpl} from '@polymer/paper-behaviors/paper-button-behavior.js';
+
+import {Polymer} from '@polymer/polymer/lib/legacy/polymer-fn.js';
+
 interface PaperButtonElement extends Polymer.Element, PaperButtonBehavior {
 
   /**
@@ -23,5 +27,3 @@ declare global {
     "paper-button": PaperButtonElement;
   }
 }
-
-export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button-animations.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button-animations.d.ts
@@ -8,6 +8,10 @@
  *   paper-menu-button-animations.js
  */
 
+import {NeonAnimationBehavior} from '@polymer/neon-animation/neon-animation-behavior.js';
+
+import {Polymer} from '@polymer/polymer/lib/legacy/polymer-fn.js';
+
 interface PaperMenuGrowHeightAnimationElement extends Polymer.Element, NeonAnimationBehavior {
   configure(config: any): any;
 }
@@ -33,5 +37,3 @@ interface PaperMenuShrinkWidthAnimationElement extends Polymer.Element, NeonAnim
 interface PaperMenuShrinkHeightAnimationElement extends Polymer.Element, NeonAnimationBehavior {
   configure(config: any): any;
 }
-
-export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button.d.ts
@@ -8,6 +8,16 @@
  *   paper-menu-button.js
  */
 
+import {IronA11yKeysBehavior} from '@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
+
+import {IronControlState} from '@polymer/iron-behaviors/iron-control-state.js';
+
+import {Polymer as Polymer$0} from '@polymer/polymer/lib/legacy/polymer-fn.js';
+
+import {html} from '@polymer/polymer/lib/utils/html-tag.js';
+
+import {dom} from '@polymer/polymer/lib/legacy/polymer.dom.js';
+
 declare function value(): any;
 
 declare function value(): any;
@@ -68,5 +78,3 @@ declare function _openedChanged(opened: boolean, oldOpened: boolean): void;
  * dropdown.
  */
 declare function _disabledChanged(disabled: boolean): void;
-
-export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/array-selector.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/array-selector.d.ts
@@ -33,9 +33,23 @@ import {ElementMixin} from '../mixins/element-mixin.js';
  */
 declare function ArraySelectorMixin<T extends new (...args: any[]) => {}>(base: T): T & ArraySelectorMixinConstructor & ElementMixinConstructor & PropertyEffectsConstructor & TemplateStampConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor & PropertiesMixinConstructor;
 
+import {ElementMixinConstructor} from '../mixins/element-mixin.js';
+
+import {PropertyEffectsConstructor} from '../mixins/property-effects.js';
+
+import {TemplateStampConstructor} from '../mixins/template-stamp.js';
+
+import {PropertyAccessorsConstructor} from '../mixins/property-accessors.js';
+
+import {PropertiesChangedConstructor} from '../mixins/properties-changed.js';
+
+import {PropertiesMixinConstructor} from '../mixins/properties-mixin.js';
+
 interface ArraySelectorMixinConstructor {
   new(...args: any[]): ArraySelectorMixin;
 }
+
+export {ArraySelectorMixinConstructor};
 
 interface ArraySelectorMixin {
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-module.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-module.d.ts
@@ -56,7 +56,7 @@ declare class DomModule extends HTMLElement {
    * @returns Returns the element which matches `selector` in the
    * module registered at the specified `id`.
    */
-  static import(id: string, selector?: string): _Element|null;
+  static import(id: string, selector?: string): Element|null;
 
   /**
    * @param name Name of attribute.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-repeat.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/elements/dom-repeat.d.ts
@@ -10,7 +10,7 @@
 
 import {PolymerElement} from '../../polymer-element.js';
 
-import {TemplateInstanceBase as TemplateInstanceBase$0, templatize, modelForElement as modelForElement$0} from '../utils/templatize.js';
+import {TemplateInstanceBase, templatize, modelForElement as modelForElement$0} from '../utils/templatize.js';
 
 import {Debouncer} from '../utils/debounce.js';
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/class.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/class.d.ts
@@ -116,3 +116,5 @@ export {Class};
  * @returns Generated class
  */
 declare function Class(info: PolymerInit): {new(): HTMLElement};
+
+import {PolymerInit} from '../../interfaces';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
@@ -35,7 +35,21 @@ export {LegacyElementMixin};
  * found on the Polymer 1.x `Polymer.Base` prototype applied to all elements
  * defined using the `Polymer({...})` function.
  */
-declare function LegacyElementMixin<T extends new (...args: any[]) => {}>(base: T): T & LegacyElementMixinConstructor;
+declare function LegacyElementMixin<T extends new (...args: any[]) => {}>(base: T): T & LegacyElementMixinConstructor & ElementMixinConstructor & PropertyEffectsConstructor & TemplateStampConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor & PropertiesMixinConstructor & GestureEventListenersConstructor;
+
+import {ElementMixinConstructor} from '../mixins/element-mixin.js';
+
+import {PropertyEffectsConstructor} from '../mixins/property-effects.js';
+
+import {TemplateStampConstructor} from '../mixins/template-stamp.js';
+
+import {PropertyAccessorsConstructor} from '../mixins/property-accessors.js';
+
+import {PropertiesChangedConstructor} from '../mixins/properties-changed.js';
+
+import {PropertiesMixinConstructor} from '../mixins/properties-mixin.js';
+
+import {GestureEventListenersConstructor} from '../mixins/gesture-event-listeners.js';
 
 interface LegacyElementMixinConstructor {
   new(...args: any[]): LegacyElementMixin;
@@ -55,34 +69,17 @@ interface LegacyElementMixin {
   readonly domHost: any;
 
   /**
-   * Legacy callback called during the `constructor`, for overriding
-   * by the user.
+   * Overrides the default `Polymer.PropertyEffects` implementation to
+   * add support for installing `hostAttributes` and `listeners`.
    */
-  created(): void;
+  ready(): void;
 
   /**
-   * Provides an implementation of `connectedCallback`
-   * which adds Polymer legacy API's `attached` method.
+   * Overrides the default `Polymer.PropertyEffects` implementation to
+   * add support for class initialization via the `_registered` callback.
+   * This is called only when the first instance of the element is created.
    */
-  connectedCallback(): void;
-
-  /**
-   * Legacy callback called during `connectedCallback`, for overriding
-   * by the user.
-   */
-  attached(): void;
-
-  /**
-   * Provides an implementation of `disconnectedCallback`
-   * which adds Polymer legacy API's `detached` method.
-   */
-  disconnectedCallback(): void;
-
-  /**
-   * Legacy callback called during `disconnectedCallback`, for overriding
-   * by the user.
-   */
-  detached(): void;
+  _initializeProperties(): void;
 
   /**
    * Provides an override implementation of `attributeChangedCallback`
@@ -96,6 +93,36 @@ interface LegacyElementMixin {
   attributeChangedCallback(name: string, old: string|null, value: string|null, namespace: string|null): void;
 
   /**
+   * Provides an implementation of `connectedCallback`
+   * which adds Polymer legacy API's `attached` method.
+   */
+  connectedCallback(): void;
+
+  /**
+   * Provides an implementation of `disconnectedCallback`
+   * which adds Polymer legacy API's `detached` method.
+   */
+  disconnectedCallback(): void;
+
+  /**
+   * Legacy callback called during the `constructor`, for overriding
+   * by the user.
+   */
+  created(): void;
+
+  /**
+   * Legacy callback called during `connectedCallback`, for overriding
+   * by the user.
+   */
+  attached(): void;
+
+  /**
+   * Legacy callback called during `disconnectedCallback`, for overriding
+   * by the user.
+   */
+  detached(): void;
+
+  /**
    * Legacy callback called during `attributeChangedChallback`, for overriding
    * by the user.
    *
@@ -106,25 +133,12 @@ interface LegacyElementMixin {
   attributeChanged(name: string, old: string|null, value: string|null): void;
 
   /**
-   * Overrides the default `Polymer.PropertyEffects` implementation to
-   * add support for class initialization via the `_registered` callback.
-   * This is called only when the first instance of the element is created.
-   */
-  _initializeProperties(): void;
-
-  /**
    * Called automatically when an element is initializing.
    * Users may override this method to perform class registration time
    * work. The implementation should ensure the work is performed
    * only once for the class.
    */
   _registered(): void;
-
-  /**
-   * Overrides the default `Polymer.PropertyEffects` implementation to
-   * add support for installing `hostAttributes` and `listeners`.
-   */
-  ready(): void;
 
   /**
    * Ensures an element has required attributes. Called when the element

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
@@ -197,7 +197,7 @@ interface LegacyElementMixin {
    * @param attribute Attribute name to serialize to.
    * @param node Element to set attribute to.
    */
-  serializeValueToAttribute(value: any, attribute: string, node: _Element|null): void;
+  serializeValueToAttribute(value: any, attribute: string, node: Element|null): void;
 
   /**
    * Copies own properties (including accessor descriptors) from a source
@@ -268,7 +268,7 @@ interface LegacyElementMixin {
    * @param eventName Name of event to listen for.
    * @param methodName Name of handler method on `this` to call.
    */
-  listen(node: _Element|null, eventName: string, methodName: string): void;
+  listen(node: Element|null, eventName: string, methodName: string): void;
 
   /**
    * Convenience method to remove an event listener from a given element,
@@ -279,7 +279,7 @@ interface LegacyElementMixin {
    * @param methodName Name of handler method on `this` to not call
    *      anymore.
    */
-  unlisten(node: _Element|null, eventName: string, methodName: string): void;
+  unlisten(node: Element|null, eventName: string, methodName: string): void;
 
   /**
    * Override scrolling behavior to all direction, one direction, or none.
@@ -295,7 +295,7 @@ interface LegacyElementMixin {
    * @param node Element to apply scroll direction setting.
    * Defaults to `this`.
    */
-  setScrollDirection(direction?: string, node?: _Element|null): void;
+  setScrollDirection(direction?: string, node?: Element|null): void;
 
   /**
    * Convenience method to run `querySelector` on this local DOM scope.
@@ -305,7 +305,7 @@ interface LegacyElementMixin {
    * @param slctr Selector to run on this local DOM scope
    * @returns Element found by the selector, or null if not found.
    */
-  $$(slctr: string): _Element|null;
+  $$(slctr: string): Element|null;
 
   /**
    * Force this element to distribute its children to its local dom.
@@ -415,7 +415,7 @@ interface LegacyElementMixin {
    * @param node The element to be checked.
    * @returns true if node is in this element's local DOM tree.
    */
-  isLocalDescendant(node: _Element): boolean;
+  isLocalDescendant(node: Element): boolean;
 
   /**
    * No-op for backwards compatibility. This should now be handled by
@@ -513,7 +513,7 @@ interface LegacyElementMixin {
    *    instance.
    * @returns Newly created and configured element.
    */
-  create(tag: string, props?: object|null): _Element;
+  create(tag: string, props?: object|null): Element;
 
   /**
    * Polyfill for Element.prototype.matches, which is sometimes still
@@ -523,7 +523,7 @@ interface LegacyElementMixin {
    * @param node Element to test the selector against.
    * @returns Whether the element matches the selector.
    */
-  elementMatches(selector: string, node?: _Element): boolean;
+  elementMatches(selector: string, node?: Element): boolean;
 
   /**
    * Toggles an HTML attribute on or off.
@@ -533,7 +533,7 @@ interface LegacyElementMixin {
    *    When unspecified, the state of the attribute will be reversed.
    * @param node Node to target.  Defaults to `this`.
    */
-  toggleAttribute(name: string, bool?: boolean, node?: _Element|null): void;
+  toggleAttribute(name: string, bool?: boolean, node?: Element|null): void;
 
   /**
    * Toggles a CSS class on or off.
@@ -543,7 +543,7 @@ interface LegacyElementMixin {
    *    When unspecified, the state of the class will be reversed.
    * @param node Node to target.  Defaults to `this`.
    */
-  toggleClass(name: string, bool?: boolean, node?: _Element|null): void;
+  toggleClass(name: string, bool?: boolean, node?: Element|null): void;
 
   /**
    * Cross-platform helper for setting an element's CSS `transform` property.
@@ -552,7 +552,7 @@ interface LegacyElementMixin {
    * @param node Element to apply the transform to.
    * Defaults to `this`
    */
-  transform(transformText: string, node?: _Element|null): void;
+  transform(transformText: string, node?: Element|null): void;
 
   /**
    * Cross-platform helper for setting an element's CSS `translate3d`
@@ -564,7 +564,7 @@ interface LegacyElementMixin {
    * @param node Element to apply the transform to.
    * Defaults to `this`.
    */
-  translate3d(x: number, y: number, z: number, node?: _Element|null): void;
+  translate3d(x: number, y: number, z: number, node?: Element|null): void;
 
   /**
    * Removes an item from an array, if it exists.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/legacy-element-mixin.d.ts
@@ -35,11 +35,13 @@ export {LegacyElementMixin};
  * found on the Polymer 1.x `Polymer.Base` prototype applied to all elements
  * defined using the `Polymer({...})` function.
  */
-declare function LegacyElementMixin<T extends new (...args: any[]) => {}>(base: T): T & LegacyElementMixinConstructor & Polymer.ElementMixinConstructor & Polymer.GestureEventListenersConstructor;
+declare function LegacyElementMixin<T extends new (...args: any[]) => {}>(base: T): T & LegacyElementMixinConstructor;
 
 interface LegacyElementMixinConstructor {
   new(...args: any[]): LegacyElementMixin;
 }
+
+export {LegacyElementMixinConstructor};
 
 interface LegacyElementMixin {
   isAttached: boolean;

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/mutable-data-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/mutable-data-behavior.d.ts
@@ -66,7 +66,7 @@ interface MutableDataBehavior {
   _shouldPropertyChange(property: string, value: any, old: any): boolean;
 }
 
-const MutableDataBehavior: object;
+declare const MutableDataBehavior: object;
 
 
 /**
@@ -149,7 +149,7 @@ interface OptionalMutableDataBehavior {
   _shouldPropertyChange(property: string, value: any, old: any): boolean;
 }
 
-const OptionalMutableDataBehavior: object;
+declare const OptionalMutableDataBehavior: object;
 
 
 /**

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer-fn.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer-fn.d.ts
@@ -27,3 +27,5 @@ import {Class} from './class.js';
 declare function Polymer(info: PolymerInit): {new(): HTMLElement};
 
 export {Polymer};
+
+import {PolymerInit} from '../../interfaces';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer.dom.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer.dom.d.ts
@@ -49,7 +49,7 @@ declare class DomApi {
    *   of this element changes
    * @returns Observer instance
    */
-  observeNodes(callback: (p0: _Element, p1: {target: _Element, addedNodes: _Element[], removedNodes: _Element[]}) => void): Polymer.FlattenedNodesObserver;
+  observeNodes(callback: (p0: Element, p1: {target: Element, addedNodes: Element[], removedNodes: Element[]}) => void): FlattenedNodesObserver;
 
   /**
    * Disconnects an observer previously created via `observeNodes`
@@ -57,7 +57,7 @@ declare class DomApi {
    * @param observerHandle Observer instance
    *   to disconnect.
    */
-  unobserveNodes(observerHandle: Polymer.FlattenedNodesObserver): void;
+  unobserveNodes(observerHandle: FlattenedNodesObserver): void;
 
   /**
    * Provided as a backwards-compatible API only.  This method does nothing.
@@ -131,8 +131,8 @@ declare class DomApi {
   replaceChild(oldChild: Node, newChild: Node): Node;
   setAttribute(name: string, value: string): void;
   removeAttribute(name: string): void;
-  querySelector(selector: string): _Element|null;
-  querySelectorAll(selector: string): NodeListOf<_Element>;
+  querySelector(selector: string): Element|null;
+  querySelectorAll(selector: string): NodeListOf<Element>;
 }
 
 /**

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/templatizer-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/templatizer-behavior.d.ts
@@ -113,7 +113,7 @@ interface Templatizer {
   modelForElement(el: HTMLElement|null): TemplateInstanceBase|null;
 }
 
-const Templatizer: object;
+declare const Templatizer: object;
 
 
 /**

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/templatizer-behavior.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/templatizer-behavior.d.ts
@@ -8,7 +8,7 @@
  *   lib/legacy/templatizer-behavior.js
  */
 
-import {TemplateInstanceBase as TemplateInstanceBase$0, templatize as templatize$0, modelForElement as modelForElement$0} from '../utils/templatize.js';
+import {TemplateInstanceBase, templatize as templatize$0, modelForElement as modelForElement$0} from '../utils/templatize.js';
 
 export {Templatizer};
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/dir-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/dir-mixin.d.ts
@@ -36,6 +36,10 @@ export {DirMixin};
  */
 declare function DirMixin<T extends new (...args: any[]) => {}>(base: T): T & DirMixinConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor;
 
+import {PropertyAccessorsConstructor} from './property-accessors.js';
+
+import {PropertiesChangedConstructor} from './properties-changed.js';
+
 interface DirMixinConstructor {
   new(...args: any[]): DirMixin;
   _processStyleText(cssText: any, baseURI: any): any;
@@ -48,6 +52,8 @@ interface DirMixinConstructor {
    */
   _replaceDirInCssText(text: string): string;
 }
+
+export {DirMixinConstructor};
 
 interface DirMixin {
   ready(): void;

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/disable-upgrade-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/disable-upgrade-mixin.d.ts
@@ -37,9 +37,23 @@ export {DisableUpgradeMixin};
  */
 declare function DisableUpgradeMixin<T extends new (...args: any[]) => {}>(base: T): T & DisableUpgradeMixinConstructor & ElementMixinConstructor & PropertyEffectsConstructor & TemplateStampConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor & PropertiesMixinConstructor;
 
+import {ElementMixinConstructor} from './element-mixin.js';
+
+import {PropertyEffectsConstructor} from './property-effects.js';
+
+import {TemplateStampConstructor} from './template-stamp.js';
+
+import {PropertyAccessorsConstructor} from './property-accessors.js';
+
+import {PropertiesChangedConstructor} from './properties-changed.js';
+
+import {PropertiesMixinConstructor} from './properties-mixin.js';
+
 interface DisableUpgradeMixinConstructor {
   new(...args: any[]): DisableUpgradeMixin;
 }
+
+export {DisableUpgradeMixinConstructor};
 
 interface DisableUpgradeMixin {
   _initializeProperties(): void;

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
@@ -260,3 +260,5 @@ export {updateStyles};
  * These properties are retained unless a value of `null` is set.
  */
 declare function updateStyles(props?: object|null): void;
+
+import {StampedTemplate} from '../../interfaces';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
@@ -81,6 +81,16 @@ export {ElementMixin};
  */
 declare function ElementMixin<T extends new (...args: any[]) => {}>(base: T): T & ElementMixinConstructor & PropertyEffectsConstructor & TemplateStampConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor & PropertiesMixinConstructor;
 
+import {PropertyEffectsConstructor} from './property-effects.js';
+
+import {TemplateStampConstructor} from './template-stamp.js';
+
+import {PropertyAccessorsConstructor} from './property-accessors.js';
+
+import {PropertiesChangedConstructor} from './properties-changed.js';
+
+import {PropertiesMixinConstructor} from './properties-mixin.js';
+
 interface ElementMixinConstructor {
   new(...args: any[]): ElementMixin;
 
@@ -134,6 +144,8 @@ interface ElementMixinConstructor {
    */
   _finalizeTemplate(is: string): void;
 }
+
+export {ElementMixinConstructor};
 
 interface ElementMixin {
   _template: HTMLTemplateElement|null;

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/element-mixin.d.ts
@@ -141,7 +141,7 @@ interface ElementMixin {
   rootPath: string;
   importPath: string;
   root: StampedTemplate|HTMLElement|ShadowRoot|null;
-  $: {[key: string]: _Element};
+  $: {[key: string]: Element};
 
   /**
    * Stamps the element template.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/gesture-event-listeners.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/gesture-event-listeners.d.ts
@@ -30,6 +30,8 @@ interface GestureEventListenersConstructor {
   new(...args: any[]): GestureEventListeners;
 }
 
+export {GestureEventListenersConstructor};
+
 interface GestureEventListeners {
 
   /**

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/mutable-data.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/mutable-data.d.ts
@@ -53,6 +53,8 @@ interface MutableDataConstructor {
   new(...args: any[]): MutableData;
 }
 
+export {MutableDataConstructor};
+
 interface MutableData {
 
   /**
@@ -117,6 +119,8 @@ declare function OptionalMutableData<T extends new (...args: any[]) => {}>(base:
 interface OptionalMutableDataConstructor {
   new(...args: any[]): OptionalMutableData;
 }
+
+export {OptionalMutableDataConstructor};
 
 interface OptionalMutableData {
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-changed.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-changed.d.ts
@@ -59,6 +59,8 @@ interface PropertiesChangedConstructor {
   typeForProperty(name: string): void;
 }
 
+export {PropertiesChangedConstructor};
+
 interface PropertiesChanged {
 
   /**

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-changed.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-changed.d.ts
@@ -273,7 +273,7 @@ interface PropertiesChanged {
    * @param value Value to serialize.
    * @param attribute Attribute name to serialize to.
    */
-  _valueToNodeAttribute(node: _Element|null, value: any, attribute: string): void;
+  _valueToNodeAttribute(node: Element|null, value: any, attribute: string): void;
 
   /**
    * Converts a typed JavaScript value to a string.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-mixin.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/properties-mixin.d.ts
@@ -28,6 +28,8 @@ export {PropertiesMixin};
  */
 declare function PropertiesMixin<T extends new (...args: any[]) => {}>(base: T): T & PropertiesMixinConstructor & PropertiesChangedConstructor;
 
+import {PropertiesChangedConstructor} from './properties-changed.js';
+
 interface PropertiesMixinConstructor {
   new(...args: any[]): PropertiesMixin;
 
@@ -55,6 +57,8 @@ interface PropertiesMixinConstructor {
    */
   _finalizeClass(): void;
 }
+
+export {PropertiesMixinConstructor};
 
 interface PropertiesMixin {
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-accessors.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-accessors.d.ts
@@ -41,6 +41,8 @@ export {PropertyAccessors};
  */
 declare function PropertyAccessors<T extends new (...args: any[]) => {}>(base: T): T & PropertyAccessorsConstructor & PropertiesChangedConstructor;
 
+import {PropertiesChangedConstructor} from './properties-changed.js';
+
 interface PropertyAccessorsConstructor {
   new(...args: any[]): PropertyAccessors;
 
@@ -62,6 +64,8 @@ interface PropertyAccessorsConstructor {
    */
   createPropertiesForAttributes(): void;
 }
+
+export {PropertyAccessorsConstructor};
 
 interface PropertyAccessors {
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
@@ -854,3 +854,11 @@ interface PropertyEffects {
    */
   _removeBoundDom(dom: StampedTemplate): void;
 }
+
+import {TemplateInfo} from '../../interfaces';
+
+import {NodeInfo} from '../../interfaces';
+
+import {BindingPart} from '../../interfaces';
+
+import {StampedTemplate} from '../../interfaces';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
@@ -53,6 +53,12 @@ export {PropertyEffects};
  */
 declare function PropertyEffects<T extends new (...args: any[]) => {}>(base: T): T & PropertyEffectsConstructor & TemplateStampConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor;
 
+import {TemplateStampConstructor} from './template-stamp.js';
+
+import {PropertyAccessorsConstructor} from './property-accessors.js';
+
+import {PropertiesChangedConstructor} from './properties-changed.js';
+
 interface PropertyEffectsConstructor {
   new(...args: any[]): PropertyEffects;
 
@@ -294,6 +300,8 @@ interface PropertyEffectsConstructor {
    */
   _evaluateBinding(inst: this|null, part: BindingPart|null, path: string, props: object|null, oldProps: object|null, hasPaths: boolean): any;
 }
+
+export {PropertyEffectsConstructor};
 
 interface PropertyEffects {
   readonly PROPERTY_EFFECT_TYPES: any;

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
@@ -101,7 +101,7 @@ interface PropertyEffectsConstructor {
    * @returns `true` if the visited node added node-specific
    *   metadata to `nodeInfo`
    */
-  _parseTemplateNodeAttribute(node: _Element|null, templateInfo: TemplateInfo|null, nodeInfo: NodeInfo|null, name: string, value: string): boolean;
+  _parseTemplateNodeAttribute(node: Element|null, templateInfo: TemplateInfo|null, nodeInfo: NodeInfo|null, name: string, value: string): boolean;
 
   /**
    * Ensures an accessor exists for the specified property, and adds

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/strict-binding-parser.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/strict-binding-parser.d.ts
@@ -23,6 +23,14 @@ import {PropertyEffects} from './property-effects.js';
  */
 declare function StrictBindingParser<T extends new (...args: any[]) => {}>(base: T): T & StrictBindingParserConstructor & PropertyEffectsConstructor & TemplateStampConstructor & PropertyAccessorsConstructor & PropertiesChangedConstructor;
 
+import {PropertyEffectsConstructor} from './property-effects.js';
+
+import {TemplateStampConstructor} from './template-stamp.js';
+
+import {PropertyAccessorsConstructor} from './property-accessors.js';
+
+import {PropertiesChangedConstructor} from './properties-changed.js';
+
 interface StrictBindingParserConstructor {
   new(...args: any[]): StrictBindingParser;
 
@@ -60,6 +68,8 @@ interface StrictBindingParserConstructor {
    */
   _parseBindings(text: string, templateInfo: object|null): BindingPart[]|null;
 }
+
+export {StrictBindingParserConstructor};
 
 interface StrictBindingParser {
 }

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/strict-binding-parser.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/strict-binding-parser.d.ts
@@ -65,3 +65,5 @@ interface StrictBindingParser {
 }
 
 export {StrictBindingParser};
+
+import {BindingPart} from '../../interfaces';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
@@ -195,6 +195,8 @@ interface TemplateStampConstructor {
   _contentForTemplate(template: HTMLTemplateElement|null): DocumentFragment|null;
 }
 
+export {TemplateStampConstructor};
+
 interface TemplateStamp {
 
   /**

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
@@ -163,7 +163,7 @@ interface TemplateStampConstructor {
    * @returns `true` if the visited node added node-specific
    *   metadata to `nodeInfo`
    */
-  _parseTemplateNodeAttributes(node: _Element|null, templateInfo: TemplateInfo|null, nodeInfo: NodeInfo|null): boolean;
+  _parseTemplateNodeAttributes(node: Element|null, templateInfo: TemplateInfo|null, nodeInfo: NodeInfo|null): boolean;
 
   /**
    * Parses a single template node attribute and adds node metadata to
@@ -180,7 +180,7 @@ interface TemplateStampConstructor {
    * @returns `true` if the visited node added node-specific
    *   metadata to `nodeInfo`
    */
-  _parseTemplateNodeAttribute(node: _Element|null, templateInfo: TemplateInfo, nodeInfo: NodeInfo, name: string, value: string): boolean;
+  _parseTemplateNodeAttribute(node: Element|null, templateInfo: TemplateInfo, nodeInfo: NodeInfo, name: string, value: string): boolean;
 
   /**
    * Returns the `content` document fragment for a given template.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/template-stamp.d.ts
@@ -254,3 +254,9 @@ interface TemplateStamp {
    */
   _removeEventListenerFromNode(node: Node|null, eventName: string, handler: (p0: Event) => void): void;
 }
+
+import {TemplateInfo} from '../../interfaces';
+
+import {NodeInfo} from '../../interfaces';
+
+import {StampedTemplate} from '../../interfaces';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/async.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/async.d.ts
@@ -111,3 +111,7 @@ declare namespace microTask {
 }
 
 export {microTask};
+
+import {AsyncInterface} from '../../interfaces';
+
+import {IdleDeadline} from '../../interfaces';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/boot.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/boot.d.ts
@@ -8,5 +8,3 @@
  *   lib/utils/boot.js
  */
 
-/// <reference path="../../extra-types.d.ts" />
-

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/debounce.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/debounce.d.ts
@@ -76,3 +76,5 @@ declare class Debouncer {
    */
   isActive(): boolean;
 }
+
+import {AsyncInterface} from '../../interfaces';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flattened-nodes-observer.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flattened-nodes-observer.d.ts
@@ -59,7 +59,7 @@ declare class FlattenedNodesObserver {
    * @param callback Function called when there are additions
    * or removals from the target's list of flattened nodes.
    */
-  constructor(target: _Element|null, callback: ((p0: _Element, p1: {target: _Element, addedNodes: _Element[], removedNodes: _Element[]}) => void)|null);
+  constructor(target: Element|null, callback: ((p0: Element, p1: {target: Element, addedNodes: Element[], removedNodes: Element[]}) => void)|null);
 
   /**
    * Returns the list of flattened nodes for the given `node`.

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flush.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flush.d.ts
@@ -25,3 +25,5 @@ export {flush};
  * - ShadyDOM distribution
  */
 declare function flush(): void;
+
+import {Debouncer} from './debounce.js';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/gestures.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/gestures.d.ts
@@ -24,7 +24,7 @@ export {deepTargetFind};
  * @returns Returns the deepest shadowRoot inclusive element
  * found at the screen position given.
  */
-declare function deepTargetFind(x: number, y: number): _Element|null;
+declare function deepTargetFind(x: number, y: number): Element|null;
 
 export {addListener};
 
@@ -64,7 +64,7 @@ export {setTouchAction};
  * This value is checked on first move, thus it should be called prior to
  * adding event listeners.
  */
-declare function setTouchAction(node: _Element, value: string): void;
+declare function setTouchAction(node: Element, value: string): void;
 
 export {prevent};
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/gestures.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/gestures.d.ts
@@ -85,3 +85,5 @@ export {resetMouseCanceller};
  * Calling this method in production may cause duplicate taps or other Gestures.
  */
 declare function resetMouseCanceller(): void;
+
+import {GestureRecognizer} from '../../interfaces';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/templatize.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/templatize.d.ts
@@ -21,8 +21,8 @@ declare class TemplateInstanceBase extends
    * is either another templatize instance that had option `parentModel: true`,
    * or else the host element.
    */
-  readonly parentModel: Polymer.PropertyEffects;
-  _methodHost: Polymer.PropertyEffects;
+  readonly parentModel: PropertyEffects;
+  _methodHost: PropertyEffects;
 
   /**
    * Override point for adding custom or simulated event handling.
@@ -158,7 +158,7 @@ export {templatize};
  * @returns Generated class bound to the template
  *   provided
  */
-declare function templatize(template: HTMLTemplateElement, owner?: Polymer.PropertyEffects|null, options?: object|null): {new(): TemplateInstanceBase};
+declare function templatize(template: HTMLTemplateElement, owner?: PropertyEffects|null, options?: object|null): {new(): TemplateInstanceBase};
 
 export {modelForElement};
 

--- a/packages/gen-typescript-declarations/src/ts-ast/declarations.ts
+++ b/packages/gen-typescript-declarations/src/ts-ast/declarations.ts
@@ -396,7 +396,8 @@ export class ConstValue {
   }
 
   serialize(depth: number = 0): string {
-    return `${indent(depth)}const ${this.name}: ${this.type.serialize()};\n`;
+    return indent(depth) + (depth === 0 ? 'declare ' : '') +
+        `const ${this.name}: ${this.type.serialize()};\n`;
   }
 }
 


### PR DESCRIPTION
- Adds an `autoImport` config option to automatically add ES module imports when particular identifiers are referenced. We'll use this to inject imports for custom interfaces like `PolymerInit` etc.
- I'm keeping a branch of changes to Polymer 3.0 itself at https://github.com/Polymer/polymer/compare/polymer-3-typescript, you can see the new `interfaces.d.ts` and `gen-tsd.json` files here.
- Automatically detect if a project uses NPM or Bower and configure module resolution settings accordingly.
- Automatically import/export synthetic mixin constructor interfaces.
- Support serializing top-level `const` values with `declare`.
- Use SHAs instead of branches for the 3.0 elements since they might change and break Travis.