### PR TITLE
analyzer: ignore lifecycle methods in custom elements

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
-<!-- Add new, unreleased changes here. -->
+## Unreleased
+* Ignore custom element life-cycle methods when scanning element classes
 
 ## [3.1.3] - 2018-10-15
 * Make `HtmlDocument#stringify()` faster by only cloning the ast and stringifing

--- a/packages/analyzer/src/javascript/class-scanner.ts
+++ b/packages/analyzer/src/javascript/class-scanner.ts
@@ -35,6 +35,13 @@ import {JavaScriptScanner} from './javascript-scanner';
 import * as jsdoc from './jsdoc';
 
 
+const lifeCycleMethods: string[] = [
+  'connectedCallback',
+  'disconnectedCallback',
+  'adoptedCallback',
+  'attributeChangedCallback'
+];
+
 /**
  * Represents the first argument of a call to customElements.define.
  */
@@ -293,6 +300,11 @@ export class ClassScanner implements JavaScriptScanner {
         class_.properties.set(prop.name, finalProp);
       }
       methods = getMethods(astNode.node, document);
+
+      for (const lifeCycleMethod of lifeCycleMethods) {
+        methods.delete(lifeCycleMethod);
+      }
+
       staticMethods = getStaticMethods(astNode.node, document);
     }
 

--- a/packages/analyzer/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
+++ b/packages/analyzer/src/test/polymer/polymer2-element-scanner_vanilla-elements_test.ts
@@ -55,7 +55,8 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
       'class-expression',
       'vanilla-with-observed-attributes',
       'register-before-declaration',
-      'register-before-expression'
+      'register-before-expression',
+      'vanilla-with-lifecycle-methods',
     ].sort());
     assert.deepEqual(elementsList.map((e) => e.className).sort(), [
       undefined,
@@ -63,7 +64,8 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
       'ClassExpression',
       'WithObservedAttributes',
       'RegisterBeforeDeclaration',
-      'RegisterBeforeExpression'
+      'RegisterBeforeExpression',
+      'WithLifeCycleMethods',
     ].sort());
     assert.deepEqual(
         elementsList.map((e) => e.superClass && e.superClass.identifier).sort(),
@@ -74,7 +76,16 @@ suite('Polymer2ElementScanner - Vanilla Element Scanning', () => {
           'HTMLElement',
           'HTMLElement',
           'HTMLElement',
+          'HTMLElement',
         ].sort());
+  });
+
+  test('Ignores lifecycle methods', () => {
+    const element = elements.get('vanilla-with-lifecycle-methods')!;
+
+    assert.deepEqual(Array.from(element.methods.values()).map((m) => m.name), [
+      'validMethod'
+    ]);
   });
 
   test('Extracts attributes from observedAttributes', () => {

--- a/packages/analyzer/src/test/static/vanilla-elements.js
+++ b/packages/analyzer/src/test/static/vanilla-elements.js
@@ -32,3 +32,12 @@ class WithObservedAttributes extends HTMLElement {
 
 customElements.define(
     'vanilla-with-observed-attributes', WithObservedAttributes);
+
+class WithLifeCycleMethods extends HTMLElement {
+  connectedCallback() {}
+  disconnectedCallback() {}
+  attributeChangedCallback() {}
+  adoptedCallback() {}
+  validMethod() {}
+}
+customElements.define('vanilla-with-lifecycle-methods', WithLifeCycleMethods);


### PR DESCRIPTION
Fixes #637.

---

This is a possible solution. I ignored all the lifecycle methods but only when dealing with a custom element class, so other classes should not be affected.