### PR TITLE
[gen-typescript-declarations] Add --verify command-line flag.

### DIFF
--- a/packages/gen-typescript-declarations/CHANGELOG.md
+++ b/packages/gen-typescript-declarations/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   statements emitted for them.
 * Update the URL for this repo put in generated file headers, since it has moved
   into the Polymer tools monorepo.
+* Added `--verify` command-line flag which will run the generated typings
+  through the TypeScript compiler (3.0) and fail with the log if it fails.
 
 ## [1.4.0] - 2018-07-25
 - Support for ES module imports and exports.

--- a/packages/gen-typescript-declarations/package-lock.json
+++ b/packages/gen-typescript-declarations/package-lock.json
@@ -893,6 +893,11 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "typescript": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
+      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg=="
+    },
     "typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",

--- a/packages/gen-typescript-declarations/package.json
+++ b/packages/gen-typescript-declarations/package.json
@@ -33,6 +33,7 @@
     "glob": "^7.1.2",
     "minimatch": "^3.0.4",
     "polymer-analyzer": "^3.0.2",
+    "typescript": "^3.0.1",
     "vscode-uri": "^1.0.3"
   },
   "devDependencies": {

--- a/packages/gen-typescript-declarations/src/cli.ts
+++ b/packages/gen-typescript-declarations/src/cli.ts
@@ -57,8 +57,8 @@ const argDefs = [
   {
     name: 'verify',
     type: Boolean,
-    description: 'Compile the generated types with TypeScript and fail if ' +
-        'they are invalid.',
+    description: 'Compile the generated types with TypeScript 3.0 and fail ' +
+        'if they are invalid.',
   },
 ];
 

--- a/packages/gen-typescript-declarations/src/verify.ts
+++ b/packages/gen-typescript-declarations/src/verify.ts
@@ -12,28 +12,6 @@
 import * as ts from 'typescript';
 
 /**
- * Compile the given declaration file paths with TypeScript and return whether
- * compilation succeeded or failed, and a "pretty" formatted error log string.
- *
- * Uses a TypeScript compiler configuration suitable for web development, and
- * strict type checking.
- */
-export function verifyTypings(filePaths: string[]): VerifyTypingsResult {
-  const program = ts.createProgram(filePaths, compilerOptions);
-  const emitResult = program.emit();
-  const diagnostics =
-      ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
-  if (diagnostics.length > 0) {
-    return {
-      success: false,
-      errorLog:
-          ts.formatDiagnosticsWithColorAndContext(diagnostics, diagnosticsHost)
-    };
-  }
-  return {success: true, errorLog: ''};
-}
-
-/**
  * The result of calling verifyTypings.
  */
 export interface VerifyTypingsResult {
@@ -60,3 +38,25 @@ const diagnosticsHost = {
   getCurrentDirectory: () => process.cwd(),
   getCanonicalFileName: (fileName: string) => fileName,
 };
+
+/**
+ * Compile the given declaration file paths with TypeScript and return whether
+ * compilation succeeded or failed, and a "pretty" formatted error log string.
+ *
+ * Uses a TypeScript compiler configuration suitable for web development, and
+ * strict type checking.
+ */
+export function verifyTypings(filePaths: string[]): VerifyTypingsResult {
+  const program = ts.createProgram(filePaths, compilerOptions);
+  const emitResult = program.emit();
+  const diagnostics =
+      ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+  if (diagnostics.length > 0) {
+    return {
+      success: false,
+      errorLog:
+          ts.formatDiagnosticsWithColorAndContext(diagnostics, diagnosticsHost)
+    };
+  }
+  return {success: true, errorLog: ''};
+}

--- a/packages/gen-typescript-declarations/src/verify.ts
+++ b/packages/gen-typescript-declarations/src/verify.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved. This
+ * code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be
+ * found at http://polymer.github.io/AUTHORS.txt The complete set of
+ * contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt Code
+ * distributed by Google as part of the polymer project is also subject to an
+ * additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import * as ts from 'typescript';
+
+/**
+ * Compile the given declaration file paths with TypeScript and return whether
+ * compilation succeeded or failed, and a "pretty" formatted error log string.
+ *
+ * Uses a TypeScript compiler configuration suitable for web development, and
+ * strict type checking.
+ */
+export function verifyTypings(filePaths: string[]): VerifyTypingsResult {
+  const program = ts.createProgram(filePaths, compilerOptions);
+  const emitResult = program.emit();
+  const diagnostics =
+      ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+  if (diagnostics.length > 0) {
+    return {
+      success: false,
+      errorLog:
+          ts.formatDiagnosticsWithColorAndContext(diagnostics, diagnosticsHost)
+    };
+  }
+  return {success: true, errorLog: ''};
+}
+
+/**
+ * The result of calling verifyTypings.
+ */
+export interface VerifyTypingsResult {
+  success: boolean;
+  errorLog: string;
+}
+
+const compilerOptions = {
+  target: ts.ScriptTarget.ES2015,
+  module: ts.ModuleKind.ES2015,
+  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+  strict: true,
+  noUnusedLocals: true,
+  noUnusedParameters: true,
+  declaration: true,
+  lib: [
+    'lib.dom.d.ts',
+    'lib.esnext.d.ts',
+  ],
+};
+
+const diagnosticsHost = {
+  getNewLine: () => '\n',
+  getCurrentDirectory: () => process.cwd(),
+  getCanonicalFileName: (fileName: string) => fileName,
+};


### PR DESCRIPTION
Runs the generated typings through the TypeScript compiler (3.0) and fails with its error log if it fails.

The goal is to make integrating fully tested type generation into new repos (the Polymer elements) as trivial as possible.

cc https://github.com/Polymer/gen-typescript-declarations/issues/79 @43081j 