### PR TITLE
Export generated legacy Polymer function element interfaces.

### DIFF
--- a/packages/gen-typescript-declarations/CHANGELOG.md
+++ b/packages/gen-typescript-declarations/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-* Legacy Polymer function element interfaces are now exported from ES modules.
+<!-- ## [Unreleased] -->
 <!-- Add new, unreleased changes here. -->
+
+## [1.5.1] - 2018-08-25
+* Legacy Polymer function element interfaces are now exported from ES modules.
 
 ## [1.5.0] - 2018-08-15
 * Legacy Polymer function components will no longer have a `_template`

--- a/packages/gen-typescript-declarations/CHANGELOG.md
+++ b/packages/gen-typescript-declarations/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+* Legacy Polymer function element interfaces are now exported from ES modules.
 <!-- Add new, unreleased changes here. -->
 
 ## [1.5.0] - 2018-08-15

--- a/packages/gen-typescript-declarations/package.json
+++ b/packages/gen-typescript-declarations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymer/gen-typescript-declarations",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Generate TypeScript type declarations for Polymer components.",
   "homepage": "https://github.com/Polymer/tools/tree/master/packages/gen-typescript-declarations",
   "repository": "github:Polymer/tools",

--- a/packages/gen-typescript-declarations/src/gen-ts.ts
+++ b/packages/gen-typescript-declarations/src/gen-ts.ts
@@ -484,6 +484,12 @@ class TypeGenerator {
           ...legacyPolymerInterfaces,
         ],
       }));
+
+      if (isPolymerElement(feature) && feature.isLegacyFactoryCall &&
+          this.root.isEsModule) {
+        this.root.members.push(
+            new ts.Export({identifiers: [{identifier: shortName}]}));
+      }
     }
 
     // The `HTMLElementTagNameMap` global interface maps custom element tag

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-button-3/paper-button.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-button-3/paper-button.d.ts
@@ -25,6 +25,8 @@ interface PaperButtonElement extends PaperButtonBehavior, LegacyElementMixin, HT
   _calculateElevation(): void;
 }
 
+export {PaperButtonElement};
+
 declare global {
 
   interface HTMLElementTagNameMap {

--- a/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button-animations.d.ts
+++ b/packages/gen-typescript-declarations/src/test/goldens/paper-menu-button-3/paper-menu-button-animations.d.ts
@@ -18,6 +18,8 @@ interface PaperMenuGrowHeightAnimationElement extends NeonAnimationBehavior, Leg
   configure(config: any): any;
 }
 
+export {PaperMenuGrowHeightAnimationElement};
+
 declare global {
 
   interface HTMLElementTagNameMap {
@@ -32,10 +34,16 @@ interface PaperMenuGrowWidthAnimationElement extends NeonAnimationBehavior, Lega
   configure(config: any): any;
 }
 
+export {PaperMenuGrowWidthAnimationElement};
+
 interface PaperMenuShrinkWidthAnimationElement extends NeonAnimationBehavior, LegacyElementMixin, HTMLElement {
   configure(config: any): any;
 }
 
+export {PaperMenuShrinkWidthAnimationElement};
+
 interface PaperMenuShrinkHeightAnimationElement extends NeonAnimationBehavior, LegacyElementMixin, HTMLElement {
   configure(config: any): any;
 }
+
+export {PaperMenuShrinkHeightAnimationElement};


### PR DESCRIPTION
Kind of an important omission I just noticed. Users should be able to import the interface we generate for legacy Polymer elements, even though those element definitions are not themselves exported.

Also prepare 1.5.1 for release.

cc @bicknellr I just verified that all types are still compiling after this change. Once it's released, refreshing all the package-lock.json files is all that's needed to pull in this fix.