### PR TITLE
[gen-typescript-declarations] Expanded TemplateStringsArray type for html function in polymer

### DIFF
--- a/packages/gen-typescript-declarations/src/closure-types.ts
+++ b/packages/gen-typescript-declarations/src/closure-types.ts
@@ -194,7 +194,7 @@ const renameMap = new Map<string, string>([
   // will concede that technicality.)
   ['Object', 'object'],
   // The tagged template literal function argument.
-  ['ITemplateArray', 'TemplateStringsArray'],
+  ['ITemplateArray', 'TemplateStringsArray|string[]'],
 ]);
 
 /*

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-2/lib/utils/html-tag.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-2/lib/utils/html-tag.d.ts
@@ -60,7 +60,7 @@ declare namespace Polymer {
    *
    * @returns Constructed HTMLTemplateElement
    */
-  function html(strings: TemplateStringsArray, ...values: any[]): HTMLTemplateElement;
+  function html(strings: TemplateStringsArray|string[], ...values: any[]): HTMLTemplateElement;
 
 
   /**
@@ -83,5 +83,5 @@ declare namespace Polymer {
    *
    * @returns Constructed literal string
    */
-  function htmlLiteral(strings: TemplateStringsArray, ...values: any[]): LiteralString;
+  function htmlLiteral(strings: TemplateStringsArray|string[], ...values: any[]): LiteralString;
 }

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/html-tag.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/html-tag.d.ts
@@ -58,7 +58,7 @@ export {html};
  *
  * @returns Constructed HTMLTemplateElement
  */
-declare function html(strings: TemplateStringsArray, ...values: any[]): HTMLTemplateElement;
+declare function html(strings: TemplateStringsArray|string[], ...values: any[]): HTMLTemplateElement;
 
 export {htmlLiteral};
 
@@ -85,4 +85,4 @@ export {htmlLiteral};
  *
  * @returns Constructed literal string
  */
-declare function htmlLiteral(strings: TemplateStringsArray, ...values: any[]): LiteralString;
+declare function htmlLiteral(strings: TemplateStringsArray|string[], ...values: any[]): LiteralString;

--- a/packages/modulizer/fixtures/packages/polymer/source/types/lib/utils/html-tag.d.ts
+++ b/packages/modulizer/fixtures/packages/polymer/source/types/lib/utils/html-tag.d.ts
@@ -59,7 +59,7 @@ declare namespace Polymer {
    *
    * @returns Constructed HTMLTemplateElement
    */
-  function html(strings: TemplateStringsArray, ...values: any[]): HTMLTemplateElement;
+  function html(strings: TemplateStringsArray|string[], ...values: any[]): HTMLTemplateElement;
 
 
   /**
@@ -82,5 +82,5 @@ declare namespace Polymer {
    *
    * @returns Constructed literal string
    */
-  function htmlLiteral(strings: TemplateStringsArray, ...values: any[]): LiteralString;
+  function htmlLiteral(strings: TemplateStringsArray|string[], ...values: any[]): LiteralString;
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/18213789/44423411-7e2c0f80-a59f-11e8-8551-82ed6da74a12.png)

After:
![image](https://user-images.githubusercontent.com/18213789/44423450-9308a300-a59f-11e8-9bca-1d398ce2ccba.png)

Unfortunately, the function
```typescript
html`<style>${style}</style>${view()}`
````

Not work if vars style or view loaded from webpack
![image](https://user-images.githubusercontent.com/18213789/44423610-ff83a200-a59f-11e8-8445-cca9ec89b83e.png)
Gives error:
![image](https://user-images.githubusercontent.com/18213789/44423782-6903b080-a5a0-11e8-88bf-f180253cc29f.png)

### This change solves the problem