### PR TITLE
More robust gen-tsd test fixture setup.

### DIFF
--- a/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
+++ b/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
@@ -22,7 +22,8 @@ mkdir -p fixtures
 cd fixtures
 
 while read -r repo commitish dir; do
-  if [ -d $dir ]; then continue; fi  # Already set up.
+  if [ -f $dir/INSTALLED ]; then continue; fi  # Already set up successfully.
+  rm -rf $dir
   # Note you can't do a shallow clone of a SHA.
   git clone $repo $dir
   cd $dir
@@ -32,5 +33,6 @@ while read -r repo commitish dir; do
   elif [ -e package.json ]; then
     npm install --production
   fi
+  touch INSTALLED
   cd -
 done < ../../../scripts/fixtures.txt

--- a/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
+++ b/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
@@ -22,7 +22,13 @@ mkdir -p fixtures
 cd fixtures
 
 while read -r repo commitish dir; do
-  if [ -f $dir/INSTALLED ]; then continue; fi  # Already set up successfully.
+  if [ -f $dir/INSTALLED ] &&
+     # Did we update the fixture commitish since we last ran setup?
+     (cd $dir && [ $(git rev-list -1 $commitish) == $(git rev-list -1 HEAD) ])
+  then
+    continue
+  fi
+
   rm -rf $dir
   # Note you can't do a shallow clone of a SHA.
   git clone $repo $dir

--- a/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
+++ b/packages/gen-typescript-declarations/scripts/setup-fixtures.sh
@@ -23,7 +23,7 @@ cd fixtures
 
 while read -r repo commitish dir; do
   if [ -f $dir/INSTALLED ] &&
-     # Did we update the fixture commitish since we last ran setup?
+     # Is the SHA for this fixture the same since we last ran setup?
      (cd $dir && [ $(git rev-list -1 $commitish) == $(git rev-list -1 HEAD) ])
   then
     continue


### PR DESCRIPTION
Previously, the type generator test setup script would simply skip setting up a fixture directory if the directory already existed.

We now will only skip installing a fixture if both 1) the previous clone/install attempt actually succeeded (by touching an `INSTALL` file after npm/bower install), and 2) that the SHA for the fixture hasn't changed since the last install.

This should fix confusing local test breakages we sometimes hit, since previously you had to just know to delete the test fixtures sometimes.