### PR TITLE
Faster HTML Stringify

### DIFF
--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Make `HtmlDocument::stringify()` faster by only cloning the ast and stringifing
+  inline documents into the cloned ast.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.1.2] - 2018-08-23

--- a/packages/analyzer/CHANGELOG.md
+++ b/packages/analyzer/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-* Make `HtmlDocument::stringify()` faster by only cloning the ast and stringifing
+* Make `HtmlDocument#stringify()` faster by only cloning the ast and stringifing
   inline documents into the cloned ast.
 <!-- Add new, unreleased changes here. -->
 


### PR DESCRIPTION
- Clone only the HTMLDocument ast, and stringify inline documents into the
cloned ast at the same position.

Fixes #688