### PR TITLE
Update travis-browsers.json

### DIFF
--- a/packages/wct-sauce/travis-browsers.json
+++ b/packages/wct-sauce/travis-browsers.json
@@ -2,12 +2,12 @@
   {
     "browserName":  "microsoftedge",
     "platform":     "Windows 10",
-    "version":      "14"
+    "version":      "15"
   },
   {
     "browserName":  "microsoftedge",
     "platform":     "Windows 10",
-    "version":      "15"
+    "version":      "17"
   },
   {
     "browserName":  "internet explorer",
@@ -16,17 +16,22 @@
   },
   {
     "browserName":  "safari",
-    "platform":     "OS X 10.12",
+    "platform":     "macos 10.13",
     "version":      "11"
   },
   {
     "browserName":  "safari",
-    "platform":     "OS X 10.11",
+    "platform":     "OS X 10.12",
     "version":      "10"
   },
   {
     "browserName":  "safari",
     "platform":     "OS X 10.11",
     "version":      "9"
+  },
+  {
+    "browserName":  "chrome",
+    "platform":     "Linux",
+    "version":      "41"
   }
 ]


### PR DESCRIPTION
Test Edge 15 and 17, Safari 9, 10, 11, and Chrome 41