### PR TITLE
analyzer: merge property info from constructors

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
-<!-- Add new, unreleased changes here. -->
+## Unreleased
+* Merge property information from constructors into associated scanned
+  properties when scanning classes
 
 ## [3.1.3] - 2018-10-15
 * Make `HtmlDocument#stringify()` faster by only cloning the ast and stringifing

--- a/packages/analyzer/src/javascript/class-scanner.ts
+++ b/packages/analyzer/src/javascript/class-scanner.ts
@@ -916,7 +916,24 @@ export function extractPropertiesFromClass(
   for (const prop of esutil
            .extractPropertiesFromClassOrObjectBody(astNode, document)
            .values()) {
-    properties.set(prop.name, prop);
+    const existing = properties.get(prop.name);
+
+    if (!existing) {
+      properties.set(prop.name, prop);
+    } else {
+      properties.set(prop.name, {
+        name: prop.name,
+        astNode: prop.astNode,
+        type: prop.type || existing.type,
+        jsdoc: prop.jsdoc,
+        sourceRange: prop.sourceRange,
+        description: prop.description || existing.description,
+        privacy: prop.privacy || existing.privacy,
+        warnings: prop.warnings,
+        readOnly: prop.readOnly === undefined ?
+          existing.readOnly : prop.readOnly
+      });
+    }
   }
 
   return properties;

--- a/packages/analyzer/src/test/javascript/class-scanner_test.ts
+++ b/packages/analyzer/src/test/javascript/class-scanner_test.ts
@@ -224,6 +224,13 @@ suite('Class', () => {
           cls.properties.get('__customPropertyOnProtoPrivate'),
           {name: '__customPropertyOnProtoPrivate', privacy: 'private'});
 
+      assert.deepInclude(
+          cls.properties.get('constructorJSDocGetter'),
+          {
+            name: 'constructorJSDocGetter',
+            description: 'a getter with constructor jsdoc'
+          });
+
       assert.deepEqual(await getTestProps(cls), {
         name: 'Class',
         constructorMethod: {description: '', name: 'constructor'},
@@ -232,6 +239,7 @@ suite('Class', () => {
         properties: [
           {name: 'customPropertyWithValue'},
           {name: 'customPropertyWithJSDoc'},
+          {name: 'constructorJSDocGetter'},
           {name: 'customPropertyGetter'},
           {name: 'customPropertyGetterType'},
           {name: 'customPropertyWithGetterSetter'},

--- a/packages/analyzer/src/test/static/class/class-properties.js
+++ b/packages/analyzer/src/test/static/class/class-properties.js
@@ -45,7 +45,11 @@ class Class {
     this.customPropertyWithValue = 5;
     /** @public a jsdoc property */
     this.customPropertyWithJSDoc;
+    /** @public a getter with constructor jsdoc */
+    this.constructorJSDocGetter;
   }
+
+  get constructorJSDocGetter() { return true; }
 }
 
 /** @type {string} */


### PR DESCRIPTION
Fixes #630.

---

This should handle merging of property information for situations like this:

```js
class Foo {
  constructor() {
    /** @public some description */
    this.someProperty;
  }

  get someProperty() { return 1; }
}
```

we need to take the description from the constructor but everything else from the actual getter.

in terms of precedence, i take the property's info unless it is empty, then i try take the constructor's info.