### PR TITLE
[gen-typescript-declarations] Error on analyzer errors, but only important files.

### DIFF
--- a/packages/gen-typescript-declarations/CHANGELOG.md
+++ b/packages/gen-typescript-declarations/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `excludeIdentifiers` option now applies to properties and methods.
 * The pattern `import * as foo from 'foo'; export {foo as bar};` is now
   supported.
+* Exit with a non-zero code when an analysis error is encountered.
 
 ## [1.4.0] - 2018-07-25
 - Support for ES module imports and exports.

--- a/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
+++ b/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
@@ -27,10 +27,10 @@ while read -r repo commitish dir; do
   git clone $repo $dir
   cd $dir
   git checkout $commitish
-  if [ -e package.json ]; then
-    npm install --production
-  elif [ -e bower.json ]; then
+  if [ -e bower.json ]; then
     bower install --production
+  elif [ -e package.json ]; then
+    npm install --production
   fi
   cd -
 done < ../../../scripts/fixtures.txt

--- a/packages/gen-typescript-declarations/src/gen-ts.ts
+++ b/packages/gen-typescript-declarations/src/gen-ts.ts
@@ -219,9 +219,19 @@ async function analyzerToAst(
     tsDocs.push(tsDoc);
   }
 
+  const filteredWarnings = warnings.filter((warning) => {
+    const sourcePath =
+        analyzerUrlToRelativePath(warning.sourceRange.file, rootDir);
+    return sourcePath !== undefined &&
+        !excludeFiles.some((pattern) => pattern.match(sourcePath));
+  });
   const warningPrinter =
       new analyzer.WarningPrinter(process.stderr, {maxCodeLines: 1});
-  await warningPrinter.printWarnings(warnings);
+  await warningPrinter.printWarnings(filteredWarnings);
+  if (filteredWarnings.some(
+          (warning) => warning.severity === analyzer.Severity.ERROR)) {
+    throw new Error('Encountered error generating types.');
+  }
 
   return tsDocs;
 }


### PR DESCRIPTION
This time we ignore errors in files we don't care about (tests/demos).

Also, look for bower.json instead of package.json during test setup. Bower projects typically also have package.jsons, but not vice-versa, so this eliminates a bunch of warnings we had due to incorrect file
resolution in tests.