### PR TITLE
all: standardise tslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "The Polymer Project Authors",
   "scripts": {
     "bootstrap": "lerna bootstrap --ci",
+    "lint": "lerna run lint --stream",
     "build": "lerna run build --stream",
     "format": "lerna run format --stream",
     "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec 'rm -f package-lock.json npm-shrinkwrap.json' && lerna clean --yes && lerna exec --stream -- npm install && lerna bootstrap",

--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -20,7 +20,7 @@
     "build": "tsc && npm run generate-json-schema",
     "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i",
     "generate-json-schema": "typescript-json-schema --required --ignoreErrors src/analysis-format/analysis-format.ts -o lib/analysis.schema.json Analysis",
-    "lint": "tslint -p ./ && node ./scripts/depcheck.js",
+    "lint": "tslint -p . && node ./scripts/depcheck.js",
     "tslint": "tslint -p .",
     "test": "npm run clean && npm run build && npm run lint && mocha \"lib/test/**/*_test.js\"",
     "quicktest": "export QUICK_TESTS=true; npm run build && mocha \"lib/test/**/*_test.js\"",

--- a/packages/analyzer/tslint.json
+++ b/packages/analyzer/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tslint.json"
-  }
+  "extends": "../../tslint.json"
+}

--- a/packages/browser-capabilities/package.json
+++ b/packages/browser-capabilities/package.json
@@ -13,6 +13,7 @@
     "node": ">=8.0"
   },
   "scripts": {
+    "lint": "tslint -p .",
     "build": "rm -Rf lib/ && tsc",
     "build:watch": "tsc --watch",
     "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i",

--- a/packages/build/tslint.json
+++ b/packages/build/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tslint.json"
-  }
+  "extends": "../../tslint.json"
+}

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -50,6 +50,7 @@
     "tsc-then": "^1.1.0"
   },
   "scripts": {
+    "lint": "tslint -p .",
     "build": "tsc",
     "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i",
     "test": "npm run build && tslint -c tslint.json \"src/**/*.ts\" && mocha \"lib/test/**/*_test.js\"",

--- a/packages/bundler/tslint.json
+++ b/packages/bundler/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tslint.json"
+  "extends": "../../tslint.json"
 }

--- a/packages/cleankill/index.ts
+++ b/packages/cleankill/index.ts
@@ -36,9 +36,9 @@ export function onInterrupt(handler: Handler): void {
  */
 export async function promiseAllStrict(
       promises: Promise<any>[]): Promise<void> {
-  let errors = await Promise.all(
+  const errors = await Promise.all(
       promises.map((p) => p.then(() => null, (e) => e)));
-  let firstError = errors.find((e) => e != null);
+  const firstError = errors.find((e) => e != null);
   if (firstError) {
     throw firstError;
   }

--- a/packages/cleankill/package.json
+++ b/packages/cleankill/package.json
@@ -7,6 +7,7 @@
   "license": "BSD-3-Clause",
   "repository": "github:Polymer/tools",
   "scripts": {
+    "lint": "tslint -p .",
     "build": "npm run clean && tsc",
     "clean": "rm -f *.js *.d.ts",
     "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i"

--- a/packages/cleankill/tslint.json
+++ b/packages/cleankill/tslint.json
@@ -1,58 +1,6 @@
 {
-    "rules": {
-        "class-name": true,
-        "indent": [
-            true,
-            "spaces"
-        ],
-        "no-duplicate-variable": true,
-        "no-eval": true,
-        "no-internal-module": false,
-        "no-trailing-whitespace": true,
-        "no-var-keyword": true,
-        "one-line": [
-            true,
-            "check-open-brace",
-            "check-whitespace"
-        ],
-        "quotemark": [
-            true,
-            "single",
-            "avoid-escape"
-        ],
-        "semicolon": [
-            true,
-            "always"
-        ],
-        "trailing-comma": [
-            true,
-            "multiline"
-        ],
-        "triple-equals": [
-            true,
-            "allow-null-check"
-        ],
-        "typedef-whitespace": [
-            true,
-            {
-                "call-signature": "nospace",
-                "index-signature": "nospace",
-                "parameter": "nospace",
-                "property-declaration": "nospace",
-                "variable-declaration": "nospace"
-            }
-        ],
-        "variable-name": [
-            true,
-            "ban-keywords"
-        ],
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ]
-    }
+  "extends": "../../tslint.json",
+  "rules": {
+    "no-any": false
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "polymer": "bin/polymer.js"
   },
   "scripts": {
-    "lint": "tslint -p ./ && node scripts/depcheck.js",
+    "lint": "tslint -p . && node scripts/depcheck.js",
     "clean": "rm -rf lib/",
     "build": "npm run clean && tsc",
     "format": "find src -name \"*.ts\" -not -path \"*/fixtures/*\" | xargs clang-format --style=file -i",

--- a/packages/cli/tslint.json
+++ b/packages/cli/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tslint.json"
+  "extends": "../../tslint.json"
 }

--- a/packages/dom5/tslint.json
+++ b/packages/dom5/tslint.json
@@ -1,59 +1,6 @@
 {
-    "rules": {
-        "class-name": true,
-        "indent": [
-            true,
-            "spaces"
-        ],
-        "prefer-const": true,
-        "no-duplicate-variable": true,
-        "no-eval": true,
-        "no-internal-module": true,
-        "no-trailing-whitespace": true,
-        "no-var-keyword": true,
-        "one-line": [
-            true,
-            "check-open-brace",
-            "check-whitespace"
-        ],
-        "quotemark": [
-            true,
-            "single",
-            "avoid-escape"
-        ],
-        "semicolon": [
-            true,
-            "always"
-        ],
-        "trailing-comma": [
-            true,
-            "multiline"
-        ],
-        "triple-equals": [
-            true,
-            "allow-null-check"
-        ],
-        "typedef-whitespace": [
-            true,
-            {
-                "call-signature": "nospace",
-                "index-signature": "nospace",
-                "parameter": "nospace",
-                "property-declaration": "nospace",
-                "variable-declaration": "nospace"
-            }
-        ],
-        "variable-name": [
-            true,
-            "ban-keywords"
-        ],
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ]
-    }
+  "extends": "../../tslint.json",
+  "rules": {
+    "no-any": false
+  }
 }

--- a/packages/editor-service/package.json
+++ b/packages/editor-service/package.json
@@ -15,7 +15,7 @@
     "build": "tsc",
     "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i",
     "prepublishOnly": "npm run clean && npm run build",
-    "lint": "tslint --project ./tsconfig.json",
+    "lint": "tslint -p .",
     "test": "npm run clean && npm run build && mocha \"lib/test/**/*_test.js\" && npm run lint",
     "test:unit": "mocha \"lib/test/**/*_test.js\"",
     "test:watch": "tsc-then -- mocha \"lib/test/**/*_test.js\""

--- a/packages/editor-service/tslint.json
+++ b/packages/editor-service/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tslint.json"
+  "extends": "../../tslint.json"
 }

--- a/packages/esm-amd-loader/package.json
+++ b/packages/esm-amd-loader/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i",
     "clean": "rm -rf lib/",
-    "lint": "tslint --project . --format stylish",
+    "lint": "tslint -p . --format stylish",
     "build": "npm run clean && tsc && npm run minify",
     "minify": "babel-minify lib/esm-amd-loader.js --outFile=lib/esm-amd-loader.min.js",
     "get-size": "npm run build && cat lib/esm-amd-loader.min.js | gzip -9 > esm-amd-loader.min.js.gz && ls -a -l -h esm-amd-loader.min.js.gz && rm esm-amd-loader.min.js.gz",

--- a/packages/esm-amd-loader/test/package.json
+++ b/packages/esm-amd-loader/test/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i",
     "clean": "rm -rf lib/",
-    "lint": "tslint --project . --format stylish",
+    "lint": "tslint -p . --format stylish",
     "build": "npm run clean && tsc",
     "test": "npm run lint && npm run build && npm run test:wct",
     "test:wct": "bash run-wct.sh"

--- a/packages/esm-amd-loader/tslint.json
+++ b/packages/esm-amd-loader/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tslint.json"
-  }
+  "extends": "../../tslint.json"
+}

--- a/packages/gen-typescript-declarations/package.json
+++ b/packages/gen-typescript-declarations/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "format": "find src -name \"*.ts\" -not -path \"src/test/fixtures/*\" -not -path \"src/test/goldens/*\" | xargs clang-format --style=file -i",
-    "lint": "tslint --project . --format stylish",
+    "lint": "tslint -p . --format stylish",
     "build": "npm run clean && tsc",
     "build:watch": "tsc --watch",
     "prepack": "npm run build",

--- a/packages/linter/package.json
+++ b/packages/linter/package.json
@@ -41,7 +41,7 @@
     "build": "npm run clean && tsc",
     "clean": "touch lib && rm -rf lib && mkdir lib",
     "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i",
-    "lint": "tslint -c tslint.json src/*.ts src/**/*.ts",
+    "lint": "tslint -p .",
     "test": "npm run build && mocha \"lib/test/**/*_test.js\" && npm run lint",
     "test:unit": "mocha \"lib/test/**/*_test.js\"",
     "test:watch": "tsc-then -- mocha \"lib/test/**/*_test.js\"",

--- a/packages/linter/tslint.json
+++ b/packages/linter/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tslint.json"
+  "extends": "../../tslint.json"
 }

--- a/packages/modulizer/package.json
+++ b/packages/modulizer/package.json
@@ -25,7 +25,7 @@
     "test:fast": "npm run build && bash test/run-mocha.sh unit",
     "test:watch": "tsc-then -- bash test/run-mocha.sh unit",
     "test": "npm run test:fast && npm run lint",
-    "lint": "tslint -p ./",
+    "lint": "tslint -p .",
     "format": "find bin src -name \"*.[jt]s\" | xargs clang-format --style=file -i",
     "clean": "rm -rf ./lib/",
     "prepublishOnly": "npm test"

--- a/packages/polyserve/package.json
+++ b/packages/polyserve/package.json
@@ -12,6 +12,7 @@
     "polyserve": "bin/polyserve"
   },
   "scripts": {
+    "lint": "tslint -p .",
     "start": "./bin/polyserve",
     "clean": "rimraf lib",
     "build": "npm run clean && tsc",

--- a/packages/polyserve/tslint.json
+++ b/packages/polyserve/tslint.json
@@ -1,3 +1,3 @@
 {
-    "extends": "../../tslint.json"
+  "extends": "../../tslint.json"
 }

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -10,6 +10,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
+    "lint": "tslint -p .",
     "build": "tsc && typescript-json-schema src/index.ts ProjectOptions --ignoreErrors -o lib/schema.json",
     "test": "npm run build && mocha \"test/**/*_test.js\"",
     "test:unit": "mocha \"test/**/*_test.js\"",

--- a/packages/project-config/src/test/builds_test.ts
+++ b/packages/project-config/src/test/builds_test.ts
@@ -27,10 +27,12 @@ suite('builds', () => {
       assert.equal(isValidPreset('es6'), false);
       assert.equal(isValidPreset('js-compile'), false);
       assert.equal(isValidPreset(''), false);
+      // tslint:disable:no-any
       assert.equal(isValidPreset(null as any), false);
       assert.equal(isValidPreset(undefined as any), false);
       assert.equal(isValidPreset(0 as any), false);
       assert.equal(isValidPreset(1 as any), false);
+      // tslint:enable:no-any
     });
   });
 

--- a/packages/wct-local/package.json
+++ b/packages/wct-local/package.json
@@ -14,7 +14,7 @@
   "main": "lib/plugin.js",
   "typings": "lib/plugin.d.ts",
   "scripts": {
-    "lint": "gulp lint",
+    "lint": "tslint -p .",
     "build": "tsc",
     "format": "find src scripts -name \"*.[jt]s\" | xargs clang-format --style=file -i",
     "prepublishOnly": "tsc",

--- a/packages/workspaces/package.json
+++ b/packages/workspaces/package.json
@@ -9,7 +9,7 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i",
-    "lint": "tslint -p ./",
+    "lint": "tslint -p .",
     "build": "tsc",
     "build:watch": "tsc --watch",
     "test": "npm run build && mocha"

--- a/packages/workspaces/tslint.json
+++ b/packages/workspaces/tslint.json
@@ -1,60 +1,6 @@
 {
-    "rules": {
-        "arrow-parens": true,
-        "class-name": true,
-        "indent": [
-            true,
-            "spaces"
-        ],
-        "prefer-const": true,
-        "no-duplicate-variable": true,
-        "no-eval": true,
-        "no-internal-module": true,
-        "no-trailing-whitespace": true,
-        "no-var-keyword": true,
-        "one-line": [
-            true,
-            "check-open-brace",
-            "check-whitespace"
-        ],
-        "quotemark": [
-            true,
-            "single",
-            "avoid-escape"
-        ],
-        "semicolon": [
-            true,
-            "always"
-        ],
-        "trailing-comma": [
-            true,
-            "multiline"
-        ],
-        "triple-equals": [
-            true,
-            "allow-null-check"
-        ],
-        "typedef-whitespace": [
-            true,
-            {
-                "call-signature": "nospace",
-                "index-signature": "nospace",
-                "parameter": "nospace",
-                "property-declaration": "nospace",
-                "variable-declaration": "nospace"
-            }
-        ],
-        "variable-name": [
-            true,
-            "ban-keywords"
-        ],
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ]
-    }
+  "extends": "../../tslint.json",
+  "rules": {
+    "no-any": false
+  }
 }


### PR DESCRIPTION
Fixes #305.

---

Let me know if you still want this, otherwise i will throw it away.

* Added missing lint commands
* Made all tslint configs inherit the base one
* Fixed a couple of lint errors
* Added a lint script (`npm run lint`) to lint all packages

Couple of packages break the `no-any` rule so i turned it off as i didn't want to be altering interfaces for this.