### PR TITLE
`Polymer.dom.flush()` only if `Polymer` exists

### DIFF
--- a/packages/web-component-tester/data/a11ySuite.js
+++ b/packages/web-component-tester/data/a11ySuite.js
@@ -54,8 +54,10 @@ var a11ySuiteExport;
             // instantiate fixture
             fixtureElement.create();
 
-            // Make sure lazy-loaded dom is ready (eg <template is='dom-repeat'>)
-            Polymer.dom.flush();
+            if (typeof Polymer !== 'undefined') {
+              // Make sure lazy-loaded dom is ready (eg <template is='dom-repeat'>)
+              Polymer.dom.flush();
+            }
 
             // If we have a beforeEach function, call it
             if (beforeEach) {


### PR DESCRIPTION
From https://github.com/Polymer/tools/pull/611.  This PR is just to ensure passing tests on latest rebase.

Looks like we essentially do the same in https://github.com/Polymer/tools/blob/master/packages/web-component-tester/browser/environment/helpers.ts#L128 but more so...

```ts
  let scope;
  if (window.Polymer && window.Polymer.dom && window.Polymer.dom.flush) {
    scope = window.Polymer.dom;
  } else if (window.Polymer && window.Polymer.flush) {
    scope = window.Polymer;
  } else if (window.WebComponents && window.WebComponents.flush) {
    scope = window.WebComponents;
  }
  if (scope) {
    scope.flush();
  }
```

I won't amend a11ysuite.js to do that yet, but it is worth noting.