### PR TITLE
Friendlier nuke script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "lerna bootstrap --ci",
     "build": "lerna run build --stream",
     "format": "lerna run format --stream",
-    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- \"bash -c \\\"test ! -f package-lock.json && npm install || echo package-lock.json present.\\\"\"",
+    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- \"bash -c \\\"test ! -f package-lock.json && npm install || true\\\"\"",
     "test": "npm run build && npm run test:unit",
     "test:all": "npm run test:unit && npm run test:integration",
     "test:all:parallel": "npm run test:unit && npm run test:integration:parallel",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "lerna bootstrap --ci",
     "build": "lerna run build --stream",
     "format": "lerna run format --stream",
-    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- \"bash -c \\\"test ! -f package-lock.json && npm install --package-lock-only || true\\\"\"",
+    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- \"test -f package-lock.json || npm install --package-lock-only\"",
     "test": "npm run build && npm run test:unit",
     "test:all": "npm run test:unit && npm run test:integration",
     "test:all:parallel": "npm run test:unit && npm run test:integration:parallel",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "lerna bootstrap --ci",
     "build": "lerna run build --stream",
     "format": "lerna run format --stream",
-    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- bash -c \"test ! -f package-lock.json && npm install\"",
+    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- bash -c \"test ! -f package-lock.json && npm install || echo package-lock.json present.\"",
     "test": "npm run build && npm run test:unit",
     "test:all": "npm run test:unit && npm run test:integration",
     "test:all:parallel": "npm run test:unit && npm run test:integration:parallel",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "lerna bootstrap --ci",
     "build": "lerna run build --stream",
     "format": "lerna run format --stream",
-    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- bash -c \"test ! -f package-lock.json && npm install || echo package-lock.json present.\"",
+    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- \"bash -c \\\"test ! -f package-lock.json && npm install || echo package-lock.json present.\\\"\"",
     "test": "npm run build && npm run test:unit",
     "test:all": "npm run test:unit && npm run test:integration",
     "test:all:parallel": "npm run test:unit && npm run test:integration:parallel",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "lerna bootstrap --ci",
     "build": "lerna run build --stream",
     "format": "lerna run format --stream",
-    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- \"bash -c \\\"test ! -f package-lock.json && npm install || true\\\"\"",
+    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- \"bash -c \\\"test ! -f package-lock.json && npm install --package-lock-only || true\\\"\"",
     "test": "npm run build && npm run test:unit",
     "test:all": "npm run test:unit && npm run test:integration",
     "test:all:parallel": "npm run test:unit && npm run test:integration:parallel",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bootstrap": "lerna bootstrap --ci",
     "build": "lerna run build --stream",
     "format": "lerna run format --stream",
-    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec 'rm -f package-lock.json npm-shrinkwrap.json' && lerna clean --yes && lerna exec --stream -- npm install && lerna bootstrap",
+    "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json npm-shrinkwrap.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- bash -c \"test ! -f package-lock.json && npm install\"",
     "test": "npm run build && npm run test:unit",
     "test:all": "npm run test:unit && npm run test:integration",
     "test:all:parallel": "npm run test:unit && npm run test:integration:parallel",


### PR DESCRIPTION
The old nuke script runs `npm install` before the bootstrap which is problematic when you have a package that isn't yet published, for example.  Also, this is not what lerna bootstrap package-locks are supposed to look like, so I wanted to avoid it doing this.  However, the `npm install` step was added by @TimvdLippe previously because the `npm audit` command would fail when hitting a package without a package-lock, which occurs in bootstrapped packages that have zero dependencies, in our case, that's `cleankill`.  So to solve the missing package-lock problem I just run `npm install --package-lock-only` on any package that doesn't have one, after the bootstrap.

This solved a recurring pain-point of being able to nuke/update the `wct-mocha-extraction` branch I'm working on which has unpublished packages.

Here's an example run of it adding missing package-lock.json to cleankill:

```
λ npm run nuke

> polymer-tools@ nuke /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script
> rm -rf package-lock.json node_modules && npm install && lerna exec "rm -f package-lock.json npm-shrinkwrap.json" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- "bash -c \"test ! -f package-lock.json && npm install --package-lock-only || true\""

npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN sinon-chai@3.2.0 requires a peer of sinon@>=4.0.0 <7.0.0 but none is installed. You must install peer dependencies yourself.

added 652 packages from 818 contributors and audited 35789 packages in 14.742s
found 0 vulnerabilities

lerna notice cli v3.2.1
lerna info versioning independent
lerna success exec Executed command in 21 packages: "rm -f package-lock.json npm-shrinkwrap.json"
lerna notice cli v3.2.1
lerna info versioning independent
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/analyzer/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/browser-capabilities/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/build/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/bundler/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/cleankill/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/cli/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/common/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/dom5/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/editor-service/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/esm-amd-loader/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/gen-typescript-declarations/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/linter/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/modulizer/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/polyserve/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/project-config/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-browser-legacy/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-local/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-sauce/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/web-component-tester/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/workspaces/node_modules
lerna info clean removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/esm-amd-loader/test/node_modules
lerna success clean finished
lerna notice cli v3.2.1
lerna info versioning independent
lerna info Bootstrapping 21 packages
lerna info Installing external dependencies
lerna info Symlinking packages and binaries
lerna WARN EREPLACE_EXIST dom5 is already installed for polymer-build. Replacing with symlink...
lerna info lifecycle wct-local@2.1.1~postinstall: wct-local@2.1.1
lerna info lifecycle wct-sauce@2.1.0~postinstall: wct-sauce@2.1.0

> wct-local@2.1.1 postinstall /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-local
> node scripts/postinstall.js

----------
selenium-standalone installation starting
----------

---
selenium install:
from: https://selenium-release.storage.googleapis.com/3.12/selenium-server-standalone-3.12.0.jar
to: /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-local/node_modules/selenium-standalone/.selenium/selenium-server/3.12.0-server.jar
---
chrome install:
from: https://chromedriver.storage.googleapis.com/2.40/chromedriver_mac64.zip
to: /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-local/node_modules/selenium-standalone/.selenium/chromedriver/2.40-x64-chromedriver
---
firefox install:
from: https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-macos.tar.gz
to: /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-local/node_modules/selenium-standalone/.selenium/geckodriver/0.20.1-x64-geckodriver


-----
selenium-standalone installation finished
-----

> wct-sauce@2.1.0 postinstall /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-sauce
> node scripts/postinstall.js

Prefetching the Sauce Connect binary.
Missing Sauce Connect local proxy, downloading dependency
This will only happen once.
Downloading 7.98MB
Archive checksum verified.
Unzipping /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-sauce/node_modules/sauce-connect-launcher/sc/sc-4.5.1-osx.zip
Removing /Users/brendanb/src/github.com/Polymer/tools~friendlier-nuke-script/packages/wct-sauce/node_modules/sauce-connect-launcher/sc/sc-4.5.1-osx.zip
Sauce Connect downloaded correctly
lerna success Bootstrapped 21 packages
lerna notice cli v3.2.1
lerna info versioning independent
cleankill: npm notice created a lockfile as package-lock.json. You should commit this file.
cleankill: up to date in 0.543s
cleankill: found 0 vulnerabilities
lerna success exec Executed command in 21 packages: "bash -c \"test ! -f package-lock.json && npm install --package-lock-only || true\""
```