### PR TITLE
Force "foo" in "import * as foo" to be resolvable.

### DIFF
--- a/packages/gen-typescript-declarations/CHANGELOG.md
+++ b/packages/gen-typescript-declarations/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `autoImport` now supports bare-module specifiers. Local files must now
   begin with `.`.
 * `excludeIdentifiers` option now applies to properties and methods.
+* The pattern `import * as foo from 'foo'; export {foo as bar};` is now
+  supported.
 
 ## [1.4.0] - 2018-07-25
 - Support for ES module imports and exports.

--- a/packages/gen-typescript-declarations/src/gen-ts.ts
+++ b/packages/gen-typescript-declarations/src/gen-ts.ts
@@ -319,6 +319,12 @@ class TypeGenerator {
   public warnings: analyzer.Warning[] = [];
   private excludeIdentifiers: Set<String>;
 
+  /**
+   * Identifiers in this set will always be considered resolvable, e.g.
+   * for when determining what identifiers should be exported.
+   */
+  private forceResolvable = new Set<string>();
+
   constructor(
       private root: ts.Document,
       private analysis: analyzer.Analysis,
@@ -851,6 +857,7 @@ class TypeGenerator {
             identifier: ts.AllIdentifiers,
             alias: specifier.local.name,
           });
+          this.forceResolvable.add(specifier.local.name);
         }
       }
 
@@ -927,6 +934,9 @@ class TypeGenerator {
   private isResolvable(
       identifier: string,
       fromFeature: analyzer.JavascriptImport|analyzer.Export) {
+    if (this.forceResolvable.has(identifier)) {
+      return true;
+    }
     const resolved =
         resolveImportExportFeature(fromFeature, identifier, this.analyzerDoc);
     return resolved !== undefined && resolved.feature !== undefined &&


### PR DESCRIPTION
This is so that we don't need https://github.com/PolymerElements/iron-dropdown/pull/165