### PR TITLE
cli: update chalk dependency

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -4,6 +4,626 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
+			"integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.1.2",
+				"@babel/helpers": "^7.1.2",
+				"@babel/parser": "^7.1.2",
+				"@babel/template": "^7.1.2",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.1.2",
+				"convert-source-map": "^1.1.0",
+				"debug": "^3.1.0",
+				"json5": "^0.5.0",
+				"lodash": "^4.17.10",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
+			"integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+			"requires": {
+				"@babel/types": "^7.1.3",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.10",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-call-delegate": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
+			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
+			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+			"integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
+			"integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-simple-access": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+		},
+		"@babel/helper-regex": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"requires": {
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-wrap-function": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
+			"integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.0.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"requires": {
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
+			"integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/template": "^7.1.0",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
+			"integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+			"requires": {
+				"@babel/template": "^7.1.2",
+				"@babel/traverse": "^7.1.0",
+				"@babel/types": "^7.1.2"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
+			"integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w=="
+		},
+		"@babel/plugin-external-helpers": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0.tgz",
+			"integrity": "sha512-tZKTMdhZvTy0KCEX5EGQQm1RHr7jUa36q/yax1baEA0yZapVYmu10yW7LTqijITgSq416gPVjrcexiA6y4pJlA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.1.0.tgz",
+			"integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0",
+				"@babel/plugin-syntax-async-generators": "^7.0.0"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
+			"integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
+			"integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
+			"integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-import-meta": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0.tgz",
+			"integrity": "sha512-FEoGvhXVAiWzpDjyZIlBGzKyNk/lnRPy7aPke3PjVkiAY0QFsvFfkjUg5diRwVfowBA8SJqvFt0ZoXNSjl70hQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
+			"integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
+			"integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
+			"integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
+			"integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
+			"integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"lodash": "^4.17.10"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
+			"integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-define-map": "^7.1.0",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-optimise-call-expression": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"globals": {
+					"version": "11.8.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
+				}
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
+			"integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
+			"integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
+			"integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
+			"integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
+			"integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
+			"integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
+			"requires": {
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-instanceof": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.0.0.tgz",
+			"integrity": "sha512-Dv6MtJZOjjGjnHlSwQVpYlwZBkPzaWX/1zoHUW82fmKmUNOp+XnYA1lCYCB+7RXkX8rBa6IuNZ9Y8u3MLJCxuQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
+			"integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.1.0.tgz",
+			"integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
+			"integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.1.0"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
+			"integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
+			"requires": {
+				"@babel/helper-call-delegate": "^7.1.0",
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+			"requires": {
+				"regenerator-transform": "^0.13.3"
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
+			"integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
+			"integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
+			"integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
+			"integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
+			"integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
+			"integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0",
+				"regexpu-core": "^4.1.3"
+			}
+		},
+		"@babel/template": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+			"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.1.2",
+				"@babel/types": "^7.1.2"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
+			"integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.1.3",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/parser": "^7.1.3",
+				"@babel/types": "^7.1.3",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.10"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.8.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA=="
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
+			"integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.10",
+				"to-fast-properties": "^2.0.0"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -17,6 +637,66 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz",
 			"integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw=="
+		},
+		"@polymer/esm-amd-loader": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.3.tgz",
+			"integrity": "sha512-j7fDIkNeR8cekqK2WRH5YV1VtIdPwqrgb5OzAN5QUIWEBkFj5OsxTvrkJiSaFgEMdKZoozs/vz+oq83Qehp4wA=="
+		},
+		"@polymer/sinonjs": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
+			"integrity": "sha512-/U8F/cOTrbF2iVVYgINYmvKbtbexs+89Q3v8AaHADRYabTg7aOZGOb0RyWpOI+sUJt04kj63U4FwMhzW5r4wZA=="
+		},
+		"@polymer/test-fixture": {
+			"version": "0.0.3",
+			"resolved": "http://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+			"integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk="
+		},
+		"@polymer/tools-common": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@polymer/tools-common/-/tools-common-2.0.1.tgz",
+			"integrity": "sha512-McFmpKINBpdDkIz7jf+hIddUDYLaeEV+SFqfoNJEYZwgXZta145fy/SlXSKj31RcAjroxfocRplN/p3HLYwloQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "^9.6.4",
+				"depcheck": "^0.6.0",
+				"fs-extra": "^3.0.0",
+				"gulp-eslint": "^4.0.0",
+				"gulp-mocha": "^6.0.0",
+				"gulp-tslint": "^8.0.0",
+				"gulp-typescript": "^3.0.0",
+				"merge-stream": "^1.0.0",
+				"run-sequence": "^1.0.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "9.6.35",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.35.tgz",
+					"integrity": "sha512-h5zvHS8wXHGa+Gcqs9K8vqCgOtqjr0+NqG/DDJmQIX1wpR9HivAfgV8bjcD3mGM4bPfQw5Aneb2Pn8355L83jA==",
+					"dev": true
+				},
+				"fs-extra": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+					"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^3.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"jsonfile": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+					"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				}
+			}
 		},
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
@@ -36,6 +716,62 @@
 				"array-from": "^2.1.1"
 			}
 		},
+		"@types/babel-generator": {
+			"version": "6.25.2",
+			"resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.2.tgz",
+			"integrity": "sha512-W7PQkeDlYOqJblfNeqZARwj4W8nO+ZhQQZksU8+wbaKuHeUdIVUAdREO/Qb0FfNr3CY5Sq1gNtqsyFeZfS3iSw==",
+			"requires": {
+				"@types/babel-types": "*"
+			}
+		},
+		"@types/babel-traverse": {
+			"version": "6.25.4",
+			"resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.4.tgz",
+			"integrity": "sha512-+/670NaZE7qPvdh8EtGds32/2uHFKE5JeS+7ePH6nGwF8Wj8r671/RkTiJQP2k22nFntWEb9xQ11MFj7xEqI0g==",
+			"requires": {
+				"@types/babel-types": "*"
+			}
+		},
+		"@types/babel-types": {
+			"version": "6.25.2",
+			"resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
+			"integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA=="
+		},
+		"@types/babylon": {
+			"version": "6.16.3",
+			"resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.3.tgz",
+			"integrity": "sha512-lyJ8sW1PbY3uwuvpOBZ9zMYKshMnQpXmeDHh8dj9j2nJm/xrW0FgB5gLSYOArj5X0IfaXnmhFoJnhS4KbqIMug==",
+			"requires": {
+				"@types/babel-types": "*"
+			}
+		},
+		"@types/bluebird": {
+			"version": "3.5.24",
+			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.24.tgz",
+			"integrity": "sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg=="
+		},
+		"@types/body-parser": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+			"integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+			"requires": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/chai": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.6.tgz",
+			"integrity": "sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw=="
+		},
+		"@types/chai-subset": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
+			"integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
+			"requires": {
+				"@types/chai": "*"
+			}
+		},
 		"@types/chalk": {
 			"version": "0.4.31",
 			"resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
@@ -51,6 +787,42 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/clean-css": {
+			"version": "3.4.30",
+			"resolved": "http://registry.npmjs.org/@types/clean-css/-/clean-css-3.4.30.tgz",
+			"integrity": "sha1-AFLBNvUkgAJCjjY4s33ko5gYZB0="
+		},
+		"@types/clone": {
+			"version": "0.1.30",
+			"resolved": "http://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
+			"integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
+		},
+		"@types/compression": {
+			"version": "0.0.33",
+			"resolved": "http://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
+			"integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
+			"requires": {
+				"@types/express": "*"
+			}
+		},
+		"@types/connect": {
+			"version": "3.4.32",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+			"integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/content-type": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@types/content-type/-/content-type-1.1.2.tgz",
+			"integrity": "sha512-w2d7fBCYbCBUBTGtkC4JfX1FicTtgEmq7wTTjc7rC5RA/JdB1Bi7o88nKzUqAnIIBXJVmq0n4tTmF3PJN8QqCg=="
+		},
+		"@types/cssbeautify": {
+			"version": "0.3.1",
+			"resolved": "http://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+			"integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8="
+		},
 		"@types/del": {
 			"version": "3.0.1",
 			"resolved": "http://registry.npmjs.org/@types/del/-/del-3.0.1.tgz",
@@ -59,10 +831,56 @@
 				"@types/glob": "*"
 			}
 		},
+		"@types/doctrine": {
+			"version": "0.0.1",
+			"resolved": "http://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
+			"integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
+		},
+		"@types/escape-html": {
+			"version": "0.0.20",
+			"resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-0.0.20.tgz",
+			"integrity": "sha512-6dhZJLbA7aOwkYB2GDGdIqJ20wmHnkDzaxV9PJXe7O02I2dSFTERzRB6JrX6cWKaS+VqhhY7cQUMCbO5kloFUw=="
+		},
+		"@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+		},
 		"@types/events": {
 			"version": "1.2.0",
 			"resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
 			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+		},
+		"@types/express": {
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.0.tgz",
+			"integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
+			"requires": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "*",
+				"@types/serve-static": "*"
+			}
+		},
+		"@types/express-serve-static-core": {
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
+			"integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
+			"requires": {
+				"@types/events": "*",
+				"@types/node": "*",
+				"@types/range-parser": "*"
+			}
+		},
+		"@types/fancy-log": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@types/fancy-log/-/fancy-log-1.3.0.tgz",
+			"integrity": "sha512-mQjDxyOM1Cpocd+vm1kZBP7smwKZ4TNokFeds9LV7OZibmPJFEzY3+xZMrKfUdNT71lv8GoCPD6upKwHxubClw==",
+			"dev": true
+		},
+		"@types/fast-levenshtein": {
+			"version": "0.0.1",
+			"resolved": "http://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.1.tgz",
+			"integrity": "sha1-OjYVzxc2Rcj8pY0FHk4ygk5L0oY="
 		},
 		"@types/findup-sync": {
 			"version": "0.3.29",
@@ -79,6 +897,12 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@types/freeport": {
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/@types/freeport/-/freeport-1.0.21.tgz",
+			"integrity": "sha1-c/ZUPtZ9PKP/+XuYVZFZi3CSBm8=",
+			"optional": true
 		},
 		"@types/fs-extra": {
 			"version": "5.0.4",
@@ -116,6 +940,25 @@
 				"@types/glob": "*"
 			}
 		},
+		"@types/gulp-if": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/@types/gulp-if/-/gulp-if-0.0.33.tgz",
+			"integrity": "sha512-J5lzff21X7r1x/4hSzn02GgIUEyjCqYIXZ9GgGBLhbsD3RiBdqwnkFWgF16/0jO5rcVZ52Zp+6MQMQdvIsWuKg==",
+			"requires": {
+				"@types/node": "*",
+				"@types/vinyl": "*"
+			}
+		},
+		"@types/html-minifier": {
+			"version": "3.5.2",
+			"resolved": "http://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.2.tgz",
+			"integrity": "sha512-yikK28/KlVyf8g9i/k+TDFlteLuZ6QQTUdVqvKtzEB+8DSLCTjxfh6IK45KnW4rYFI3Y8T4LWpYJMTmfJleWaQ==",
+			"requires": {
+				"@types/clean-css": "*",
+				"@types/relateurl": "*",
+				"@types/uglify-js": "*"
+			}
+		},
 		"@types/inquirer": {
 			"version": "0.0.32",
 			"resolved": "http://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.32.tgz",
@@ -125,6 +968,17 @@
 				"@types/through": "*"
 			}
 		},
+		"@types/is-windows": {
+			"version": "0.2.0",
+			"resolved": "http://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+			"integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8="
+		},
+		"@types/launchpad": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@types/launchpad/-/launchpad-0.6.0.tgz",
+			"integrity": "sha1-NylhCbfyd/bmxf1+DAcGvJGPu1E=",
+			"optional": true
+		},
 		"@types/merge-stream": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@types/merge-stream/-/merge-stream-1.1.2.tgz",
@@ -132,6 +986,11 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@types/mime": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+			"integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -151,6 +1010,32 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
 			"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
 		},
+		"@types/opn": {
+			"version": "3.0.28",
+			"resolved": "http://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
+			"integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/parse5": {
+			"version": "2.2.34",
+			"resolved": "http://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
+			"integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/path-is-inside": {
+			"version": "1.0.0",
+			"resolved": "http://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+			"integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw=="
+		},
+		"@types/pem": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/@types/pem/-/pem-1.9.3.tgz",
+			"integrity": "sha512-+hHbGi9PAyHVeRdMJN6yNuMWoshJ+7oTqYuhBB1/vHq0Tfu46ucbvgxmhwBfe0GCiJZvCa20VHhHsA0mY5W6hQ=="
+		},
 		"@types/puppeteer": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-1.9.0.tgz",
@@ -159,6 +1044,16 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@types/range-parser": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
+			"integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw=="
+		},
+		"@types/relateurl": {
+			"version": "0.2.28",
+			"resolved": "http://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
+			"integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y="
 		},
 		"@types/request": {
 			"version": "2.0.3",
@@ -300,11 +1195,28 @@
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
 			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
 		},
+		"@types/serve-static": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+			"requires": {
+				"@types/express-serve-static-core": "*",
+				"@types/mime": "*"
+			}
+		},
 		"@types/sinon": {
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-5.0.5.tgz",
 			"integrity": "sha512-Wnuv66VhvAD2LEJfZkq8jowXGxe+gjVibeLCYcVBp7QLdw0BFx2sRkKzoiiDkYEPGg5VyqO805Rcj0stVjQwCQ==",
 			"dev": true
+		},
+		"@types/spdy": {
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
+			"integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/temp": {
 			"version": "0.8.32",
@@ -328,10 +1240,38 @@
 			"integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
 			"dev": true
 		},
+		"@types/ua-parser-js": {
+			"version": "0.7.32",
+			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
+			"integrity": "sha512-+z7Q72Mlnq6SFkQYHzLg2Z70pIsgRVzgx1b5PV8eUv5uaZ/zoqIs45XnhtToW4gTeX4FbjIP49nhIjyvPF4rPg=="
+		},
+		"@types/uglify-js": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
+			"integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+			"requires": {
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
 		"@types/update-notifier": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-1.0.3.tgz",
 			"integrity": "sha512-BLStNhP2DFF7funARwTcoD6tetRte8NK3Sc59mn7GNALCN975jOlKX3dGvsFxXr/HwQMxxCuRn9IWB3WQ7odHQ=="
+		},
+		"@types/uuid": {
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+			"integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/vinyl": {
 			"version": "2.0.2",
@@ -349,6 +1289,28 @@
 				"@types/glob-stream": "*",
 				"@types/node": "*",
 				"@types/vinyl": "*"
+			}
+		},
+		"@types/whatwg-url": {
+			"version": "6.4.0",
+			"resolved": "http://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+			"integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-ZrJDWpvg75LTGX4XwuneY9s6bF3OeZcGTpoGh3zDV9ytzcHMFsRrMIaLBRJZQMBoGyKs6unBQfVdrLZiYfb1zQ==",
+			"optional": true
+		},
+		"@types/winston": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
+			"integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
+			"requires": {
+				"winston": "*"
 			}
 		},
 		"@types/yeoman-generator": {
@@ -370,11 +1332,61 @@
 				"@types/yeoman-generator": "*"
 			}
 		},
+		"@webcomponents/webcomponentsjs": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.2.7.tgz",
+			"integrity": "sha512-011DyXjpQoZ7f6oMCpYTYgrzsWJ7+0fEbt6Y8KcfZZa3ZdJ/ttoMgeH75SqHDe7aNdolfMhCvrSNNgh9wcsgpA=="
+		},
 		"abbrev": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
 			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
 			"dev": true
+		},
+		"accepts": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"requires": {
+				"mime-types": "~2.1.18",
+				"negotiator": "0.6.1"
+			}
+		},
+		"accessibility-developer-tools": {
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+			"integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ="
+		},
+		"acorn": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"requires": {
+				"acorn": "^3.0.4"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+				}
+			}
+		},
+		"adm-zip": {
+			"version": "0.4.11",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+			"integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
+			"optional": true
+		},
+		"after": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
 		},
 		"agent-base": {
 			"version": "2.1.1",
@@ -403,6 +1415,12 @@
 				"json-schema-traverse": "^0.3.0"
 			}
 		},
+		"ajv-keywords": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
+		},
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -418,10 +1436,28 @@
 				"string-width": "^1.0.1"
 			}
 		},
+		"ansi-colors": {
+			"version": "1.1.0",
+			"resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "^0.1.0"
+			}
+		},
 		"ansi-escapes": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
 			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+		},
+		"ansi-gray": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
@@ -429,9 +1465,18 @@
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+			"dev": true
 		},
 		"any-promise": {
 			"version": "1.3.0",
@@ -445,6 +1490,39 @@
 			"requires": {
 				"micromatch": "^2.1.5",
 				"normalize-path": "^2.0.0"
+			}
+		},
+		"append-field": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+			"integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
+		},
+		"archiver": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+			"integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+			"requires": {
+				"archiver-utils": "^1.3.0",
+				"async": "^2.0.0",
+				"buffer-crc32": "^0.2.1",
+				"glob": "^7.0.0",
+				"lodash": "^4.8.0",
+				"readable-stream": "^2.0.0",
+				"tar-stream": "^1.5.0",
+				"zip-stream": "^1.2.0"
+			}
+		},
+		"archiver-utils": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+			"integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+			"requires": {
+				"glob": "^7.0.0",
+				"graceful-fs": "^4.1.0",
+				"lazystream": "^1.0.0",
+				"lodash": "^4.8.0",
+				"normalize-path": "^2.0.0",
+				"readable-stream": "^2.0.0"
 			}
 		},
 		"argparse": {
@@ -501,6 +1579,11 @@
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
 		},
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+		},
 		"array-from": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
@@ -524,6 +1607,11 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+		},
+		"arraybuffer.slice": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+			"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -564,8 +1652,7 @@
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-			"dev": true
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -591,27 +1678,280 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
 				"js-tokens": "^3.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
 			}
+		},
+		"babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"requires": {
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+				}
+			}
+		},
+		"babel-helper-evaluate-path": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.4.3.tgz",
+			"integrity": "sha1-ComvcCwGshcCf6NxkI3UmJ0+Yz8="
+		},
+		"babel-helper-flip-expressions": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+			"integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0="
+		},
+		"babel-helper-is-nodes-equiv": {
+			"version": "0.0.1",
+			"resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+			"integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
+		},
+		"babel-helper-is-void-0": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+			"integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4="
+		},
+		"babel-helper-mark-eval-scopes": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+			"integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI="
+		},
+		"babel-helper-remove-or-void": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+			"integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA="
+		},
+		"babel-helper-to-multiple-sequence-expressions": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.4.3.tgz",
+			"integrity": "sha1-W1GLESf0ezA4dzOGoVYaK0jmMrY="
 		},
 		"babel-messages": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-plugin-minify-builtins": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.4.3.tgz",
+			"integrity": "sha1-nqPVn0rEp7uVjXEtKVVqH4b3+B4=",
+			"requires": {
+				"babel-helper-evaluate-path": "^0.4.3"
+			}
+		},
+		"babel-plugin-minify-constant-folding": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.4.3.tgz",
+			"integrity": "sha1-MA+d6N2ghEoXaxk2U5YOJK0z4ZE=",
+			"requires": {
+				"babel-helper-evaluate-path": "^0.4.3"
+			}
+		},
+		"babel-plugin-minify-dead-code-elimination": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.4.3.tgz",
+			"integrity": "sha1-c2KCZYZPkAjQAnUG9Yq+s8HQLZg=",
+			"requires": {
+				"babel-helper-evaluate-path": "^0.4.3",
+				"babel-helper-mark-eval-scopes": "^0.4.3",
+				"babel-helper-remove-or-void": "^0.4.3",
+				"lodash.some": "^4.6.0"
+			}
+		},
+		"babel-plugin-minify-flip-comparisons": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+			"integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
+			"requires": {
+				"babel-helper-is-void-0": "^0.4.3"
+			}
+		},
+		"babel-plugin-minify-guarded-expressions": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.1.tgz",
+			"integrity": "sha1-ylpZoGvBwi3Vz9mWpnUWOm9hm30=",
+			"requires": {
+				"babel-helper-flip-expressions": "^0.4.1"
+			}
+		},
+		"babel-plugin-minify-infinity": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+			"integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco="
+		},
+		"babel-plugin-minify-mangle-names": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.4.3.tgz",
+			"integrity": "sha1-FvG/90t6fJPfwkHngx3V+0sCPvc=",
+			"requires": {
+				"babel-helper-mark-eval-scopes": "^0.4.3"
+			}
+		},
+		"babel-plugin-minify-numeric-literals": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+			"integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw="
+		},
+		"babel-plugin-minify-replace": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.4.3.tgz",
+			"integrity": "sha1-nSifS6FdTmAR6HmfpfG6d+yBIZ0="
+		},
+		"babel-plugin-minify-simplify": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.4.3.tgz",
+			"integrity": "sha1-N3VthcYURktLCSfytOQXGR1Vc4o=",
+			"requires": {
+				"babel-helper-flip-expressions": "^0.4.3",
+				"babel-helper-is-nodes-equiv": "^0.0.1",
+				"babel-helper-to-multiple-sequence-expressions": "^0.4.3"
+			}
+		},
+		"babel-plugin-minify-type-constructors": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+			"integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
+			"requires": {
+				"babel-helper-is-void-0": "^0.4.3"
+			}
+		},
+		"babel-plugin-transform-inline-consecutive-adds": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+			"integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE="
+		},
+		"babel-plugin-transform-member-expression-literals": {
+			"version": "6.10.0-alpha.f95869d4",
+			"resolved": "http://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.10.0-alpha.f95869d4.tgz",
+			"integrity": "sha1-Jy69Ki1DQbhsJNzYQ3SuWqNwKHQ="
+		},
+		"babel-plugin-transform-merge-sibling-variables": {
+			"version": "6.10.0-alpha.f95869d4",
+			"resolved": "http://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.10.0-alpha.f95869d4.tgz",
+			"integrity": "sha1-SKMw0oKT4xjQcXXCYMdIWec5i0M="
+		},
+		"babel-plugin-transform-minify-booleans": {
+			"version": "6.10.0-alpha.f95869d4",
+			"resolved": "http://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.10.0-alpha.f95869d4.tgz",
+			"integrity": "sha1-He72nCITUDipHeH10T11njRkxDw="
+		},
+		"babel-plugin-transform-property-literals": {
+			"version": "6.10.0-alpha.f95869d4",
+			"resolved": "http://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.10.0-alpha.f95869d4.tgz",
+			"integrity": "sha1-NxJ6qgQSXD0Iv5XNtajx0uRMpFM=",
+			"requires": {
+				"esutils": "^2.0.2"
+			}
+		},
+		"babel-plugin-transform-regexp-constructors": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+			"integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU="
+		},
+		"babel-plugin-transform-remove-console": {
+			"version": "6.10.0-alpha.f95869d4",
+			"resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.10.0-alpha.f95869d4.tgz",
+			"integrity": "sha1-xXF6+fdpGLKCHPrvRNgkXU6pQiw="
+		},
+		"babel-plugin-transform-remove-debugger": {
+			"version": "6.10.0-alpha.f95869d4",
+			"resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.10.0-alpha.f95869d4.tgz",
+			"integrity": "sha1-H8NcKcfAh4zzDlWKczZRkG6IjkQ="
+		},
+		"babel-plugin-transform-remove-undefined": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.4.3.tgz",
+			"integrity": "sha1-1AsNp/kcCMBsxyt2dHTAHEiU3gI=",
+			"requires": {
+				"babel-helper-evaluate-path": "^0.4.3"
+			}
+		},
+		"babel-plugin-transform-simplify-comparison-operators": {
+			"version": "6.10.0-alpha.f95869d4",
+			"resolved": "http://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
+			"integrity": "sha1-9UmabcPtaGvaUzY4ZrZ92ndMW+0="
+		},
+		"babel-plugin-transform-undefined-to-void": {
+			"version": "6.10.0-alpha.f95869d4",
+			"resolved": "http://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
+			"integrity": "sha1-F1oaMJDmFkA/jIGc3Ooa7LZlI7I="
+		},
+		"babel-preset-minify": {
+			"version": "0.4.0-alpha.caaefb4c",
+			"resolved": "http://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0-alpha.caaefb4c.tgz",
+			"integrity": "sha1-pQUsWVXdl9JGmbKB/amjAuqMGHE=",
+			"requires": {
+				"babel-plugin-minify-builtins": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-constant-folding": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-dead-code-elimination": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-flip-comparisons": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-guarded-expressions": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-infinity": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-mangle-names": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-numeric-literals": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-replace": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-simplify": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-minify-type-constructors": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-transform-inline-consecutive-adds": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-transform-member-expression-literals": "^6.10.0-alpha.caaefb4c",
+				"babel-plugin-transform-merge-sibling-variables": "^6.10.0-alpha.caaefb4c",
+				"babel-plugin-transform-minify-booleans": "^6.10.0-alpha.caaefb4c",
+				"babel-plugin-transform-property-literals": "^6.10.0-alpha.caaefb4c",
+				"babel-plugin-transform-regexp-constructors": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-transform-remove-console": "^6.10.0-alpha.caaefb4c",
+				"babel-plugin-transform-remove-debugger": "^6.10.0-alpha.caaefb4c",
+				"babel-plugin-transform-remove-undefined": "^0.4.0-alpha.caaefb4c",
+				"babel-plugin-transform-simplify-comparison-operators": "^6.10.0-alpha.caaefb4c",
+				"babel-plugin-transform-undefined-to-void": "^6.10.0-alpha.caaefb4c",
+				"lodash.isplainobject": "^4.0.6"
 			}
 		},
 		"babel-runtime": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -621,7 +1961,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-messages": "^6.23.0",
@@ -638,7 +1977,6 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"esutils": "^2.0.2",
@@ -649,8 +1987,12 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-			"dev": true
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+		},
+		"backo2": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -717,12 +2059,41 @@
 				}
 			}
 		},
+		"base64-arraybuffer": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+		},
+		"base64-js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+			"integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
+		},
+		"base64id": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+			"integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"requires": {
 				"tweetnacl": "^0.14.3"
+			}
+		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+			"dev": true
+		},
+		"better-assert": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+			"integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+			"requires": {
+				"callsite": "1.0.0"
 			}
 		},
 		"binary-extensions": {
@@ -744,10 +2115,62 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
+		"blob": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+			"integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+		},
+		"body-parser": {
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"http-errors": "~1.6.3",
+				"iconv-lite": "0.4.23",
+				"on-finished": "~2.3.0",
+				"qs": "6.5.2",
+				"raw-body": "2.3.3",
+				"type-is": "~1.6.16"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.23",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				}
+			}
+		},
+		"boom": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"requires": {
+				"hoek": "4.x.x"
+			}
+		},
 		"bower": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
 			"integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc="
+		},
+		"bower-config": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
+			"integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
+			"requires": {
+				"graceful-fs": "^4.1.3",
+				"mout": "^1.0.0",
+				"optimist": "^0.6.1",
+				"osenv": "^0.1.3",
+				"untildify": "^2.1.0"
+			}
 		},
 		"bower-json": {
 			"version": "0.8.1",
@@ -779,6 +2202,30 @@
 				"repeating": "^2.0.0",
 				"string-width": "^1.0.1",
 				"widest-line": "^1.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
 			}
 		},
 		"brace-expansion": {
@@ -800,12 +2247,81 @@
 				"repeat-element": "^1.1.2"
 			}
 		},
+		"browser-capabilities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-1.1.2.tgz",
+			"integrity": "sha512-T9BTu9Lmdrh9XZe0XnUY3jGiBlB0jAkl4M9qvt+1SszqlckgcUTzJuBwD6HNNKjdiDA+18KfiIUJEVxTY2W24g==",
+			"requires": {
+				"@types/ua-parser-js": "^0.7.31",
+				"ua-parser-js": "^0.7.15"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
+		},
 		"browserify-zlib": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
 			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
 			"requires": {
 				"pako": "~0.2.0"
+			}
+		},
+		"browserstack": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.1.tgz",
+			"integrity": "sha512-O8VMT64P9NOLhuIoD4YngyxBURefaSdR4QdhG8l6HZ9VxtU7jc3m6jLufFwKA5gaf7fetfB2TnRJnMxyob+heg==",
+			"optional": true,
+			"requires": {
+				"https-proxy-agent": "^2.2.1"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+					"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+					"optional": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"optional": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+					"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+					"optional": true,
+					"requires": {
+						"agent-base": "^4.1.0",
+						"debug": "^3.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"optional": true
+				}
+			}
+		},
+		"buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+			"integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
 			}
 		},
 		"buffer-alloc": {
@@ -822,6 +2338,11 @@
 			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
 			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
 		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+		},
 		"buffer-fill": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -836,6 +2357,43 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"busboy": {
+			"version": "0.2.14",
+			"resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+			"integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+			"requires": {
+				"dicer": "0.2.5",
+				"readable-stream": "1.1.x"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
 		"cache-base": {
 			"version": "1.0.1",
@@ -865,6 +2423,35 @@
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
 			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
 		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
+			"requires": {
+				"callsites": "^0.2.0"
+			}
+		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
+		},
+		"camel-case": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+			"requires": {
+				"no-case": "^2.2.0",
+				"upper-case": "^1.1.1"
+			}
+		},
 		"camelcase": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -879,6 +2466,21 @@
 				"map-obj": "^1.0.0"
 			}
 		},
+		"cancel-token": {
+			"version": "0.1.1",
+			"resolved": "http://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+			"integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+			"requires": {
+				"@types/node": "^4.0.30"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "4.9.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-4.9.0.tgz",
+					"integrity": "sha512-xUFkZ+er9gUGw0x9qyfmr/Th0LuX6IB0m7HrRMB6sO6vcBVRFZ/3YV1EeiOC2fG50RX09avDfKwGBHOnPVxFeg=="
+				}
+			}
+		},
 		"capture-stack-trace": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
@@ -890,21 +2492,24 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chalk": {
-			"version": "1.1.3",
-			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"chokidar": {
 			"version": "1.7.0",
@@ -926,6 +2531,17 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
 			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+		},
+		"ci-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -952,6 +2568,26 @@
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
+		},
+		"clean-css": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+			"requires": {
+				"source-map": "~0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
+		"cleankill": {
+			"version": "2.0.0",
+			"resolved": "http://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
+			"integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE="
 		},
 		"cli-boxes": {
 			"version": "1.0.0",
@@ -1072,6 +2708,12 @@
 				"simple-swizzle": "^0.2.2"
 			}
 		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
+		},
 		"colornames": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
@@ -1161,19 +2803,60 @@
 		"commander": {
 			"version": "2.17.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-			"dev": true,
-			"optional": true
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
 		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
+		"component-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+		},
+		"component-inherit": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+		},
+		"compress-commons": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+			"integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+			"requires": {
+				"buffer-crc32": "^0.2.1",
+				"crc32-stream": "^2.0.0",
+				"normalize-path": "^2.0.0",
+				"readable-stream": "^2.0.0"
+			}
+		},
+		"compressible": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+			"integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+			"requires": {
+				"mime-db": ">= 1.36.0 < 2"
+			}
+		},
+		"compression": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+			"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+			"requires": {
+				"accepts": "~1.3.5",
+				"bytes": "3.0.0",
+				"compressible": "~2.0.14",
+				"debug": "2.6.9",
+				"on-headers": "~1.0.1",
+				"safe-buffer": "5.1.2",
+				"vary": "~1.1.2"
+			}
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1214,6 +2897,16 @@
 				}
 			}
 		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+		},
 		"convert-source-map": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -1221,6 +2914,16 @@
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -1230,13 +2933,36 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"crc": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
+			"integrity": "sha1-XZyPt3okXNXsopHl0tAFM0urAII="
+		},
+		"crc32-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+			"integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+			"requires": {
+				"crc": "^3.4.4",
+				"readable-stream": "^2.0.0"
+			},
+			"dependencies": {
+				"crc": {
+					"version": "3.8.0",
+					"resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+					"integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+					"requires": {
+						"buffer": "^5.1.0"
+					}
+				}
+			}
 		},
 		"create-error-class": {
 			"version": "3.0.2",
@@ -1258,6 +2984,56 @@
 				"which": "^1.2.9"
 			}
 		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+		},
+		"cryptiles": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"requires": {
+				"boom": "5.x.x"
+			},
+			"dependencies": {
+				"boom": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"requires": {
+						"hoek": "4.x.x"
+					}
+				}
+			}
+		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+		},
+		"css-slam": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/css-slam/-/css-slam-2.1.2.tgz",
+			"integrity": "sha512-cObrY+mhFEmepWpua6EpMrgRNTQ0eeym+kvR0lukI6hDEzK7F8himEDS4cJ9+fPHCoArTzVrrR0d+oAUbTR1NA==",
+			"requires": {
+				"command-line-args": "^5.0.2",
+				"command-line-usage": "^5.0.5",
+				"dom5": "^3.0.0",
+				"parse5": "^4.0.0",
+				"shady-css-parser": "^0.1.0"
+			}
+		},
+		"css-what": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+			"integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
+		},
+		"cssbeautify": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
+			"integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
+		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1265,6 +3041,11 @@
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
+		},
+		"cycle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
 		},
 		"dargs": {
 			"version": "6.0.0",
@@ -1431,6 +3212,11 @@
 				"yargs": "^8.0.2"
 			}
 		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+		},
 		"deprecate": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.1.0.tgz",
@@ -1442,6 +3228,11 @@
 			"resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
 			"integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=",
 			"dev": true
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
 		"detect-conflict": {
 			"version": "1.0.1",
@@ -1456,6 +3247,19 @@
 				"fs-exists-sync": "^0.1.0"
 			}
 		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"requires": {
+				"repeating": "^2.0.0"
+			}
+		},
+		"detect-node": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+		},
 		"diagnostics": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
@@ -1464,6 +3268,38 @@
 				"colorspace": "1.1.x",
 				"enabled": "1.0.x",
 				"kuler": "1.0.x"
+			}
+		},
+		"dicer": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+			"integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+			"requires": {
+				"readable-stream": "1.1.x",
+				"streamsearch": "0.1.2"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
 			}
 		},
 		"diff": {
@@ -1492,6 +3328,39 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"requires": {
+				"esutils": "^2.0.2"
+			}
+		},
+		"dom-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
+			"integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
+			"requires": {
+				"urijs": "^1.16.1"
+			}
+		},
+		"dom5": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.1.tgz",
+			"integrity": "sha512-JPFiouQIr16VQ4dX6i0+Hpbg3H2bMKPmZ+WZgBOSSvOPx9QHwwY8sPzeM2baUtViESYto6wC2nuZOMC/6gulcA==",
+			"requires": {
+				"@types/parse5": "^2.2.34",
+				"clone": "^2.1.0",
+				"parse5": "^4.0.0"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 				}
 			}
 		},
@@ -1541,10 +3410,20 @@
 			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
 			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
 		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
 		"ejs": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+		},
+		"emitter-component": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+			"integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
 		},
 		"enabled": {
 			"version": "1.0.2",
@@ -1553,6 +3432,11 @@
 			"requires": {
 				"env-variable": "0.0.x"
 			}
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -1566,6 +3450,89 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
 			"integrity": "sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o="
+		},
+		"engine.io": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
+			"integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+			"requires": {
+				"accepts": "~1.3.4",
+				"base64id": "1.0.0",
+				"cookie": "0.3.1",
+				"debug": "~3.1.0",
+				"engine.io-parser": "~2.1.0",
+				"ws": "~3.3.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ws": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+					"requires": {
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0",
+						"ultron": "~1.1.0"
+					}
+				}
+			}
+		},
+		"engine.io-client": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+			"integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+			"requires": {
+				"component-emitter": "1.2.1",
+				"component-inherit": "0.0.3",
+				"debug": "~3.1.0",
+				"engine.io-parser": "~2.1.1",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
+				"ws": "~3.3.1",
+				"xmlhttprequest-ssl": "~1.5.4",
+				"yeast": "0.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ws": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+					"requires": {
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0",
+						"ultron": "~1.1.0"
+					}
+				}
+			}
+		},
+		"engine.io-parser": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+			"integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+			"requires": {
+				"after": "0.8.2",
+				"arraybuffer.slice": "~0.0.7",
+				"base64-arraybuffer": "0.1.5",
+				"blob": "0.0.4",
+				"has-binary2": "~1.0.2"
+			}
 		},
 		"env-variable": {
 			"version": "0.0.5",
@@ -1592,17 +3559,20 @@
 		"es6-promise": {
 			"version": "4.2.5",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-			"integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
-			"dev": true
+			"integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -1640,11 +3610,315 @@
 				}
 			}
 		},
+		"eslint": {
+			"version": "4.19.1",
+			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+			"dev": true,
+			"requires": {
+				"ajv": "^5.3.0",
+				"babel-code-frame": "^6.22.0",
+				"chalk": "^2.1.0",
+				"concat-stream": "^1.6.0",
+				"cross-spawn": "^5.1.0",
+				"debug": "^3.1.0",
+				"doctrine": "^2.1.0",
+				"eslint-scope": "^3.7.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^3.5.4",
+				"esquery": "^1.0.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"functional-red-black-tree": "^1.0.1",
+				"glob": "^7.1.2",
+				"globals": "^11.0.1",
+				"ignore": "^3.3.3",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^3.0.6",
+				"is-resolvable": "^1.0.0",
+				"js-yaml": "^3.9.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.2",
+				"pluralize": "^7.0.0",
+				"progress": "^2.0.0",
+				"regexpp": "^1.0.1",
+				"require-uncached": "^1.0.3",
+				"semver": "^5.3.0",
+				"strip-ansi": "^4.0.0",
+				"strip-json-comments": "~2.0.1",
+				"table": "4.0.2",
+				"text-table": "~0.2.0"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+					"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"chardet": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+					"dev": true
+				},
+				"cli-cursor": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^2.0.0"
+					}
+				},
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"external-editor": {
+					"version": "2.2.0",
+					"resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+					"dev": true,
+					"requires": {
+						"chardet": "^0.4.0",
+						"iconv-lite": "^0.4.17",
+						"tmp": "^0.0.33"
+					}
+				},
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
+					}
+				},
+				"globals": {
+					"version": "11.8.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+					"dev": true
+				},
+				"inquirer": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^2.0.4",
+						"figures": "^2.0.0",
+						"lodash": "^4.3.0",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rx-lite": "^4.0.8",
+						"rx-lite-aggregates": "^4.0.8",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"mute-stream": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+					"dev": true
+				},
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"restore-cursor": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"dev": true,
+					"requires": {
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"tmp": {
+					"version": "0.0.33",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"dev": true,
+					"requires": {
+						"os-tmpdir": "~1.0.2"
+					}
+				}
+			}
+		},
+		"eslint-scope": {
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+			"integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+					"dev": true
+				}
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
+		},
+		"espree": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"requires": {
+				"acorn": "^5.5.0",
+				"acorn-jsx": "^3.0.0"
+			}
+		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
+		},
+		"esquery": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.0.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+					"dev": true
+				}
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.1.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+					"dev": true
+				}
+			}
 		},
 		"estraverse": {
 			"version": "1.9.3",
@@ -1655,14 +3929,22 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
+		"eventemitter3": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
 		},
 		"execa": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -1677,7 +3959,6 @@
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"shebang-command": "^1.2.0",
@@ -1713,6 +3994,50 @@
 			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
 			"requires": {
 				"os-homedir": "^1.0.1"
+			}
+		},
+		"express": {
+			"version": "4.16.4",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"requires": {
+				"accepts": "~1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.3",
+				"content-disposition": "0.5.2",
+				"content-type": "~1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "1.1.1",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "~2.0.4",
+				"qs": "6.5.2",
+				"range-parser": "~1.2.0",
+				"safe-buffer": "5.1.2",
+				"send": "0.16.2",
+				"serve-static": "1.13.2",
+				"setprototypeof": "1.1.0",
+				"statuses": "~1.4.0",
+				"type-is": "~1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"path-to-regexp": {
+					"version": "0.1.7",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+				}
 			}
 		},
 		"ext-list": {
@@ -1802,6 +4127,22 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"eyes": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+		},
+		"fancy-log": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+			"dev": true,
+			"requires": {
+				"ansi-gray": "^0.1.1",
+				"color-support": "^1.1.3",
+				"time-stamp": "^1.0.0"
+			}
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
@@ -2111,8 +4452,7 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fast-safe-stringify": {
 			"version": "2.0.6",
@@ -2142,6 +4482,16 @@
 				"object-assign": "^4.1.0"
 			}
 		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
+			}
+		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -2163,6 +4513,35 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
 			"integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
+		},
+		"finalhandler": {
+			"version": "1.1.1",
+			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"statuses": "~1.4.0",
+				"unpipe": "~1.0.0"
+			}
+		},
+		"find-port": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/find-port/-/find-port-1.0.1.tgz",
+			"integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
+			"requires": {
+				"async": "~0.2.9"
+			},
+			"dependencies": {
+				"async": {
+					"version": "0.2.10",
+					"resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+					"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+				}
+			}
 		},
 		"find-replace": {
 			"version": "2.0.1",
@@ -2198,6 +4577,49 @@
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
 			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
 		},
+		"flat-cache": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
+			"requires": {
+				"circular-json": "^0.3.1",
+				"del": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"write": "^0.2.1"
+			},
+			"dependencies": {
+				"del": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+					"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+					"dev": true,
+					"requires": {
+						"globby": "^5.0.0",
+						"is-path-cwd": "^1.0.0",
+						"is-path-in-cwd": "^1.0.0",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"rimraf": "^2.2.8"
+					}
+				},
+				"globby": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+					"dev": true,
+					"requires": {
+						"array-union": "^1.0.1",
+						"arrify": "^1.0.0",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				}
+			}
+		},
 		"follow-redirects": {
 			"version": "0.0.7",
 			"resolved": "http://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
@@ -2225,6 +4647,11 @@
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
+		"fork-stream": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+			"integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA="
+		},
 		"form-data": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
@@ -2245,6 +4672,19 @@
 				}
 			}
 		},
+		"formatio": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+			"integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+			"requires": {
+				"samsam": "1.x"
+			}
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -2252,6 +4692,17 @@
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
+		},
+		"freeport": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz",
+			"integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
+			"optional": true
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"fs-constants": {
 			"version": "1.0.0",
@@ -2741,6 +5192,12 @@
 				}
 			}
 		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -2942,6 +5399,14 @@
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
 			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
 		},
+		"global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"requires": {
+				"ini": "^1.3.4"
+			}
+		},
 		"global-modules": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
@@ -2979,8 +5444,7 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-			"dev": true
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"globby": {
 			"version": "8.0.1",
@@ -3001,6 +5465,15 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
+			}
+		},
+		"glogg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"dev": true,
+			"requires": {
+				"sparkles": "^1.0.0"
 			}
 		},
 		"got": {
@@ -3038,6 +5511,88 @@
 				"lodash": "^4.17.2"
 			}
 		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
+		},
+		"gulp-eslint": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-4.0.2.tgz",
+			"integrity": "sha512-fcFUQzFsN6dJ6KZlG+qPOEkqfcevRUXgztkYCvhNvJeSvOicC8ucutN4qR/ID8LmNZx9YPIkBzazTNnVvbh8wg==",
+			"dev": true,
+			"requires": {
+				"eslint": "^4.0.0",
+				"fancy-log": "^1.3.2",
+				"plugin-error": "^1.0.0"
+			}
+		},
+		"gulp-if": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+			"integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
+			"requires": {
+				"gulp-match": "^1.0.3",
+				"ternary-stream": "^2.0.1",
+				"through2": "^2.0.1"
+			}
+		},
+		"gulp-match": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+			"integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
+			"requires": {
+				"minimatch": "^3.0.3"
+			}
+		},
+		"gulp-mocha": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-6.0.0.tgz",
+			"integrity": "sha512-FfBldW5ttnDpKf4Sg6/BLOOKCCbr5mbixDGK1t02/8oSrTCwNhgN/mdszG3cuQuYNzuouUdw4EH/mlYtgUscPg==",
+			"dev": true,
+			"requires": {
+				"dargs": "^5.1.0",
+				"execa": "^0.10.0",
+				"mocha": "^5.2.0",
+				"npm-run-path": "^2.0.2",
+				"plugin-error": "^1.0.1",
+				"supports-color": "^5.4.0",
+				"through2": "^2.0.3"
+			},
+			"dependencies": {
+				"dargs": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+					"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk=",
+					"dev": true
+				},
+				"execa": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
 		"gulp-sourcemaps": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
@@ -3048,6 +5603,217 @@
 				"strip-bom": "^2.0.0",
 				"through2": "^2.0.0",
 				"vinyl": "^1.0.0"
+			}
+		},
+		"gulp-tslint": {
+			"version": "8.1.3",
+			"resolved": "https://registry.npmjs.org/gulp-tslint/-/gulp-tslint-8.1.3.tgz",
+			"integrity": "sha512-KEP350N5B9Jg6o6jnyCyKVBPemJePYpMsGfIQq0G0ErvY7tw4Lrfb/y3L4WRf7ek0OsaE8nnj86w+lcLXW8ovw==",
+			"dev": true,
+			"requires": {
+				"@types/fancy-log": "1.3.0",
+				"chalk": "2.3.1",
+				"fancy-log": "1.3.2",
+				"map-stream": "~0.0.7",
+				"plugin-error": "1.0.1",
+				"through": "~2.3.8"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.3.1",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+					"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.2.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"gulp-typescript": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.2.4.tgz",
+			"integrity": "sha512-bZosNvbUGzFA4bjjWoUPyjU5vfgJSzlYKkU0Jutbsrj+td8yvtqxethhqfzB9MwyamaUODIuidj5gIytZ523Bw==",
+			"dev": true,
+			"requires": {
+				"gulp-util": "~3.0.7",
+				"source-map": "~0.5.3",
+				"through2": "~2.0.1",
+				"vinyl-fs": "~2.4.3"
+			}
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"dev": true,
+			"requires": {
+				"array-differ": "^1.0.0",
+				"array-uniq": "^1.0.2",
+				"beeper": "^1.0.0",
+				"chalk": "^1.0.0",
+				"dateformat": "^2.0.0",
+				"fancy-log": "^1.1.0",
+				"gulplog": "^1.0.0",
+				"has-gulplog": "^0.1.0",
+				"lodash._reescape": "^3.0.0",
+				"lodash._reevaluate": "^3.0.0",
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.template": "^3.0.0",
+				"minimist": "^1.1.0",
+				"multipipe": "^0.1.2",
+				"object-assign": "^3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "^2.0.0",
+				"vinyl": "^0.5.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"dateformat": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+					"dev": true
+				},
+				"duplexer2": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+					"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "~1.1.9"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"lodash.template": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+					"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+					"dev": true,
+					"requires": {
+						"lodash._basecopy": "^3.0.0",
+						"lodash._basetostring": "^3.0.0",
+						"lodash._basevalues": "^3.0.0",
+						"lodash._isiterateecall": "^3.0.0",
+						"lodash._reinterpolate": "^3.0.0",
+						"lodash.escape": "^3.0.0",
+						"lodash.keys": "^3.0.0",
+						"lodash.restparam": "^3.0.0",
+						"lodash.templatesettings": "^3.0.0"
+					}
+				},
+				"lodash.templatesettings": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+					"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+					"dev": true,
+					"requires": {
+						"lodash._reinterpolate": "^3.0.0",
+						"lodash.escape": "^3.0.0"
+					}
+				},
+				"multipipe": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+					"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+					"dev": true,
+					"requires": {
+						"duplexer2": "0.0.2"
+					}
+				},
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				},
+				"vinyl": {
+					"version": "0.5.3",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+					"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+					"dev": true,
+					"requires": {
+						"clone": "^1.0.0",
+						"clone-stats": "^0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"dev": true,
+			"requires": {
+				"glogg": "^1.0.0"
 			}
 		},
 		"gunzip-maybe": {
@@ -3062,6 +5828,11 @@
 				"pumpify": "^1.3.3",
 				"through2": "^2.0.3"
 			}
+		},
+		"handle-thing": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+			"integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
 		},
 		"handlebars": {
 			"version": "4.0.12",
@@ -3105,10 +5876,44 @@
 				"ansi-regex": "^2.0.0"
 			}
 		},
+		"has-binary2": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+			"integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+			"requires": {
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+				}
+			}
+		},
+		"has-color": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+		},
+		"has-cors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+			"integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"dev": true,
+			"requires": {
+				"sparkles": "^1.0.0"
+			}
 		},
 		"has-symbol-support-x": {
 			"version": "1.4.2",
@@ -3177,6 +5982,27 @@
 				}
 			}
 		},
+		"hawk": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"requires": {
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
+			}
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+		},
+		"hoek": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+		},
 		"homedir-polyfill": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
@@ -3189,6 +6015,101 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+		},
+		"hpack.js": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+			"requires": {
+				"inherits": "^2.0.1",
+				"obuf": "^1.0.0",
+				"readable-stream": "^2.0.1",
+				"wbuf": "^1.1.0"
+			}
+		},
+		"html-minifier": {
+			"version": "3.5.20",
+			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
+			"integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
+			"requires": {
+				"camel-case": "3.0.x",
+				"clean-css": "4.2.x",
+				"commander": "2.17.x",
+				"he": "1.1.x",
+				"param-case": "2.1.x",
+				"relateurl": "0.2.x",
+				"uglify-js": "3.4.x"
+			}
+		},
+		"http-deceiver": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+			"integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+		},
+		"http-errors": {
+			"version": "1.6.3",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.0",
+				"statuses": ">= 1.4.0 < 2"
+			}
+		},
+		"http-proxy": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+			"integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+			"requires": {
+				"eventemitter3": "^3.0.0",
+				"follow-redirects": "^1.0.0",
+				"requires-port": "^1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"follow-redirects": {
+					"version": "1.5.9",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+					"integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+					"requires": {
+						"debug": "=3.1.0"
+					}
+				}
+			}
+		},
+		"http-proxy-middleware": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
+			"requires": {
+				"http-proxy": "^1.16.2",
+				"is-glob": "^3.1.0",
+				"lodash": "^4.17.2",
+				"micromatch": "^2.3.11"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
+			}
 		},
 		"http-signature": {
 			"version": "1.2.0",
@@ -3218,15 +6139,30 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
+		"ieee754": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+		},
 		"ignore": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
 			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
 		},
+		"import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+		},
+		"indent": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
+			"integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
 		},
 		"indent-string": {
 			"version": "2.1.0",
@@ -3235,6 +6171,11 @@
 			"requires": {
 				"repeating": "^2.0.0"
 			}
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -3274,6 +6215,30 @@
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.0",
 				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
 			}
 		},
 		"interpret": {
@@ -3290,7 +6255,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -3300,6 +6264,11 @@
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 			"dev": true
+		},
+		"ipaddr.js": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -3333,6 +6302,14 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
 				"builtin-modules": "^1.0.0"
+			}
+		},
+		"is-ci": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+			"requires": {
+				"ci-info": "^1.5.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -3416,6 +6393,15 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
 			"integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+		},
+		"is-installed-globally": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"requires": {
+				"global-dirs": "^0.1.0",
+				"is-path-inside": "^1.0.0"
+			}
 		},
 		"is-npm": {
 			"version": "1.0.0",
@@ -3505,6 +6491,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
 			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
@@ -3667,8 +6659,7 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
 			"version": "3.12.0",
@@ -3684,6 +6675,11 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+		},
+		"jsesc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -3708,10 +6704,21 @@
 				"jsonify": "~0.0.0"
 			}
 		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
 			"version": "4.0.0",
@@ -3726,6 +6733,11 @@
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsonschema": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3766,6 +6778,28 @@
 			"integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
 			"requires": {
 				"package-json": "^2.0.0"
+			}
+		},
+		"launchpad": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/launchpad/-/launchpad-0.7.0.tgz",
+			"integrity": "sha1-9CfTwOFehp7hVROCi6/vwW+ce8M=",
+			"optional": true,
+			"requires": {
+				"async": "^2.0.1",
+				"browserstack": "^1.2.0",
+				"debug": "^2.2.0",
+				"plist": "^2.0.1",
+				"q": "^1.4.1",
+				"underscore": "^1.8.3"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+					"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+					"optional": true
+				}
 			}
 		},
 		"lazy-req": {
@@ -3833,10 +6867,77 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+			"dev": true
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+			"dev": true
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+			"dev": true
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+			"dev": true
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+			"dev": true
+		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"dev": true,
+			"requires": {
+				"lodash._root": "^3.0.0"
+			}
 		},
 		"lodash.get": {
 			"version": "4.4.2",
@@ -3844,15 +6945,76 @@
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
 		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
+			}
+		},
 		"lodash.padend": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
 			"integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
+		},
+		"lodash.some": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"lodash.template": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+			"requires": {
+				"lodash._reinterpolate": "~3.0.0",
+				"lodash.templatesettings": "^4.0.0"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+			"requires": {
+				"lodash._reinterpolate": "~3.0.0"
+			}
 		},
 		"log-symbols": {
 			"version": "1.0.2",
@@ -3860,6 +7022,30 @@
 			"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 			"requires": {
 				"chalk": "^1.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
 			}
 		},
 		"logform": {
@@ -3891,7 +7077,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -3905,6 +7090,11 @@
 				"signal-exit": "^3.0.0"
 			}
 		},
+		"lower-case": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+		},
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -3914,10 +7104,17 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
+			}
+		},
+		"magic-string": {
+			"version": "0.22.5",
+			"resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+			"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+			"requires": {
+				"vlq": "^0.2.2"
 			}
 		},
 		"make-dir": {
@@ -3945,6 +7142,12 @@
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 		},
+		"map-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+			"dev": true
+		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -3953,10 +7156,33 @@
 				"object-visit": "^1.0.0"
 			}
 		},
+		"matcher": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+			"integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
+			"requires": {
+				"escape-string-regexp": "^1.0.4"
+			}
+		},
 		"math-random": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
 			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+		},
+		"md5": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+			"requires": {
+				"charenc": "~0.0.1",
+				"crypt": "~0.0.1",
+				"is-buffer": "~1.1.1"
+			}
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
 			"version": "1.1.0",
@@ -4082,6 +7308,11 @@
 				"trim-newlines": "^1.0.0"
 			}
 		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
 		"merge-stream": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -4094,6 +7325,11 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
 			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
 		"micromatch": {
 			"version": "2.3.11",
@@ -4143,12 +7379,25 @@
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
 			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
 		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
 				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimatch-all": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/minimatch-all/-/minimatch-all-1.1.0.tgz",
+			"integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
+			"requires": {
+				"minimatch": "^3.0.2"
 			}
 		},
 		"minimist": {
@@ -4190,10 +7439,95 @@
 				}
 			}
 		},
+		"mocha": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+			"dev": true,
+			"requires": {
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.5",
+				"he": "1.1.1",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"supports-color": "5.4.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"diff": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"mout": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
+			"integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw=="
+		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"multer": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/multer/-/multer-1.4.1.tgz",
+			"integrity": "sha512-zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==",
+			"requires": {
+				"append-field": "^1.0.0",
+				"busboy": "^0.2.11",
+				"concat-stream": "^1.5.2",
+				"mkdirp": "^0.5.1",
+				"object-assign": "^4.1.1",
+				"on-finished": "^2.3.0",
+				"type-is": "^1.6.4",
+				"xtend": "^4.0.0"
+			}
 		},
 		"multimatch": {
 			"version": "2.1.0",
@@ -4204,6 +7538,15 @@
 				"array-union": "^1.0.1",
 				"arrify": "^1.0.0",
 				"minimatch": "^3.0.0"
+			}
+		},
+		"multipipe": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+			"integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+			"requires": {
+				"duplexer2": "^0.1.2",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"mute-stream": {
@@ -4262,6 +7605,22 @@
 				}
 			}
 		},
+		"native-promise-only": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+			"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+		},
 		"netrc": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
@@ -4296,10 +7655,49 @@
 				}
 			}
 		},
+		"no-case": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"requires": {
+				"lower-case": "^1.1.1"
+			}
+		},
 		"node-status-codes": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
 			"integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+		},
+		"nomnom": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+			"requires": {
+				"chalk": "~0.4.0",
+				"underscore": "~1.6.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+				},
+				"chalk": {
+					"version": "0.4.0",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+					"requires": {
+						"ansi-styles": "~1.0.0",
+						"has-color": "~0.1.0",
+						"strip-ansi": "~0.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "0.1.1",
+					"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+				}
+			}
 		},
 		"nopt": {
 			"version": "3.0.6",
@@ -4333,7 +7731,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -4352,6 +7749,11 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-component": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+			"integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -4412,6 +7814,24 @@
 				}
 			}
 		},
+		"obuf": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+			"integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"on-headers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4430,11 +7850,18 @@
 			"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 		},
+		"opn": {
+			"version": "3.0.3",
+			"resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+			"integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
+			"requires": {
+				"object-assign": "^4.0.1"
+			}
+		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
@@ -4443,14 +7870,12 @@
 				"minimist": {
 					"version": "0.0.10",
 					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-					"dev": true
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
 				},
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-					"dev": true
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 				}
 			}
 		},
@@ -4572,6 +7997,14 @@
 			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
 			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
 		},
+		"param-case": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+			"requires": {
+				"no-case": "^2.2.0"
+			}
+		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -4595,6 +8028,32 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+		},
+		"parseqs": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+			"requires": {
+				"better-assert": "~1.0.0"
+			}
+		},
+		"parseuri": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+			"requires": {
+				"better-assert": "~1.0.0"
+			}
+		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -4638,7 +8097,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-			"dev": true,
 			"requires": {
 				"isarray": "0.0.1"
 			},
@@ -4646,8 +8104,7 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				}
 			}
 		},
@@ -4671,11 +8128,28 @@
 				"through2": "^2.0.3"
 			}
 		},
+		"pem": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/pem/-/pem-1.13.1.tgz",
+			"integrity": "sha512-gA/kl8/MWWBaVRRv8M4iRkaJXEbp0L9NyG5ggZlbvQxylZAq5K5wGesAZifs89kwL/m4EGdekXtBMOzXM9rv7w==",
+			"requires": {
+				"es6-promisify": "^6.0.0",
+				"md5": "^2.2.1",
+				"os-tmpdir": "^1.0.1",
+				"which": "^1.3.1"
+			},
+			"dependencies": {
+				"es6-promisify": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.0.tgz",
+					"integrity": "sha512-8Tbqjrb8lC85dd81haajYwuRmiU2rkqNAFnlvQOJeeKqdUloIlI+JcUqeJruV4rCm5Y7oNU7jfs2FbmxhRR/2g=="
+				}
+			}
+		},
 		"pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-			"dev": true
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -4700,6 +8174,43 @@
 				"pinkie": "^2.0.0"
 			}
 		},
+		"plist": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+			"integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+			"optional": true,
+			"requires": {
+				"base64-js": "1.2.0",
+				"xmlbuilder": "8.2.2",
+				"xmldom": "0.1.x"
+			}
+		},
+		"plugin-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+			"integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^1.0.1",
+				"arr-diff": "^4.0.0",
+				"arr-union": "^3.1.0",
+				"extend-shallow": "^3.0.2"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				}
+			}
+		},
+		"pluralize": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
+		},
 		"plylog": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/plylog/-/plylog-1.1.0.tgz",
@@ -4708,6 +8219,377 @@
 				"logform": "^1.9.1",
 				"winston": "^3.0.0",
 				"winston-transport": "^4.2.0"
+			}
+		},
+		"polymer-analyzer": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.1.3.tgz",
+			"integrity": "sha512-PU2gp7I4PT9/oNweNaDOS/g8mnfxarDSvUCHJ/ThJSH/gkIeqtDr6v/35Eky8G/5NjE7rPHbY+l+PGXlTKAC9w==",
+			"requires": {
+				"@babel/generator": "^7.0.0-beta.42",
+				"@babel/traverse": "^7.0.0-beta.42",
+				"@babel/types": "^7.0.0-beta.42",
+				"@types/babel-generator": "^6.25.1",
+				"@types/babel-traverse": "^6.25.2",
+				"@types/babel-types": "^6.25.1",
+				"@types/babylon": "^6.16.2",
+				"@types/chai-subset": "^1.3.0",
+				"@types/chalk": "^0.4.30",
+				"@types/clone": "^0.1.30",
+				"@types/cssbeautify": "^0.3.1",
+				"@types/doctrine": "^0.0.1",
+				"@types/is-windows": "^0.2.0",
+				"@types/minimatch": "^3.0.1",
+				"@types/parse5": "^2.2.34",
+				"@types/path-is-inside": "^1.0.0",
+				"@types/resolve": "0.0.6",
+				"@types/whatwg-url": "^6.4.0",
+				"babylon": "^7.0.0-beta.42",
+				"cancel-token": "^0.1.1",
+				"chalk": "^1.1.3",
+				"clone": "^2.0.0",
+				"cssbeautify": "^0.3.1",
+				"doctrine": "^2.0.2",
+				"dom5": "^3.0.0",
+				"indent": "0.0.2",
+				"is-windows": "^1.0.2",
+				"jsonschema": "^1.1.0",
+				"minimatch": "^3.0.4",
+				"parse5": "^4.0.0",
+				"path-is-inside": "^1.0.2",
+				"resolve": "^1.5.0",
+				"shady-css-parser": "^0.1.0",
+				"stable": "^0.1.6",
+				"strip-indent": "^2.0.0",
+				"vscode-uri": "^1.0.1",
+				"whatwg-url": "^6.4.0"
+			},
+			"dependencies": {
+				"@types/resolve": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+					"integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"babylon": {
+					"version": "7.0.0-beta.47",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+				},
+				"strip-indent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"polymer-build": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-3.1.0.tgz",
+			"integrity": "sha512-DwSiOtd1ERpGPfVCqi7SdSjW97yg4oGeUBtg2tnD/ZyEANNFSBCrkEtOFchKm/H5gCCjSEpLqqchTPrqZAYNcw==",
+			"requires": {
+				"@babel/core": "^7.0.0",
+				"@babel/plugin-external-helpers": "^7.0.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+				"@babel/plugin-syntax-async-generators": "^7.0.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.0.0",
+				"@babel/plugin-syntax-import-meta": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"@babel/plugin-transform-arrow-functions": "^7.0.0",
+				"@babel/plugin-transform-async-to-generator": "^7.0.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+				"@babel/plugin-transform-block-scoping": "^7.0.0",
+				"@babel/plugin-transform-classes": "^7.0.0",
+				"@babel/plugin-transform-computed-properties": "^7.0.0",
+				"@babel/plugin-transform-destructuring": "^7.0.0",
+				"@babel/plugin-transform-duplicate-keys": "^7.0.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+				"@babel/plugin-transform-for-of": "^7.0.0",
+				"@babel/plugin-transform-function-name": "^7.0.0",
+				"@babel/plugin-transform-instanceof": "^7.0.0",
+				"@babel/plugin-transform-literals": "^7.0.0",
+				"@babel/plugin-transform-modules-amd": "^7.0.0",
+				"@babel/plugin-transform-object-super": "^7.0.0",
+				"@babel/plugin-transform-parameters": "^7.0.0",
+				"@babel/plugin-transform-regenerator": "^7.0.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.0.0",
+				"@babel/plugin-transform-spread": "^7.0.0",
+				"@babel/plugin-transform-sticky-regex": "^7.0.0",
+				"@babel/plugin-transform-template-literals": "^7.0.0",
+				"@babel/plugin-transform-typeof-symbol": "^7.0.0",
+				"@babel/plugin-transform-unicode-regex": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@polymer/esm-amd-loader": "^1.0.0",
+				"@types/babel-types": "^6.25.1",
+				"@types/babylon": "^6.16.2",
+				"@types/gulp-if": "0.0.33",
+				"@types/html-minifier": "^3.5.1",
+				"@types/is-windows": "^0.2.0",
+				"@types/mz": "0.0.31",
+				"@types/parse5": "^2.2.34",
+				"@types/resolve": "0.0.7",
+				"@types/uuid": "^3.4.3",
+				"@types/vinyl": "^2.0.0",
+				"@types/vinyl-fs": "^2.4.8",
+				"babel-plugin-minify-guarded-expressions": "=0.4.1",
+				"babel-preset-minify": "=0.4.0-alpha.caaefb4c",
+				"babylon": "^7.0.0-beta.42",
+				"css-slam": "^2.1.2",
+				"dom5": "^3.0.0",
+				"gulp-if": "^2.0.2",
+				"html-minifier": "^3.5.10",
+				"matcher": "^1.1.0",
+				"multipipe": "^1.0.2",
+				"mz": "^2.6.0",
+				"parse5": "^4.0.0",
+				"plylog": "^1.0.0",
+				"polymer-analyzer": "^3.1.3",
+				"polymer-bundler": "^4.0.3",
+				"polymer-project-config": "^4.0.0",
+				"regenerator-runtime": "^0.11.1",
+				"stream": "0.0.2",
+				"sw-precache": "^5.1.1",
+				"uuid": "^3.2.1",
+				"vinyl": "^1.2.0",
+				"vinyl-fs": "^2.4.4"
+			},
+			"dependencies": {
+				"@types/resolve": {
+					"version": "0.0.7",
+					"resolved": "http://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
+					"integrity": "sha512-GPewdjkb0Q76o459qgp6pBLzJj/bD3oveS2kfLhIkZ9U3t3AFKtl5DlFB6lGTw0iZmcmxoGC8lpLW3NNJKrN9A==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"@types/vinyl-fs": {
+					"version": "2.4.9",
+					"resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-2.4.9.tgz",
+					"integrity": "sha512-Q0EXd6c1fORjiOuK4ZaKdfFcMyFzJlTi56dqktwaWVLIDAzE49wUs3bKnYbZwzyMWoH+NcMWnRuR73S9A0jnRA==",
+					"requires": {
+						"@types/events": "*",
+						"@types/glob-stream": "*",
+						"@types/node": "*",
+						"@types/vinyl": "*"
+					}
+				},
+				"babylon": {
+					"version": "7.0.0-beta.47",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+				}
+			}
+		},
+		"polymer-bundler": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.3.tgz",
+			"integrity": "sha512-PRx9iQc5Ku8kk3qIOxrevPc33CGrhiW/2th2PgGkUB+xUZabu8i2ngcC7hvZ7PWm4ujFhn45WYi+we4b+SGUIw==",
+			"requires": {
+				"@types/babel-generator": "^6.25.1",
+				"@types/babel-traverse": "^6.25.3",
+				"babel-generator": "^6.26.1",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"clone": "^2.1.0",
+				"command-line-args": "^5.0.2",
+				"command-line-usage": "^5.0.5",
+				"dom5": "^3.0.0",
+				"espree": "^3.5.2",
+				"magic-string": "^0.22.4",
+				"mkdirp": "^0.5.1",
+				"parse5": "^4.0.0",
+				"polymer-analyzer": "^3.1.3",
+				"rollup": "^0.64.1",
+				"source-map": "^0.5.6",
+				"vscode-uri": "^1.0.1"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+				}
+			}
+		},
+		"polymer-linter": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/polymer-linter/-/polymer-linter-3.0.1.tgz",
+			"integrity": "sha512-eDh2CeswZz4Rwf8gfYXpMN66pieq4qJvP9bH3m39LLGm81hRePo4N5OHoQzR5unen1PUdmtjDv0Iicz3dTYEZQ==",
+			"requires": {
+				"@types/fast-levenshtein": "0.0.1",
+				"@types/parse5": "^2.2.34",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"cancel-token": "^0.1.1",
+				"css-what": "^2.1.0",
+				"dom5": "^3.0.0",
+				"fast-levenshtein": "^2.0.6",
+				"parse5": "^4.0.0",
+				"polymer-analyzer": "^3.0.0",
+				"shady-css-parser": "^0.1.0",
+				"stable": "^0.1.6",
+				"strip-indent": "^2.0.0",
+				"validate-element-name": "^2.1.1"
+			},
+			"dependencies": {
+				"strip-indent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+				}
+			}
+		},
+		"polymer-project-config": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-4.0.2.tgz",
+			"integrity": "sha512-nnxLkbpYYPIVBYooeercovQIWqq4coHzQ5PwK2+NxNpVWUJ5tW3OCDt46dqw3CtJNe4r/qIOkPgBJdVwXAAEmw==",
+			"requires": {
+				"@types/node": "^9.6.4",
+				"browser-capabilities": "^1.0.0",
+				"jsonschema": "^1.1.1",
+				"minimatch-all": "^1.1.0",
+				"plylog": "^0.5.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "9.6.35",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.35.tgz",
+					"integrity": "sha512-h5zvHS8wXHGa+Gcqs9K8vqCgOtqjr0+NqG/DDJmQIX1wpR9HivAfgV8bjcD3mGM4bPfQw5Aneb2Pn8355L83jA=="
+				},
+				"async": {
+					"version": "1.0.0",
+					"resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+				},
+				"colors": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+				},
+				"plylog": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/plylog/-/plylog-0.5.0.tgz",
+					"integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
+					"requires": {
+						"@types/node": "^4.2.3",
+						"@types/winston": "^2.2.0",
+						"winston": "^2.2.0"
+					},
+					"dependencies": {
+						"@types/node": {
+							"version": "4.9.0",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-4.9.0.tgz",
+							"integrity": "sha512-xUFkZ+er9gUGw0x9qyfmr/Th0LuX6IB0m7HrRMB6sO6vcBVRFZ/3YV1EeiOC2fG50RX09avDfKwGBHOnPVxFeg=="
+						}
+					}
+				},
+				"winston": {
+					"version": "2.4.4",
+					"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+					"integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+					"requires": {
+						"async": "~1.0.0",
+						"colors": "1.0.x",
+						"cycle": "1.0.x",
+						"eyes": "0.1.x",
+						"isstream": "0.1.x",
+						"stack-trace": "0.0.x"
+					}
+				}
+			}
+		},
+		"polyserve": {
+			"version": "0.27.13",
+			"resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.27.13.tgz",
+			"integrity": "sha512-9YlIJRx4TJ07ywVHpK/+W4tEPMcoJ4oyJWHkSDrPck5jmT5bitCme8dONCSxERZrE4J8hagHE3oOPa5U9iFfYg==",
+			"requires": {
+				"@types/compression": "^0.0.33",
+				"@types/content-type": "^1.1.0",
+				"@types/escape-html": "0.0.20",
+				"@types/express": "^4.0.36",
+				"@types/mime": "^2.0.0",
+				"@types/mz": "0.0.29",
+				"@types/opn": "^3.0.28",
+				"@types/parse5": "^2.2.34",
+				"@types/pem": "^1.8.1",
+				"@types/resolve": "0.0.6",
+				"@types/serve-static": "^1.7.31",
+				"@types/spdy": "^3.4.1",
+				"bower-config": "^1.4.1",
+				"browser-capabilities": "^1.0.0",
+				"command-line-args": "^5.0.2",
+				"command-line-usage": "^5.0.5",
+				"compression": "^1.6.2",
+				"content-type": "^1.0.2",
+				"escape-html": "^1.0.3",
+				"express": "^4.8.5",
+				"find-port": "^1.0.1",
+				"http-proxy-middleware": "^0.17.2",
+				"lru-cache": "^4.0.2",
+				"mime": "^2.3.1",
+				"mz": "^2.4.0",
+				"opn": "^3.0.2",
+				"pem": "^1.8.3",
+				"polymer-build": "^3.1.0",
+				"polymer-project-config": "^4.0.0",
+				"requirejs": "^2.3.4",
+				"resolve": "^1.5.0",
+				"send": "^0.16.2",
+				"spdy": "^3.3.3"
+			},
+			"dependencies": {
+				"@types/mz": {
+					"version": "0.0.29",
+					"resolved": "http://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
+					"integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
+					"requires": {
+						"@types/bluebird": "*",
+						"@types/node": "*"
+					}
+				},
+				"@types/resolve": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+					"integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+					"requires": {
+						"@types/node": "*"
+					}
+				},
+				"mime": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+					"integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+				}
 			}
 		},
 		"posix-character-classes": {
@@ -4736,6 +8618,11 @@
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.1.0.tgz",
 			"integrity": "sha512-wa5+qGVg9Yt7PB6rYm3kXlKzgzgivYTLRandezh43jjRqgyDyP+9YxfJpJiLs9yKD1WeU8/OvtToWpW7255FtA=="
 		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -4744,8 +8631,16 @@
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-			"dev": true
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+		},
+		"proxy-addr": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+			"requires": {
+				"forwarded": "~0.1.2",
+				"ipaddr.js": "1.8.0"
+			}
 		},
 		"proxy-from-env": {
 			"version": "1.0.0",
@@ -4756,8 +8651,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
 			"version": "1.1.29",
@@ -4846,6 +8740,12 @@
 				}
 			}
 		},
+		"q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"optional": true
+		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -4870,6 +8770,32 @@
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
 					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				}
+			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+		},
+		"raw-body": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+			"requires": {
+				"bytes": "3.0.0",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.23",
+				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.23",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
 				}
 			}
 		},
@@ -5231,11 +9157,31 @@
 			"resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
 			"integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
 		},
+		"regenerate": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+		},
+		"regenerate-unicode-properties": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+			"requires": {
+				"regenerate": "^1.4.0"
+			}
+		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-			"dev": true
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+		},
+		"regenerator-transform": {
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+			"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+			"requires": {
+				"private": "^0.1.6"
+			}
 		},
 		"regex-cache": {
 			"version": "0.4.4",
@@ -5254,6 +9200,25 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regexpp": {
+			"version": "1.1.0",
+			"resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+			"dev": true
+		},
+		"regexpu-core": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+			"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+			"requires": {
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^7.0.0",
+				"regjsgen": "^0.4.0",
+				"regjsparser": "^0.3.0",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.0.2"
+			}
+		},
 		"registry-auth-token": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
@@ -5270,6 +9235,31 @@
 			"requires": {
 				"rc": "^1.0.1"
 			}
+		},
+		"regjsgen": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+			"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
+		},
+		"regjsparser": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+			"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+			"requires": {
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
+			}
+		},
+		"relateurl": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -5344,6 +9334,26 @@
 			"integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
 			"dev": true
 		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
+			"requires": {
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
+			}
+		},
+		"requirejs": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+			"integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg=="
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
 		"resolve": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -5360,6 +9370,12 @@
 				"expand-tilde": "^1.2.2",
 				"global-modules": "^0.2.3"
 			}
+		},
+		"resolve-from": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -5388,6 +9404,15 @@
 				"glob": "^7.0.5"
 			}
 		},
+		"rollup": {
+			"version": "0.64.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.64.1.tgz",
+			"integrity": "sha512-+ThdVXrvonJdOTzyybMBipP0uz605Z8AnzWVY3rf+cSGnLO7uNkJBlN+9jXqWOomkvumXfm/esmBpA5d53qm7g==",
+			"requires": {
+				"@types/estree": "0.0.39",
+				"@types/node": "*"
+			}
+		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -5396,10 +9421,35 @@
 				"is-promise": "^2.1.0"
 			}
 		},
+		"run-sequence": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
+			"integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
+			"dev": true,
+			"requires": {
+				"chalk": "*",
+				"gulp-util": "*"
+			}
+		},
 		"rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
 			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
+			"requires": {
+				"rx-lite": "*"
+			}
 		},
 		"rxjs": {
 			"version": "6.3.3",
@@ -5430,13 +9480,138 @@
 		"samsam": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-			"dev": true
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+		},
+		"sauce-connect-launcher": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.4.tgz",
+			"integrity": "sha512-X2vfwulR6brUGiicXKxPm1GJ7dBEeP1II450Uv4bHGrcGOapZNgzJvn9aioea5IC5BPp/7qjKdE3xbbTBIVXMA==",
+			"optional": true,
+			"requires": {
+				"adm-zip": "~0.4.3",
+				"async": "^2.1.2",
+				"https-proxy-agent": "^2.2.1",
+				"lodash": "^4.16.6",
+				"rimraf": "^2.5.4"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+					"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+					"optional": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"optional": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+					"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+					"optional": true,
+					"requires": {
+						"agent-base": "^4.1.0",
+						"debug": "^3.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"optional": true
+				}
+			}
 		},
 		"scoped-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
 			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
+		},
+		"select-hose": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+			"integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+		},
+		"selenium-standalone": {
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-6.15.3.tgz",
+			"integrity": "sha512-BFzdXRB8yYPfCRcLxpJDBLWM0akTBP/x0hB0g+8AR7N/PEvbW39dM/hq0Yp1R0hihVQTPI3KkAJpW6h/f41S4g==",
+			"optional": true,
+			"requires": {
+				"async": "^2.1.4",
+				"commander": "^2.9.0",
+				"cross-spawn": "^6.0.0",
+				"debug": "^4.0.0",
+				"lodash": "^4.17.4",
+				"minimist": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"progress": "2.0.0",
+				"request": "2.88.0",
+				"tar-stream": "1.6.1",
+				"urijs": "^1.18.4",
+				"which": "^1.2.12",
+				"yauzl": "^2.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+					"integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+					"optional": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"fd-slicer": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+					"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+					"optional": true,
+					"requires": {
+						"pend": "~1.2.0"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"optional": true
+				},
+				"tar-stream": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+					"integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+					"optional": true,
+					"requires": {
+						"bl": "^1.0.0",
+						"buffer-alloc": "^1.1.0",
+						"end-of-stream": "^1.0.0",
+						"fs-constants": "^1.0.0",
+						"readable-stream": "^2.3.0",
+						"to-buffer": "^1.1.0",
+						"xtend": "^4.0.0"
+					}
+				},
+				"yauzl": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+					"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+					"optional": true,
+					"requires": {
+						"buffer-crc32": "~0.2.3",
+						"fd-slicer": "~1.1.0"
+					}
+				}
+			}
 		},
 		"semver": {
 			"version": "5.6.0",
@@ -5450,6 +9625,54 @@
 			"requires": {
 				"semver": "^5.0.3"
 			}
+		},
+		"send": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "~1.6.2",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.0",
+				"statuses": "~1.4.0"
+			},
+			"dependencies": {
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+				}
+			}
+		},
+		"serve-static": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"requires": {
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.2",
+				"send": "0.16.2"
+			}
+		},
+		"server-destroy": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+			"integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
+		},
+		"serviceworker-cache-polyfill": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+			"integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -5477,6 +9700,16 @@
 					}
 				}
 			}
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+		},
+		"shady-css-parser": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+			"integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA=="
 		},
 		"shebang-command": {
 			"version": "1.2.0",
@@ -5553,10 +9786,32 @@
 				}
 			}
 		},
+		"sinon-chai": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+			"integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
+		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				}
+			}
 		},
 		"slide": {
 			"version": "1.1.6",
@@ -5660,6 +9915,98 @@
 				"kind-of": "^3.2.0"
 			}
 		},
+		"sntp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"requires": {
+				"hoek": "4.x.x"
+			}
+		},
+		"socket.io": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+			"integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+			"requires": {
+				"debug": "~3.1.0",
+				"engine.io": "~3.2.0",
+				"has-binary2": "~1.0.2",
+				"socket.io-adapter": "~1.1.0",
+				"socket.io-client": "2.1.1",
+				"socket.io-parser": "~3.2.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"socket.io-adapter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+			"integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+		},
+		"socket.io-client": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+			"integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+			"requires": {
+				"backo2": "1.0.2",
+				"base64-arraybuffer": "0.1.5",
+				"component-bind": "1.0.0",
+				"component-emitter": "1.2.1",
+				"debug": "~3.1.0",
+				"engine.io-client": "~3.2.0",
+				"has-binary2": "~1.0.2",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"object-component": "0.0.3",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
+				"socket.io-parser": "~3.2.0",
+				"to-array": "0.1.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"socket.io-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+			"integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+			"requires": {
+				"component-emitter": "1.2.1",
+				"debug": "~3.1.0",
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+				}
+			}
+		},
 		"sort-keys": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -5716,6 +10063,12 @@
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
+		"sparkles": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+			"dev": true
+		},
 		"spawn-sync": {
 			"version": "1.0.15",
 			"resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
@@ -5753,6 +10106,33 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
 			"integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
 		},
+		"spdy": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+			"requires": {
+				"debug": "^2.6.8",
+				"handle-thing": "^1.2.5",
+				"http-deceiver": "^1.2.7",
+				"safe-buffer": "^5.0.1",
+				"select-hose": "^2.0.0",
+				"spdy-transport": "^2.0.18"
+			}
+		},
+		"spdy-transport": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
+			"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+			"requires": {
+				"debug": "^2.6.8",
+				"detect-node": "^2.0.3",
+				"hpack.js": "^2.1.6",
+				"obuf": "^1.1.1",
+				"readable-stream": "^2.2.9",
+				"safe-buffer": "^5.0.1",
+				"wbuf": "^1.7.2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -5783,10 +10163,53 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+		},
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
 			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+		},
+		"stacky": {
+			"version": "1.3.1",
+			"resolved": "http://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+			"integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
+			"requires": {
+				"chalk": "^1.1.1",
+				"lodash": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "3.10.1",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -5807,6 +10230,19 @@
 				}
 			}
 		},
+		"statuses": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+		},
+		"stream": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+			"integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+			"requires": {
+				"emitter-component": "^1.1.1"
+			}
+		},
 		"stream-consume": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
@@ -5816,6 +10252,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
 			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"streamsearch": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+			"integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
 		},
 		"string-template": {
 			"version": "0.2.1",
@@ -5839,6 +10280,11 @@
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
+		},
+		"stringstream": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -5868,8 +10314,7 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
 			"version": "1.0.1",
@@ -5885,15 +10330,315 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"sw-precache": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.1.tgz",
+			"integrity": "sha512-8FAy+BP/FXE+ILfiVTt+GQJ6UEf4CVHD9OfhzH0JX+3zoy2uFk7Vn9EfXASOtVmmIVbL3jE/W8Z66VgPSZcMhw==",
+			"requires": {
+				"dom-urls": "^1.1.0",
+				"es6-promise": "^4.0.5",
+				"glob": "^7.1.1",
+				"lodash.defaults": "^4.2.0",
+				"lodash.template": "^4.4.0",
+				"meow": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"pretty-bytes": "^4.0.2",
+				"sw-toolbox": "^3.4.0",
+				"update-notifier": "^2.3.0"
+			},
+			"dependencies": {
+				"ansi-align": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+					"requires": {
+						"string-width": "^2.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"boxen": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+					"requires": {
+						"ansi-align": "^2.0.0",
+						"camelcase": "^4.0.0",
+						"chalk": "^2.0.1",
+						"cli-boxes": "^1.0.0",
+						"string-width": "^2.0.0",
+						"term-size": "^1.2.0",
+						"widest-line": "^2.0.0"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"configstore": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+					"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+					"requires": {
+						"dot-prop": "^4.1.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"unique-string": "^1.0.0",
+						"write-file-atomic": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					}
+				},
+				"dot-prop": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				},
+				"got": {
+					"version": "6.7.1",
+					"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+					"requires": {
+						"create-error-class": "^3.0.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-redirect": "^1.0.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"lowercase-keys": "^1.0.0",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"unzip-response": "^2.0.1",
+						"url-parse-lax": "^1.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"latest-version": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+					"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+					"requires": {
+						"package-json": "^4.0.0"
+					}
+				},
+				"package-json": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+					"requires": {
+						"got": "^6.7.1",
+						"registry-auth-token": "^3.0.1",
+						"registry-url": "^3.0.3",
+						"semver": "^5.1.0"
+					}
+				},
+				"pretty-bytes": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+					"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"timed-out": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+				},
+				"unzip-response": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+				},
+				"update-notifier": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+					"requires": {
+						"boxen": "^1.2.1",
+						"chalk": "^2.0.1",
+						"configstore": "^3.0.0",
+						"import-lazy": "^2.1.0",
+						"is-ci": "^1.0.10",
+						"is-installed-globally": "^0.1.0",
+						"is-npm": "^1.0.0",
+						"latest-version": "^3.0.0",
+						"semver-diff": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					}
+				},
+				"widest-line": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+					"requires": {
+						"string-width": "^2.1.1"
+					}
+				},
+				"write-file-atomic": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"xdg-basedir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+				}
+			}
+		},
+		"sw-toolbox": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+			"integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
+			"requires": {
+				"path-to-regexp": "^1.0.1",
+				"serviceworker-cache-polyfill": "^4.0.0"
+			}
 		},
 		"symbol-observable": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
 			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
 			"dev": true
+		},
+		"table": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
+			"requires": {
+				"ajv": "^5.2.3",
+				"ajv-keywords": "^2.1.0",
+				"chalk": "^2.1.0",
+				"lodash": "^4.17.4",
+				"slice-ansi": "1.0.0",
+				"string-width": "^2.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
 		},
 		"table-layout": {
 			"version": "0.4.4",
@@ -5966,6 +10711,25 @@
 				}
 			}
 		},
+		"term-size": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"requires": {
+				"execa": "^0.7.0"
+			}
+		},
+		"ternary-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+			"integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
+			"requires": {
+				"duplexify": "^3.5.0",
+				"fork-stream": "^0.0.4",
+				"merge-stream": "^1.0.0",
+				"through2": "^2.0.1"
+			}
+		},
 		"test-value": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
@@ -5978,8 +10742,7 @@
 		"text-encoding": {
 			"version": "0.6.4",
 			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-			"dev": true
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
 		},
 		"text-hex": {
 			"version": "1.0.0",
@@ -6035,6 +10798,12 @@
 				"xtend": "~4.0.0"
 			}
 		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+			"dev": true
+		},
 		"timed-out": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
@@ -6067,6 +10836,11 @@
 				}
 			}
 		},
+		"to-array": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+			"integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+		},
 		"to-buffer": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
@@ -6075,8 +10849,7 @@
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-			"dev": true
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -6125,10 +10898,30 @@
 				"punycode": "^1.4.1"
 			}
 		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "^2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+				}
+			}
+		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"triple-beam": {
 			"version": "1.3.0",
@@ -6183,8 +10976,16 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+		},
+		"type-is": {
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.18"
+			}
 		},
 		"typedarray": {
 			"version": "0.0.6",
@@ -6196,12 +10997,15 @@
 			"resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
 			"integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
 		},
+		"ua-parser-js": {
+			"version": "0.7.18",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+		},
 		"uglify-js": {
 			"version": "3.4.9",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-			"dev": true,
-			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -6210,11 +11014,43 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"optional": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
+		},
+		"ultron": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+		},
+		"underscore": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+			"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -6257,11 +11093,24 @@
 				"through2-filter": "^2.0.0"
 			}
 		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"requires": {
+				"crypto-random-string": "^1.0.0"
+			}
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"unset-value": {
 			"version": "1.0.0",
@@ -6330,7 +11179,41 @@
 				"lazy-req": "^1.1.0",
 				"semver-diff": "^2.0.0",
 				"xdg-basedir": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
 			}
+		},
+		"upper-case": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+		},
+		"urijs": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+			"integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
 		},
 		"urix": {
 			"version": "0.1.0",
@@ -6360,6 +11243,11 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -6388,6 +11276,16 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
+		},
+		"vargs": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+			"integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8="
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -6528,11 +11426,944 @@
 				}
 			}
 		},
+		"vlq": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
+		},
+		"vscode-uri": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+			"integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
+		},
 		"walkdir": {
 			"version": "0.0.11",
 			"resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
 			"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
 			"dev": true
+		},
+		"wbuf": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+			"requires": {
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"wct-local": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/wct-local/-/wct-local-2.1.2.tgz",
+			"integrity": "sha512-F83d53SJ1X9PvyXMi/NQajU5X6SP1baWilW56xdcTIMjpGq4/YTbxs+yqdqXgapV4SfUdjFBnyfwcpc4uESZng==",
+			"optional": true,
+			"requires": {
+				"@types/express": "^4.0.30",
+				"@types/freeport": "^1.0.19",
+				"@types/launchpad": "^0.6.0",
+				"@types/which": "^1.3.1",
+				"chalk": "^2.3.0",
+				"cleankill": "^2.0.0",
+				"freeport": "^1.0.4",
+				"launchpad": "^0.7.0",
+				"selenium-standalone": "^6.7.0",
+				"which": "^1.0.8"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"optional": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"optional": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"optional": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"wct-sauce": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wct-sauce/-/wct-sauce-2.1.0.tgz",
+			"integrity": "sha512-c3R4PJcbpS7Gxv2vZ4HDAqpXV6cT9peslAWMU7hHH9PMhKDPbn8RNa6E4DVL0tOmZznB+3cRmtZ6+vJ/aDwu1A==",
+			"optional": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"cleankill": "^2.0.0",
+				"lodash": "^4.17.10",
+				"request": "^2.85.0",
+				"sauce-connect-launcher": "^1.0.0",
+				"temp": "^0.8.1",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"optional": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"optional": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"optional": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"wd": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/wd/-/wd-1.11.0.tgz",
+			"integrity": "sha512-h2EBfJvmsWocIjOOg5BsHh9IJKrqZDG4Az4jEZhFugEH7sOPcX6feZQ30aFuktqDI0jquarZJmNpA6V0A0Q7Mg==",
+			"requires": {
+				"archiver": "2.1.1",
+				"async": "2.0.1",
+				"lodash": "4.17.10",
+				"mkdirp": "^0.5.1",
+				"q": "1.4.1",
+				"request": "2.85.0",
+				"vargs": "0.1.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.0.1",
+					"resolved": "http://registry.npmjs.org/async/-/async-2.0.1.tgz",
+					"integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+					"requires": {
+						"lodash": "^4.8.0"
+					}
+				},
+				"har-validator": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+					"requires": {
+						"ajv": "^5.1.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.10",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+					"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+				},
+				"q": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+					"integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
+				},
+				"request": {
+					"version": "2.85.0",
+					"resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
+					"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.6.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.1",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.1",
+						"har-validator": "~5.0.3",
+						"hawk": "~6.0.2",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.17",
+						"oauth-sign": "~0.8.2",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.1",
+						"safe-buffer": "^5.1.1",
+						"stringstream": "~0.0.5",
+						"tough-cookie": "~2.3.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.1.0"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.4",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+					"requires": {
+						"punycode": "^1.4.1"
+					}
+				}
+			}
+		},
+		"web-component-tester": {
+			"version": "6.9.0-pre.1",
+			"resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.9.0-pre.1.tgz",
+			"integrity": "sha512-hYHGRqZKNNyWR/1rPrIApb/t/BBdUK1RLKaPZp9yKhkjGgvGBSM2AEjzrnfuAeOp1Rx0oaszFNm4WHk8A7DTuw==",
+			"requires": {
+				"@polymer/sinonjs": "^1.14.1",
+				"@polymer/test-fixture": "^0.0.3",
+				"@webcomponents/webcomponentsjs": "^1.0.7",
+				"accessibility-developer-tools": "^2.12.0",
+				"async": "^2.4.1",
+				"body-parser": "^1.17.2",
+				"bower-config": "^1.4.0",
+				"chalk": "^1.1.3",
+				"cleankill": "^2.0.0",
+				"express": "^4.15.3",
+				"findup-sync": "^2.0.0",
+				"glob": "^7.1.2",
+				"lodash": "^3.10.1",
+				"multer": "^1.3.0",
+				"nomnom": "^1.8.1",
+				"polyserve": "^0.27.13",
+				"resolve": "^1.5.0",
+				"semver": "^5.3.0",
+				"send": "^0.11.1",
+				"server-destroy": "^1.0.1",
+				"sinon": "^2.3.5",
+				"sinon-chai": "^2.10.0",
+				"socket.io": "^2.0.3",
+				"stacky": "^1.3.1",
+				"update-notifier": "^2.2.0",
+				"wct-local": "^2.1.1",
+				"wct-sauce": "^2.0.2",
+				"wd": "^1.2.0"
+			},
+			"dependencies": {
+				"ansi-align": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+					"optional": true,
+					"requires": {
+						"string-width": "^2.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+				},
+				"boxen": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+					"optional": true,
+					"requires": {
+						"ansi-align": "^2.0.0",
+						"camelcase": "^4.0.0",
+						"chalk": "^2.0.1",
+						"cli-boxes": "^1.0.0",
+						"string-width": "^2.0.0",
+						"term-size": "^1.2.0",
+						"widest-line": "^2.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"optional": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"optional": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+						},
+						"ansi-styles": {
+							"version": "2.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+							"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"supports-color": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+						}
+					}
+				},
+				"configstore": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+					"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+					"optional": true,
+					"requires": {
+						"dot-prop": "^4.1.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"unique-string": "^1.0.0",
+						"write-file-atomic": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					}
+				},
+				"depd": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+					"integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+				},
+				"destroy": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
+					"integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk="
+				},
+				"detect-file": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+					"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+				},
+				"diff": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+				},
+				"dot-prop": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+					"optional": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				},
+				"ee-first": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+					"integrity": "sha1-ag18YiHkkP7v2S7D9EHJzozQl/Q="
+				},
+				"escape-html": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+					"integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A="
+				},
+				"etag": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+					"integrity": "sha1-VMUN4E7kJpVWKSWsVmWIKRvn6eo=",
+					"requires": {
+						"crc": "3.2.1"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+						}
+					}
+				},
+				"expand-tilde": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+					"requires": {
+						"homedir-polyfill": "^1.0.1"
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"findup-sync": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+					"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+					"requires": {
+						"detect-file": "^1.0.0",
+						"is-glob": "^3.1.0",
+						"micromatch": "^3.0.4",
+						"resolve-dir": "^1.0.1"
+					}
+				},
+				"fresh": {
+					"version": "0.2.4",
+					"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
+					"integrity": "sha1-NYJJkgbJcjcUGQ7ddLRgT+tKYUw="
+				},
+				"global-modules": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+					"requires": {
+						"global-prefix": "^1.0.1",
+						"is-windows": "^1.0.1",
+						"resolve-dir": "^1.0.0"
+					}
+				},
+				"global-prefix": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+					"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+					"requires": {
+						"expand-tilde": "^2.0.2",
+						"homedir-polyfill": "^1.0.1",
+						"ini": "^1.3.4",
+						"is-windows": "^1.0.1",
+						"which": "^1.2.14"
+					}
+				},
+				"got": {
+					"version": "6.7.1",
+					"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+					"optional": true,
+					"requires": {
+						"create-error-class": "^3.0.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-redirect": "^1.0.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"lowercase-keys": "^1.0.0",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"unzip-response": "^2.0.1",
+						"url-parse-lax": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"latest-version": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+					"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+					"optional": true,
+					"requires": {
+						"package-json": "^4.0.0"
+					}
+				},
+				"lodash": {
+					"version": "3.10.1",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+				},
+				"lolex": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+					"integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"mime": {
+					"version": "1.2.11",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+					"integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+				},
+				"ms": {
+					"version": "0.7.0",
+					"resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+					"integrity": "sha1-hlvpTC5zl62KV9pqYzpuLzB5i4M="
+				},
+				"on-finished": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
+					"integrity": "sha1-XIXBzDYpn3gCllP2Z/J7a5nrwCk=",
+					"requires": {
+						"ee-first": "1.1.0"
+					}
+				},
+				"package-json": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+					"optional": true,
+					"requires": {
+						"got": "^6.7.1",
+						"registry-auth-token": "^3.0.1",
+						"registry-url": "^3.0.3",
+						"semver": "^5.1.0"
+					}
+				},
+				"range-parser": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+					"integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+				},
+				"resolve-dir": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+					"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+					"requires": {
+						"expand-tilde": "^2.0.0",
+						"global-modules": "^1.0.0"
+					}
+				},
+				"send": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.11.1.tgz",
+					"integrity": "sha1-G+q/1C+eJwn5kCivMHisErRwktU=",
+					"requires": {
+						"debug": "~2.1.1",
+						"depd": "~1.0.0",
+						"destroy": "1.0.3",
+						"escape-html": "1.0.1",
+						"etag": "~1.5.1",
+						"fresh": "0.2.4",
+						"mime": "1.2.11",
+						"ms": "0.7.0",
+						"on-finished": "~2.2.0",
+						"range-parser": "~1.0.2"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.1.3",
+							"resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+							"integrity": "sha1-zoqxte6PvuK/o7Yzyrk9NmtjQY4=",
+							"requires": {
+								"ms": "0.7.0"
+							}
+						}
+					}
+				},
+				"sinon": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+					"integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+					"requires": {
+						"diff": "^3.1.0",
+						"formatio": "1.2.0",
+						"lolex": "^1.6.0",
+						"native-promise-only": "^0.8.1",
+						"path-to-regexp": "^1.7.0",
+						"samsam": "^1.1.3",
+						"text-encoding": "0.6.4",
+						"type-detect": "^4.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"timed-out": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+					"optional": true
+				},
+				"unzip-response": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+					"optional": true
+				},
+				"update-notifier": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+					"optional": true,
+					"requires": {
+						"boxen": "^1.2.1",
+						"chalk": "^2.0.1",
+						"configstore": "^3.0.0",
+						"import-lazy": "^2.1.0",
+						"is-ci": "^1.0.10",
+						"is-installed-globally": "^0.1.0",
+						"is-npm": "^1.0.0",
+						"latest-version": "^3.0.0",
+						"semver-diff": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.1",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+							"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+							"optional": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
+					}
+				},
+				"widest-line": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+					"optional": true,
+					"requires": {
+						"string-width": "^2.1.1"
+					}
+				},
+				"write-file-atomic": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+					"optional": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"xdg-basedir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+				}
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"whatwg-url": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
 		},
 		"which": {
 			"version": "1.3.1",
@@ -6611,6 +12442,15 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "^0.5.1"
+			}
+		},
 		"write-file-atomic": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
@@ -6638,6 +12478,23 @@
 				"os-homedir": "^1.0.0"
 			}
 		},
+		"xmlbuilder": {
+			"version": "8.2.2",
+			"resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+			"integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+			"optional": true
+		},
+		"xmldom": {
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+			"optional": true
+		},
+		"xmlhttprequest-ssl": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -6652,8 +12509,7 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
 			"version": "8.0.2",
@@ -6838,6 +12694,11 @@
 				"fd-slicer": "~1.0.1"
 			}
 		},
+		"yeast": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+		},
 		"yeoman-assert": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-2.2.3.tgz",
@@ -6863,6 +12724,23 @@
 				"untildify": "^2.0.0"
 			},
 			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
 				"glob": {
 					"version": "6.0.4",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
@@ -6887,6 +12765,11 @@
 						"pify": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
 					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -7696,6 +13579,17 @@
 						"yeoman-environment": "^2.0.5"
 					}
 				}
+			}
+		},
+		"zip-stream": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+			"integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+			"requires": {
+				"archiver-utils": "^1.3.0",
+				"compress-commons": "^1.2.0",
+				"lodash": "^4.8.0",
+				"readable-stream": "^2.0.0"
 			}
 		}
 	}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,6 @@
     "update-goldens": "tsc && UPDATE_POLYMER_CLI_GOLDENS=true mocha lib/test/integration/build_test.js || echo ''"
   },
   "dependencies": {
-    "@types/chalk": "^0.4.31",
     "@types/del": "^3.0.0",
     "@types/findup-sync": "^0.3.29",
     "@types/globby": "^6.1.0",
@@ -50,7 +49,7 @@
     "bower": "1.8.2",
     "bower-json": "^0.8.1",
     "bower-logger": "^0.2.2",
-    "chalk": "^1.1.3",
+    "chalk": "^2.4.1",
     "chokidar": "^1.7.0",
     "command-line-args": "^5.0.2",
     "command-line-commands": "^2.0.1",

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -15,7 +15,7 @@
 // Be careful with these imports. As many as possible should be dynamic imports
 // in the run method in order to minimize startup time from loading unused code.
 
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as commandLineUsage from 'command-line-usage';
 import * as logging from 'plylog';
 import {ProjectConfig} from 'polymer-project-config';

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -109,7 +109,7 @@ export class LintCommand implements Command {
 
   async extraUsageGroups(config: ProjectConfig): Promise<UsageGroup[]> {
     const lintLib = await import('polymer-linter');
-    const chalk = await import('chalk');
+    const { default: chalk } = await import('chalk');
     this._loadPlugins(config);
     const collectionsDocs = [];
     for (const collection of lintLib.registry.allRuleCollections) {

--- a/packages/cli/src/init/application/application.ts
+++ b/packages/cli/src/init/application/application.ts
@@ -11,7 +11,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as path from 'path';
 import Generator = require('yeoman-generator');
 

--- a/packages/cli/src/init/element/element.ts
+++ b/packages/cli/src/init/element/element.ts
@@ -11,7 +11,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as path from 'path';
 import * as logging from 'plylog';
 import Generator = require('yeoman-generator');

--- a/packages/cli/src/init/init.ts
+++ b/packages/cli/src/init/init.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as fs from 'fs';
 import * as logging from 'plylog';
 

--- a/packages/cli/src/lint/lint.ts
+++ b/packages/cli/src/lint/lint.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import * as chokidar from 'chokidar';
 import * as fs from 'mz/fs';
 import * as path from 'path';


### PR DESCRIPTION
I was in there for #612 so figured i'd split out the chalk update i did as part of my debugging.

We don't really need this but it does mean we're depending on the same version as `command-line-usage` so there's no more mismatch funkiness going on.