### PR TITLE
count for first failing launched test when we have a before hook fail…

### DIFF
--- a/packages/web-component-tester/runner/browserrunner.ts
+++ b/packages/web-component-tester/runner/browserrunner.ts
@@ -23,6 +23,7 @@ export interface Stats {
   passing?: number;
   pending?: number;
   failing?: number;
+  total?: number;
 }
 
 export interface BrowserDef extends wd.Capabilities {
@@ -198,12 +199,18 @@ export class BrowserRunner {
         passing: 0,
         pending: 0,
         failing: 0,
+        total: 0
       };
+    } else if (event === 'test-start') {
+      this.stats['total'] = this.stats['total'] + 1;
     } else if (event === 'test-end') {
       this.stats[data.state] = this.stats[data.state] + 1;
     }
 
     if (event === 'browser-end' || event === 'browser-fail') {
+      if ((this.stats['passing'] + this.stats['pending'] + this.stats['failing']) !== this.stats['total']) {
+        this.stats['failing'] = this.stats['total'] - this.stats['passing'] - this.stats['pending'];
+      }
       this.done(data);
     } else {
       this.emitter.emit(event, this.def, data, this.stats, this.browser);

--- a/packages/web-component-tester/test/fixtures/integration/compilation/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/compilation/golden.json
@@ -2,6 +2,7 @@
   "passing": 1,
   "pending": 0,
   "failing": 0,
+  "total": 1,
   "status": "complete",
   "tests": {
     "test/": {

--- a/packages/web-component-tester/test/fixtures/integration/components_dir/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/components_dir/golden.json
@@ -2,6 +2,7 @@
   "passing": 1,
   "pending": 0,
   "failing": 0,
+  "total": 1,
   "status": "complete",
   "tests": {
     "test/": {

--- a/packages/web-component-tester/test/fixtures/integration/custom-components_dir/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/custom-components_dir/golden.json
@@ -2,6 +2,7 @@
   "passing": 1,
   "pending": 0,
   "failing": 0,
+  "total": 1,
   "status": "complete",
   "tests": {
     "test/": {

--- a/packages/web-component-tester/test/fixtures/integration/custom-multiple-component_dirs/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/custom-multiple-component_dirs/golden.json
@@ -4,6 +4,7 @@
       "passing": 1,
       "pending": 0,
       "failing": 0,
+      "total": 1,
       "status": "complete",
       "tests": {
         "test/": {
@@ -15,6 +16,7 @@
       "passing": 0,
       "pending": 0,
       "failing": 1,
+      "total": 1,
       "status": "complete",
       "tests": {
         "test/": {
@@ -34,6 +36,7 @@
       "passing": 0,
       "pending": 0,
       "failing": 1,
+      "total": 1,
       "status": "complete",
       "tests": {
         "test/": {

--- a/packages/web-component-tester/test/fixtures/integration/define-webserver-hook/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/define-webserver-hook/golden.json
@@ -2,6 +2,7 @@
   "passing": 2,
   "pending": 0,
   "failing": 0,
+  "total": 2,
   "status": "complete",
   "tests": {
     "test/tests.html": {

--- a/packages/web-component-tester/test/fixtures/integration/failing/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/failing/golden.json
@@ -2,6 +2,7 @@
   "passing": 3,
   "pending": 0,
   "failing": 3,
+  "total": 6,
   "status": "complete",
   "tests": {
     "test/": {

--- a/packages/web-component-tester/test/fixtures/integration/missing/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/missing/golden.json
@@ -2,5 +2,6 @@
   "passing": 0,
   "pending": 0,
   "failing": 0,
+  "total": 0,
   "status": "error"
 }

--- a/packages/web-component-tester/test/fixtures/integration/mixed-suites/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/mixed-suites/golden.json
@@ -2,6 +2,7 @@
   "passing": 10,
   "pending": 0,
   "failing": 0,
+  "total": 10,
   "status": "complete",
   "tests": {
     "test/": {

--- a/packages/web-component-tester/test/fixtures/integration/multiple-component_dirs/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/multiple-component_dirs/golden.json
@@ -4,6 +4,7 @@
       "passing": 1,
       "pending": 0,
       "failing": 0,
+      "total": 1,
       "status": "complete",
       "tests": {
         "test/": {
@@ -17,6 +18,7 @@
       "passing": 0,
       "pending": 0,
       "failing": 1,
+      "total": 1,
       "status": "complete",
       "tests": {
         "test/": {
@@ -38,6 +40,7 @@
       "passing": 0,
       "pending": 0,
       "failing": 1,
+      "total": 1,
       "status": "complete",
       "tests": {
         "test/": {

--- a/packages/web-component-tester/test/fixtures/integration/multiple-replace/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/multiple-replace/golden.json
@@ -2,6 +2,7 @@
   "passing": 10,
   "pending": 0,
   "failing": 0,
+  "total": 10,
   "status": "complete",
   "tests": {
     "test/tests.html": {

--- a/packages/web-component-tester/test/fixtures/integration/nested/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/nested/golden.json
@@ -2,6 +2,7 @@
   "passing": 4,
   "pending": 0,
   "failing": 0,
+  "total": 4,
   "status": "complete",
   "tests": {
     "test/": {"js test": {"state": "passing"}},

--- a/packages/web-component-tester/test/fixtures/integration/no-tests/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/no-tests/golden.json
@@ -2,5 +2,6 @@
   "passing": 0,
   "pending": 0,
   "failing": 0,
+  "total": 0,
   "status": "complete"
 }

--- a/packages/web-component-tester/test/fixtures/integration/query-string/golden.json
+++ b/packages/web-component-tester/test/fixtures/integration/query-string/golden.json
@@ -2,6 +2,7 @@
   "passing": 3,
   "pending": 0,
   "failing": 0,
+  "total": 3,
   "status": "complete",
   "tests": {
     "test/tests.html": {

--- a/packages/web-component-tester/test/integration/browser.ts
+++ b/packages/web-component-tester/test/integration/browser.ts
@@ -82,6 +82,7 @@ interface VariantResultGolden {
   passing: number;
   pending: number;
   failing: number;
+  total: number;
   status: string;
   tests: TestNode;
   errors: TestErrorExpectation;
@@ -358,8 +359,9 @@ function assertStats(
     passing: number,
     pending: number,
     failing: number,
+    total: number,
     status: 'complete') {
-  const expected: Stats = {passing, pending, failing, status};
+  const expected: Stats = {passing, pending, failing, total, status};
   expect(context.stats).to.deep.equal(repeatBrowsers(context, expected));
 }
 
@@ -422,6 +424,7 @@ function assertVariantResultsConformToGolden(
           golden.passing,
           golden.pending,
           golden.failing,
+          golden.total,
           <any>golden.status);
     } catch (_) {
       // mocha reports twice the failures because reasons
@@ -431,6 +434,7 @@ function assertVariantResultsConformToGolden(
           golden.passing,
           golden.pending,
           golden.failing * 2,
+          golden.total,
           <any>golden.status);
     }
   });


### PR DESCRIPTION
Tests that are run in a suite that has a before hook failure, are not detected as having failing status, because the test-start event is sent to browserrunner but not the test-end for the first test that run in this suite. In order to detect these failures any test that has unknown state (only start) is considered as failing test.