### PR TITLE
[wct-local] Added support for SELENIUM_OVERRIDES_CONFIG variable on postinstall.

### DIFF
--- a/packages/wct-local/CHANGELOG.md
+++ b/packages/wct-local/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- Changed postinstall.js script to accept a SELENIUM_OVERRIDES_CONFIG environment variable to allow specifying an alternate location for a json file containing a 'selenium-overrides' key with configuration details for the `selenium.install()` step.  Thanks to @bernardoVale for contribution.
 <!-- Add unreleased changes here. -->
 
 ## [v2.1.1] - 2018-06-25

--- a/packages/wct-local/scripts/postinstall.js
+++ b/packages/wct-local/scripts/postinstall.js
@@ -9,7 +9,9 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-var SELENIUM_OVERRIDES = require('../package.json')['selenium-overrides'];
+var seleniumConfig = process.env.SELENIUM_OVERRIDES_CONFIG || '../package.json';
+var SELENIUM_OVERRIDES = require(seleniumConfig)['selenium-overrides'];
+
 // Work around a potential npm race condition:
 // https://github.com/npm/npm/issues/6624
 function requireSelenium(done, attempt) {


### PR DESCRIPTION
Ported over the two lines from https://github.com/Polymer/wct-local/pull/79
