### PR TITLE
[cli] Add the CustomElementsEs5Adapter when options.js.compile.target equals es5

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-<!-- ## Unreleased -->
+## Unreleased
 <!-- Add new, unreleased items here. -->
+* Fix a case where the CustomElementsEs5Adapter script was not added to the 
+  builds when the `js.compile` is an object with a target property of es5.
 
 ## v1.7.7 [06-28-2018]
 * Update dependencies.

--- a/packages/cli/src/build/build.ts
+++ b/packages/cli/src/build/build.ts
@@ -55,7 +55,8 @@ export async function build(
 
   const compiledToES5 = (options.js === undefined) ?
       false :
-      options.js.compile === true || options.js.compile === 'es5';
+      options.js.compile === true || options.js.compile === 'es5' ||
+      (options.js.compile && options.js.compile.target === 'es5');
   if (compiledToES5) {
     buildStream =
         buildStream.pipe(polymerProject.addCustomElementsEs5Adapter());

--- a/packages/cli/src/build/build.ts
+++ b/packages/cli/src/build/build.ts
@@ -56,7 +56,7 @@ export async function build(
   const compiledToES5 = (options.js === undefined) ?
       false :
       options.js.compile === true || options.js.compile === 'es5' ||
-      (options.js.compile && options.js.compile.target === 'es5');
+      (typeof options.js.compile === 'object' && options.js.compile.target === 'es5');
   if (compiledToES5) {
     buildStream =
         buildStream.pipe(polymerProject.addCustomElementsEs5Adapter());


### PR DESCRIPTION
Hi,

According to [JsOptimizeOptions](https://github.com/Polymer/tools/blob/47bcbb1fe08300607c4b445394f385507c08fe67/packages/build/src/optimize-streams.ts#L56-L61), [JsCompileOptions](https://github.com/Polymer/tools/blob/47bcbb1fe08300607c4b445394f385507c08fe67/packages/build/src/optimize-streams.ts#L51-L54) and [JsCompileTarget](https://github.com/Polymer/tools/blob/840c7c86636153438c4b414869169aa38a6d07c6/packages/project-config/src/builds.ts#L17), the polymer-cli should add the CustomElementsEs5Adapter when a build has a **js.compile.target** equals to **es5**.

By example:

```json
"builds": [
    {
      "js": {
        "minify": {
          "exclude": [
            "bower_components/fullcalendar/dist/fullcalendar.min.js",
            "bower_components/jquery/dist/jquery.min.js",
            "bower_components/moment/min/moment.min.js"
          ]
        },
        "compile": {
          "exclude": [
            "bower_components/fullcalendar/dist/fullcalendar.min.js",
            "bower_components/jquery/dist/jquery.min.js",
            "bower_components/moment/min/moment.min.js"
          ],
          "target": "es5"
        }
      },
      "preset": "es5-bundled"
    }
  ]
```

I hope that pull request should fixes a breaking change that was not in **1.6.0**. Unfortunately, I was unable to test it on my computer.

Thanks.