### PR TITLE
Support commenting out fixture lines in gen typescript declarations

### DIFF
--- a/packages/gen-typescript-declarations/scripts/fixtures.txt
+++ b/packages/gen-typescript-declarations/scripts/fixtures.txt
@@ -1,5 +1,5 @@
 https://github.com/PolymerElements/paper-behaviors.git v2.0.1 paper-behaviors-2
-https://github.com/PolymerElements/paper-behaviors.git 28cf765323b8c7fe4440752968c651ccc1b16768 paper-behaviors-3
+# https://github.com/PolymerElements/paper-behaviors.git 28cf765323b8c7fe4440752968c651ccc1b16768 paper-behaviors-3
 https://github.com/PolymerElements/paper-button.git v2.0.0 paper-button-2
 https://github.com/PolymerElements/paper-button.git adb5fcb392287413b9b20bf7103014b8fffc76c9 paper-button-3
 https://github.com/PolymerElements/paper-menu-button.git v2.0.0 paper-menu-button-2

--- a/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
+++ b/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
@@ -22,6 +22,7 @@ mkdir -p fixtures
 cd fixtures
 
 while read -r repo commitish dir; do
+  if [ $repo = "#" ]; then continue; fi  # Commented out line. 
   if [ -d $dir ]; then continue; fi  # Already set up.
   # Note you can't do a shallow clone of a SHA.
   git clone $repo $dir


### PR DESCRIPTION
Also commented out one fixture because unit tests fail when it says it can't get that repo because bad reference.