### PR TITLE
Polymer dom flush only if polymer exists

### DIFF
--- a/packages/gen-typescript-declarations/scripts/fixtures.txt
+++ b/packages/gen-typescript-declarations/scripts/fixtures.txt
@@ -1,7 +1,7 @@
 https://github.com/PolymerElements/paper-behaviors.git v2.0.1 paper-behaviors-2
 https://github.com/PolymerElements/paper-behaviors.git 28cf765323b8c7fe4440752968c651ccc1b16768 paper-behaviors-3
 https://github.com/PolymerElements/paper-button.git v2.0.0 paper-button-2
-https://github.com/PolymerElements/paper-button.git e29e692e00839adcd94cfa08a3cd6b4165f3619e paper-button-3
+https://github.com/PolymerElements/paper-button.git adb5fcb392287413b9b20bf7103014b8fffc76c9 paper-button-3
 https://github.com/PolymerElements/paper-menu-button.git v2.0.0 paper-menu-button-2
 https://github.com/PolymerElements/paper-menu-button.git 4dd8ac9107c25340b77c2ad27f8f11660eddb661 paper-menu-button-3
 https://github.com/Polymer/polymer.git 50ba80b864d4843d4e59cfdddeab6efdf280a2ec polymer-2


### PR DESCRIPTION
This issue came up when using `lit-element` and using `a11ySuite` in the WCT test suite.