### PR TITLE
[analyzer] Warn instead of throw when exported identifier is not resolved.

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Failing to resolve an exported identifier will now be a warning instead
+  of an uncaught exception.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.1.1] - 2018-08-15

--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
+<!-- Add new, unreleased changes here. -->
+
+## [3.1.2] - 2018-08-23
 * Failing to resolve an exported identifier will now be a warning instead
   of an uncaught exception.
-<!-- Add new, unreleased changes here. -->
 
 ## [3.1.1] - 2018-08-15
 * Legacy Polymer function component features will no longer have a `_template`

--- a/packages/gen-typescript-declarations/scripts/fixtures.txt
+++ b/packages/gen-typescript-declarations/scripts/fixtures.txt
@@ -5,4 +5,4 @@ https://github.com/PolymerElements/paper-button.git f644abdfc660f58b6535134ae9a0
 https://github.com/PolymerElements/paper-menu-button.git v2.0.0 paper-menu-button-2
 https://github.com/PolymerElements/paper-menu-button.git ab4885daa67d09a929c8209972e20fbf56014543 paper-menu-button-3
 https://github.com/Polymer/polymer.git 50ba80b864d4843d4e59cfdddeab6efdf280a2ec polymer-2
-https://github.com/Polymer/polymer.git 60beab88a7685880848477d642347870d569d33b polymer-3
+https://github.com/Polymer/polymer.git 7791ee9e8655b6a55ec6e65419d21e9e7eb0a581 polymer-3

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/class.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/class.d.ts
@@ -10,8 +10,6 @@
 
 import {LegacyElementMixin} from './legacy-element-mixin.js';
 
-import {DomModule} from '../elements/dom-module.js';
-
 export {mixinBehaviors};
 
 
@@ -25,7 +23,7 @@ export {mixinBehaviors};
  * @returns Returns a new Element class extended by the
  * passed in `behaviors` and also by `LegacyElementMixin`.
  */
-declare function mixinBehaviors<T>(behaviors: object|object[], klass: {new(): T}): {new(): T};
+declare function mixinBehaviors<T>(behaviors: object|object[], klass: {new(): T}): any;
 
 export {Class};
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer.dom.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/legacy/polymer.dom.d.ts
@@ -10,7 +10,9 @@
 
 import {FlattenedNodesObserver} from '../utils/flattened-nodes-observer.js';
 
-import {flush as flush$0, enqueueDebouncer} from '../utils/flush.js';
+export {flush, enqueueDebouncer as addDebouncer} from '../utils/flush.js';
+
+import {Debouncer} from '../utils/debounce.js';
 
 export {matchesSelector};
 
@@ -56,14 +58,14 @@ declare class DomApi {
   constructor(node: Node|null);
 
   /**
-   * Returns an instance of `Polymer.FlattenedNodesObserver` that
+   * Returns an instance of `FlattenedNodesObserver` that
    * listens for node changes on this element.
    *
    * @param callback Called when direct or distributed children
    *   of this element changes
    * @returns Observer instance
    */
-  observeNodes(callback: (p0: Element, p1: {target: Element, addedNodes: Element[], removedNodes: Element[]}) => void): FlattenedNodesObserver;
+  observeNodes(callback: (p0: {target: Element, addedNodes: Element[], removedNodes: Element[]}) => void): FlattenedNodesObserver;
 
   /**
    * Disconnects an observer previously created via `observeNodes`
@@ -149,8 +151,10 @@ declare class DomApi {
   querySelectorAll(selector: string): NodeListOf<Element>;
 }
 
+export {EventApi};
+
 /**
- * Event API wrapper class returned from `Polymer.dom.(target)` when
+ * Event API wrapper class returned from `dom.(target)` when
  * `target` is an `Event`.
  */
 declare class EventApi {
@@ -187,7 +191,3 @@ export {dom};
  * @returns Wrapper providing either node API or event API
  */
 declare function dom(obj?: Node|Event|null): DomApi|EventApi;
-
-export {flush$0 as flush};
-
-export {enqueueDebouncer as addDebouncer};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/mixins/property-effects.d.ts
@@ -12,9 +12,7 @@ import {dedupingMixin} from '../utils/mixin.js';
 
 import {root as root$0, isAncestor, isDescendant, get as get$0, translate, isPath as isPath$0, set as set$0, normalize} from '../utils/path.js';
 
-import * as caseMap from '../utils/case-map.js';
-
-import {camelToDashCase as camelToDashCase$0, dashToCamelCase} from '../utils/case-map.js';
+import {camelToDashCase, dashToCamelCase} from '../utils/case-map.js';
 
 import {PropertyAccessors} from './property-accessors.js';
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/boot.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/boot.d.ts
@@ -8,3 +8,5 @@
  *   lib/utils/boot.js
  */
 
+
+export {};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flattened-nodes-observer.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flattened-nodes-observer.d.ts
@@ -59,7 +59,7 @@ declare class FlattenedNodesObserver {
    * @param callback Function called when there are additions
    * or removals from the target's list of flattened nodes.
    */
-  constructor(target: Element|null, callback: ((p0: Element, p1: {target: Element, addedNodes: Element[], removedNodes: Element[]}) => void)|null);
+  constructor(target: Element, callback: ((p0: {target: Element, addedNodes: Element[], removedNodes: Element[]}) => void)|null);
 
   /**
    * Returns the list of flattened nodes for the given `node`.
@@ -70,10 +70,11 @@ declare class FlattenedNodesObserver {
    * nodes list is `<a></a><div></div><b></b>`. If the `<slot>` has other
    * `<slot>` elements assigned to it, these are flattened as well.
    *
-   * @param node The node for which to return the list of flattened nodes.
+   * @param node The node for which to
+   *      return the list of flattened nodes.
    * @returns The list of flattened nodes for the given `node`.
    */
-  static getFlattenedNodes(node: HTMLElement|HTMLSlotElement|null): any[]|null;
+  static getFlattenedNodes(node: HTMLElement|HTMLSlotElement): Node[];
 
   /**
    * Activates an observer. This method is automatically called when

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flush.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/flush.d.ts
@@ -8,6 +8,8 @@
  *   lib/utils/flush.js
  */
 
+import {Debouncer} from '../utils/debounce.js';
+
 export {enqueueDebouncer};
 
 
@@ -25,5 +27,3 @@ export {flush};
  * - ShadyDOM distribution
  */
 declare function flush(): void;
-
-import {Debouncer} from './debounce.js';

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/render-status.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/render-status.d.ts
@@ -8,6 +8,15 @@
  *   lib/utils/render-status.js
  */
 
+export {flush};
+
+
+/**
+ * Flushes all `beforeNextRender` tasks, followed by all `afterNextRender`
+ * tasks.
+ */
+declare function flush(): void;
+
 export {beforeNextRender};
 
 

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/settings.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/settings.d.ts
@@ -35,3 +35,19 @@ export {setPassiveTouchGestures};
  * Sets `passiveTouchGestures` globally for all elements using Polymer Gestures.
  */
 declare function setPassiveTouchGestures(usePassive: boolean): void;
+
+export {setStrictTemplatePolicy};
+
+
+/**
+ * Sets `strictTemplatePolicy` globally for all elements
+ */
+declare function setStrictTemplatePolicy(useStrictPolicy: boolean): void;
+
+export {setAllowTemplateFromDomModule};
+
+
+/**
+ * Sets `lookupTemplateFromDomModule` globally for all elements
+ */
+declare function setAllowTemplateFromDomModule(allowDomModule: boolean): void;

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/style-gather.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/style-gather.d.ts
@@ -8,6 +8,8 @@
  *   lib/utils/style-gather.js
  */
 
+import {DomModule} from '../elements/dom-module.js';
+
 import {resolveCss} from './resolve-url.js';
 
 export {stylesFromModules};

--- a/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/unresolved.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/polymer-3/lib/utils/unresolved.d.ts
@@ -8,3 +8,5 @@
  *   lib/utils/unresolved.js
  */
 
+
+export {};


### PR DESCRIPTION
- Warn instead of throw when exported identifier is not resolved. Fixes https://github.com/Polymer/polymer-analyzer/issues/919
- Update type generator fixture SHA for Polymer (this latest SHA was failing before the Analyzer change in this PR).
- Prepare release of Analyzer 3.1.2