### PR TITLE
[modulizer] Update dependency map to use stable 3.0.0 releases

### DIFF
--- a/packages/modulizer/dependency-map.json
+++ b/packages/modulizer/dependency-map.json
@@ -3,10 +3,6 @@
     "npm": "@polymer/app-layout",
     "semver": "^3.0.0"
   },
-  "app-elements": {
-    "npm": "@polymer/app-elements",
-    "semver": "^3.0.0-pre.18"
-  },
   "app-localize-behavior": {
     "npm": "@polymer/app-localize-behavior",
     "semver": "^3.0.0"
@@ -14,10 +10,6 @@
   "app-media": {
     "npm": "@polymer/app-media",
     "semver": "^3.0.0"
-  },
-  "app-pouchdb": {
-    "npm": "@polymer/app-pouchdb",
-    "semver": "^3.0.0-pre.18"
   },
   "app-route": {
     "npm": "@polymer/app-route",
@@ -42,10 +34,6 @@
   "iron-scroll-target-behavior": {
     "npm": "@polymer/iron-scroll-target-behavior",
     "semver": "^3.0.0"
-  },
-  "app-layout-templates": {
-    "npm": "@polymer/app-layout-templates",
-    "semver": "^3.0.0-pre.18"
   },
   "iron-icon": {
     "npm": "@polymer/iron-icon",
@@ -79,10 +67,6 @@
     "npm": "@polymer/paper-material",
     "semver": "^3.0.0"
   },
-  "paper-menu": {
-    "npm": "@polymer/paper-menu",
-    "semver": "^3.0.0-pre.18"
-  },
   "paper-styles": {
     "npm": "@polymer/paper-styles",
     "semver": "^3.0.0"
@@ -103,17 +87,9 @@
     "npm": "@polymer/iron-location",
     "semver": "^3.0.0"
   },
-  "chartjs-element": {
-    "npm": "@polymer/chartjs-element",
-    "semver": "^3.0.0-pre.18"
-  },
   "iron-component-page": {
     "npm": "@polymer/iron-component-page",
     "semver": "^3.0.0"
-  },
-  "data-elements": {
-    "npm": "@polymer/data-elements",
-    "semver": "^3.0.0-pre.18"
   },
   "iron-jsonp-library": {
     "npm": "@polymer/iron-jsonp-library",
@@ -159,10 +135,6 @@
     "npm": "@polymer/gold-cc-input",
     "semver": "^3.0.0"
   },
-  "gold-elements": {
-    "npm": "@polymer/gold-elements",
-    "semver": "^3.0.0-pre.18"
-  },
   "gold-email-input": {
     "npm": "@polymer/gold-email-input",
     "semver": "^3.0.0"
@@ -194,10 +166,6 @@
   "iron-behaviors": {
     "npm": "@polymer/iron-behaviors",
     "semver": "^3.0.0"
-  },
-  "iron-behaviors-collection": {
-    "npm": "@polymer/iron-behaviors-collection",
-    "semver": "^3.0.0-pre.18"
   },
   "iron-range-behavior": {
     "npm": "@polymer/iron-range-behavior",
@@ -259,17 +227,9 @@
     "npm": "@polymer/neon-animation",
     "semver": "^3.0.0"
   },
-  "iron-elements": {
-    "npm": "@polymer/iron-elements",
-    "semver": "^3.0.0"
-  },
   "icon-behaviors-collection": {
     "npm": "@polymer/icon-behaviors-collection",
     "semver": "^3.0.0"
-  },
-  "icon-input-elements": {
-    "npm": "@polymer/icon-input-elements",
-    "semver": "^3.0.0-pre.18"
   },
   "iron-fit-behavior": {
     "npm": "@polymer/iron-fit-behavior",
@@ -311,10 +271,6 @@
     "npm": "@polymer/iron-meta",
     "semver": "^3.0.0"
   },
-  "iron-input-elements": {
-    "npm": "@polymer/iron-input-elements",
-    "semver": "^3.0.0-pre.18"
-  },
   "iron-label": {
     "npm": "@polymer/iron-label",
     "semver": "^3.0.0"
@@ -322,18 +278,6 @@
   "iron-localstorage": {
     "npm": "@polymer/iron-localstorage",
     "semver": "^3.0.0"
-  },
-  "iron-signals": {
-    "npm": "@polymer/iron-signals",
-    "semver": "^3.0.0-pre.18"
-  },
-  "layout-elements": {
-    "npm": "@polymer/layout-elements",
-    "semver": "^3.0.0-pre.18"
-  },
-  "neon-elements": {
-    "npm": "@polymer/neon-elements",
-    "semver": "^3.0.0-pre.18"
   },
   "paper-badge": {
     "npm": "@polymer/paper-badge",
@@ -374,22 +318,6 @@
   "paper-menu-button": {
     "npm": "@polymer/paper-menu-button",
     "semver": "^3.0.0"
-  },
-  "paper-elements": {
-    "npm": "@polymer/paper-elements",
-    "semver": "^3.0.0-pre.18"
-  },
-  "paper-input-elements": {
-    "npm": "@polymer/paper-input-elements",
-    "semver": "^3.0.0-pre.18"
-  },
-  "paper-overlay-elements": {
-    "npm": "@polymer/paper-overlay-elements",
-    "semver": "^3.0.0-pre.18"
-  },
-  "paper-ui-elements": {
-    "npm": "@polymer/paper-ui-elements",
-    "semver": "^3.0.0-pre.18"
   },
   "paper-fab": {
     "npm": "@polymer/paper-fab",
@@ -447,40 +375,8 @@
     "npm": "@polymer/paper-tooltip",
     "semver": "^3.0.0"
   },
-  "platinum-bluetooth": {
-    "npm": "@polymer/platinum-bluetooth",
-    "semver": "^3.0.0-pre.18"
-  },
-  "platinum-elements": {
-    "npm": "@polymer/platinum-elements",
-    "semver": "^3.0.0-pre.18"
-  },
-  "platinum-https-redirect": {
-    "npm": "@polymer/platinum-https-redirect",
-    "semver": "^3.0.0-pre.18"
-  },
-  "platinum-push-messaging": {
-    "npm": "@polymer/platinum-push-messaging",
-    "semver": "^3.0.0-pre.18"
-  },
-  "platinum-sw": {
-    "npm": "@polymer/platinum-sw",
-    "semver": "^3.0.0-pre.18"
-  },
-  "polymer-starter-kit": {
-    "npm": "@polymer/polymer-starter-kit",
-    "semver": "^3.0.0-pre.18"
-  },
   "promise-polyfill": {
     "npm": "@polymer/promise-polyfill",
-    "semver": "^3.0.0-pre.18"
-  },
-  "seed-element": {
-    "npm": "@polymer/seed-element",
-    "semver": "^3.0.0-pre.18"
-  },
-  "performance-benchmark": {
-    "npm": "@polymer/performance-benchmark",
     "semver": "^3.0.0-pre.18"
   },
   "test-fixture": {

--- a/packages/modulizer/dependency-map.json
+++ b/packages/modulizer/dependency-map.json
@@ -1,7 +1,7 @@
 {
   "app-layout": {
     "npm": "@polymer/app-layout",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "app-elements": {
     "npm": "@polymer/app-elements",
@@ -9,11 +9,11 @@
   },
   "app-localize-behavior": {
     "npm": "@polymer/app-localize-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "app-media": {
     "npm": "@polymer/app-media",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "app-pouchdb": {
     "npm": "@polymer/app-pouchdb",
@@ -21,27 +21,27 @@
   },
   "app-route": {
     "npm": "@polymer/app-route",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "app-storage": {
     "npm": "@polymer/app-storage",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-flex-layout": {
     "npm": "@polymer/iron-flex-layout",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-media-query": {
     "npm": "@polymer/iron-media-query",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-resizable-behavior": {
     "npm": "@polymer/iron-resizable-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-scroll-target-behavior": {
     "npm": "@polymer/iron-scroll-target-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "app-layout-templates": {
     "npm": "@polymer/app-layout-templates",
@@ -49,35 +49,35 @@
   },
   "iron-icon": {
     "npm": "@polymer/iron-icon",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-icons": {
     "npm": "@polymer/iron-icons",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-selector": {
     "npm": "@polymer/iron-selector",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-drawer-panel": {
     "npm": "@polymer/paper-drawer-panel",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-header-panel": {
     "npm": "@polymer/paper-header-panel",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-icon-button": {
     "npm": "@polymer/paper-icon-button",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-item": {
     "npm": "@polymer/paper-item",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-material": {
     "npm": "@polymer/paper-material",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-menu": {
     "npm": "@polymer/paper-menu",
@@ -85,23 +85,23 @@
   },
   "paper-styles": {
     "npm": "@polymer/paper-styles",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-toggle-button": {
     "npm": "@polymer/paper-toggle-button",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-toolbar": {
     "npm": "@polymer/paper-toolbar",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-ajax": {
     "npm": "@polymer/iron-ajax",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-location": {
     "npm": "@polymer/iron-location",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "chartjs-element": {
     "npm": "@polymer/chartjs-element",
@@ -109,7 +109,7 @@
   },
   "iron-component-page": {
     "npm": "@polymer/iron-component-page",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "data-elements": {
     "npm": "@polymer/data-elements",
@@ -117,47 +117,47 @@
   },
   "iron-jsonp-library": {
     "npm": "@polymer/iron-jsonp-library",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "font-roboto": {
     "npm": "@polymer/font-roboto",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "font-roboto-local": {
     "npm": "@polymer/font-roboto-local",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "gold-cc-cvc-input": {
     "npm": "@polymer/gold-cc-cvc-input",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-form-element-behavior": {
     "npm": "@polymer/iron-form-element-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-input": {
     "npm": "@polymer/paper-input",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "gold-cc-expiration-input": {
     "npm": "@polymer/gold-cc-expiration-input",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-a11y-keys-behavior": {
     "npm": "@polymer/iron-a11y-keys-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-validator-behavior": {
     "npm": "@polymer/iron-validator-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-validatable-behavior": {
     "npm": "@polymer/iron-validatable-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "gold-cc-input": {
     "npm": "@polymer/gold-cc-input",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "gold-elements": {
     "npm": "@polymer/gold-elements",
@@ -165,35 +165,35 @@
   },
   "gold-email-input": {
     "npm": "@polymer/gold-email-input",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "gold-phone-input": {
     "npm": "@polymer/gold-phone-input",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "gold-zip-input": {
     "npm": "@polymer/gold-zip-input",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-input": {
     "npm": "@polymer/iron-input",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-a11y-announcer": {
     "npm": "@polymer/iron-a11y-announcer",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-a11y-keys": {
     "npm": "@polymer/iron-a11y-keys",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-autogrow-textarea": {
     "npm": "@polymer/iron-autogrow-textarea",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-behaviors": {
     "npm": "@polymer/iron-behaviors",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-behaviors-collection": {
     "npm": "@polymer/iron-behaviors-collection",
@@ -201,35 +201,35 @@
   },
   "iron-range-behavior": {
     "npm": "@polymer/iron-range-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-overlay-behavior": {
     "npm": "@polymer/iron-overlay-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-scroll-threshold": {
     "npm": "@polymer/iron-scroll-threshold",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-menu-behavior": {
     "npm": "@polymer/iron-menu-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-checked-element-behavior": {
     "npm": "@polymer/iron-checked-element-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-collapse": {
     "npm": "@polymer/iron-collapse",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-doc-viewer": {
     "npm": "@polymer/iron-doc-viewer",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-demo-helpers": {
     "npm": "@polymer/iron-demo-helpers",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "marked": {
     "npm": "marked",
@@ -237,7 +237,7 @@
   },
   "marked-element": {
     "npm": "@polymer/marked-element",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "prism": {
     "npm": "prismjs",
@@ -245,27 +245,27 @@
   },
   "prism-element": {
     "npm": "@polymer/prism-element",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-button": {
     "npm": "@polymer/paper-button",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-dropdown": {
     "npm": "@polymer/iron-dropdown",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "neon-animation": {
     "npm": "@polymer/neon-animation",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-elements": {
     "npm": "@polymer/iron-elements",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "icon-behaviors-collection": {
     "npm": "@polymer/icon-behaviors-collection",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "icon-input-elements": {
     "npm": "@polymer/icon-input-elements",
@@ -273,43 +273,43 @@
   },
   "iron-fit-behavior": {
     "npm": "@polymer/iron-fit-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-iconset": {
     "npm": "@polymer/iron-iconset",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-iconset-svg": {
     "npm": "@polymer/iron-iconset-svg",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-image": {
     "npm": "@polymer/iron-image",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-list": {
     "npm": "@polymer/iron-list",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-pages": {
     "npm": "@polymer/iron-pages",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-swipeable-container": {
     "npm": "@polymer/iron-swipeable-container",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-test-helpers": {
     "npm": "@polymer/iron-test-helpers",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-form": {
     "npm": "@polymer/iron-form",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-meta": {
     "npm": "@polymer/iron-meta",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-input-elements": {
     "npm": "@polymer/iron-input-elements",
@@ -317,11 +317,11 @@
   },
   "iron-label": {
     "npm": "@polymer/iron-label",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-localstorage": {
     "npm": "@polymer/iron-localstorage",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "iron-signals": {
     "npm": "@polymer/iron-signals",
@@ -337,43 +337,43 @@
   },
   "paper-badge": {
     "npm": "@polymer/paper-badge",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-behaviors": {
     "npm": "@polymer/paper-behaviors",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-ripple": {
     "npm": "@polymer/paper-ripple",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-card": {
     "npm": "@polymer/paper-card",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-checkbox": {
     "npm": "@polymer/paper-checkbox",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-dialog": {
     "npm": "@polymer/paper-dialog",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-dialog-behavior": {
     "npm": "@polymer/paper-dialog-behavior",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-dialog-scrollable": {
     "npm": "@polymer/paper-dialog-scrollable",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-dropdown-menu": {
     "npm": "@polymer/paper-dropdown-menu",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-menu-button": {
     "npm": "@polymer/paper-menu-button",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-elements": {
     "npm": "@polymer/paper-elements",
@@ -393,59 +393,59 @@
   },
   "paper-fab": {
     "npm": "@polymer/paper-fab",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-listbox": {
     "npm": "@polymer/paper-listbox",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-radio-button": {
     "npm": "@polymer/paper-radio-button",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-radio-group": {
     "npm": "@polymer/paper-radio-group",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-slider": {
     "npm": "@polymer/paper-slider",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-linear-progress": {
     "npm": "@polymer/paper-linear-progress",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-progress": {
     "npm": "@polymer/paper-progress",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-scroll-header-panel": {
     "npm": "@polymer/paper-scroll-header-panel",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-spinner": {
     "npm": "@polymer/paper-spinner",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-swatch-picker": {
     "npm": "@polymer/paper-swatch-picker",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-tabs": {
     "npm": "@polymer/paper-tabs",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-text-field": {
     "npm": "@polymer/paper-text-field",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-toast": {
     "npm": "@polymer/paper-toast",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "paper-tooltip": {
     "npm": "@polymer/paper-tooltip",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^3.0.0"
   },
   "platinum-bluetooth": {
     "npm": "@polymer/platinum-bluetooth",
@@ -485,7 +485,7 @@
   },
   "test-fixture": {
     "npm": "@polymer/test-fixture",
-    "semver": "^3.0.0-pre.18"
+    "semver": "^4.0.0"
   },
   "shadycss": {
     "npm": "@webcomponents/shadycss",

--- a/packages/modulizer/fixtures/packages/iron-icon/expected/package.json
+++ b/packages/modulizer/fixtures/packages/iron-icon/expected/package.json
@@ -15,12 +15,12 @@
     "@polymer/gen-typescript-declarations": "^1.2.0",
     "bower": "^1.8.0",
     "@polymer/promise-polyfill": "^3.0.0-pre.18",
-    "@polymer/iron-iconset": "^3.0.0-pre.18",
-    "@polymer/iron-icons": "^3.0.0-pre.18",
-    "@polymer/iron-component-page": "^3.0.0-pre.18",
+    "@polymer/iron-iconset": "^3.0.0",
+    "@polymer/iron-icons": "^3.0.0",
+    "@polymer/iron-component-page": "^3.0.0",
     "wct-browser-legacy": "^1.0.1",
     "@webcomponents/webcomponentsjs": "^2.0.0",
-    "@polymer/iron-demo-helpers": "^3.0.0-pre.18"
+    "@polymer/iron-demo-helpers": "^3.0.0"
   },
   "scripts": {
     "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir ."
@@ -35,8 +35,8 @@
   "main": "iron-icon.js",
   "author": "The Polymer Authors",
   "dependencies": {
-    "@polymer/iron-flex-layout": "^3.0.0-pre.18",
-    "@polymer/iron-meta": "^3.0.0-pre.18",
+    "@polymer/iron-flex-layout": "^3.0.0",
+    "@polymer/iron-meta": "^3.0.0",
     "@polymer/polymer": "^3.0.0"
   }
 }

--- a/packages/modulizer/fixtures/packages/paper-button/expected/package.json
+++ b/packages/modulizer/fixtures/packages/paper-button/expected/package.json
@@ -17,12 +17,12 @@
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.2.0",
     "bower": "^1.8.0",
-    "@polymer/iron-component-page": "^3.0.0-pre.18",
-    "@polymer/iron-demo-helpers": "^3.0.0-pre.18",
-    "@polymer/iron-icon": "^3.0.0-pre.18",
-    "@polymer/iron-icons": "^3.0.0-pre.18",
-    "@polymer/iron-test-helpers": "^3.0.0-pre.18",
-    "@polymer/test-fixture": "^3.0.0-pre.18",
+    "@polymer/iron-component-page": "^3.0.0",
+    "@polymer/iron-demo-helpers": "^3.0.0",
+    "@polymer/iron-icon": "^3.0.0",
+    "@polymer/iron-icons": "^3.0.0",
+    "@polymer/iron-test-helpers": "^3.0.0",
+    "@polymer/test-fixture": "^4.0.0",
     "wct-browser-legacy": "^1.0.1",
     "@webcomponents/webcomponentsjs": "^2.0.0"
   },
@@ -40,8 +40,8 @@
   "author": "The Polymer Authors",
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "@polymer/iron-flex-layout": "^3.0.0-pre.18",
-    "@polymer/paper-behaviors": "^3.0.0-pre.18",
-    "@polymer/paper-styles": "^3.0.0-pre.18"
+    "@polymer/iron-flex-layout": "^3.0.0",
+    "@polymer/paper-behaviors": "^3.0.0",
+    "@polymer/paper-styles": "^3.0.0"
   }
 }

--- a/packages/modulizer/fixtures/packages/polymer/expected/package.json
+++ b/packages/modulizer/fixtures/packages/polymer/expected/package.json
@@ -38,8 +38,8 @@
     "through2": "^2.0.0",
     "web-component-tester": "^6.9.0",
     "wct-browser-legacy": "^1.0.1",
-    "@polymer/test-fixture": "^3.0.0-pre.18",
-    "@polymer/iron-component-page": "^3.0.0-pre.18"
+    "@polymer/test-fixture": "^4.0.0",
+    "@polymer/iron-component-page": "^3.0.0"
   },
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
This includes `test-fixture` 4.0.0 major bump.

Also removed a bunch of archived elements, e.g.
- iron-signals
- paper-menu
- platinum-*

Note: fixtures updated manually, running the script now will produce incorrect output since the `master` branches no longer use Polymer 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/tools/703)
<!-- Reviewable:end -->
