### PR TITLE
Updated polymer-cli integration tests to use v3.0.0 tag in Polymer/shop now that 3.0 branch has been deleted

### DIFF
--- a/packages/cli/src/github/github.ts
+++ b/packages/cli/src/github/github.ts
@@ -199,4 +199,18 @@ export class Github {
           this._repo}/legacy.tar.gz/${branch.commit.sha}`
     };
   }
+
+  async getTag(tag: string): Promise<CodeSource> {
+    // GitHubApi.Branch is not correct.
+    interface Reference {
+      object: {sha: string};
+    }
+    const ref: Reference = await this._github.gitdata.getReference(
+        {owner: this._owner, repo: this._repo, ref: `tags/${tag}`});
+    return {
+      name: tag,
+      tarball_url: `https://codeload.github.com/${this._owner}/${
+          this._repo}/legacy.tar.gz/${ref.object.sha}`
+    };
+  }
 }

--- a/packages/cli/src/init/github.ts
+++ b/packages/cli/src/init/github.ts
@@ -30,6 +30,7 @@ export interface GithubGeneratorOptions {
   repo: string;
   semverRange?: string;
   branch?: string;
+  tag?: string;
   installDependencies?: InstallOptions;
 }
 
@@ -40,6 +41,7 @@ export function createGithubGenerator(githubOptions: GithubGeneratorOptions):
   const repo = githubOptions.repo;
   const semverRange = githubOptions.semverRange || '*';
   const branch = githubOptions.branch;
+  const tag = githubOptions.tag;
   const installDependencies = githubOptions.installDependencies;
 
   return class GithubGenerator extends Generator {
@@ -61,14 +63,16 @@ export function createGithubGenerator(githubOptions: GithubGeneratorOptions):
     async _writing() {
       let codeSource;
 
-      if (branch === undefined) {
+      if (branch) {
+        codeSource = await this._github.getBranch(branch!);
+      } else if (tag) {
+        codeSource = await this._github.getTag(tag);
+      } else {
         logger.info(
             (semverRange === '*') ?
                 `Finding latest release of ${owner}/${repo}` :
                 `Finding latest ${semverRange} release of ${owner}/${repo}`);
         codeSource = await this._github.getSemverRelease(semverRange);
-      } else {
-        codeSource = await this._github.getBranch(branch);
       }
 
       await this._github.extractReleaseTarball(

--- a/packages/cli/src/test/integration/integration_test.ts
+++ b/packages/cli/src/test/integration/integration_test.ts
@@ -524,7 +524,7 @@ suite('polymer shop', function() {
           owner: 'Polymer',
           repo: 'shop',
           githubToken,
-          branch: '3.0',
+          tag: 'v3.0.0',
           installDependencies: {
             bower: false,
             npm: true,


### PR DESCRIPTION
Monorepo integration tests were broken because Polymer/shop 3.0 branch was deleted yesterday.

I had to add a new getTag method to the GitHub class to download a tag commit for the integration tests since we didn't have that scenario before.

Otherwise its same.