### PR TITLE
[polymer-build] Added wct-mocha to the list of supported WCT client-side packages in the html-transform.

### DIFF
--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Added `wct-mocha` to the set of recognized WCT client-side packages in `htmlTransform` when using [@polymer/esm-amd-loader](https://github.com/Polymer/tools/tree/master/packages/esm-amd-loader). 
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.4] - 2018-06-28

--- a/packages/build/src/html-transform.ts
+++ b/packages/build/src/html-transform.ts
@@ -123,7 +123,8 @@ export function htmlTransform(
     } else if (wctScript === undefined) {
       const src = dom5.getAttribute(script, 'src') || '';
       if (src.includes('web-component-tester/browser.js') ||
-          src.includes('wct-browser-legacy/browser.js')) {
+          src.includes('wct-browser-legacy/browser.js') ||
+          src.includes('wct-mocha/browser.js')) {
         wctScript = script;
       }
     }


### PR DESCRIPTION
For WCT to work properly with the esm-amd-loader, polymer-build adds a little hack where it waits for all defined modules to resolve before calling the original WCT waitFor callback.  That hack is only added when there is a recognized WCT client-side package.  Previously `web-component-tester/browser.js` or `wct-browser-legacy/browser.js`.  This PR just adds `wct-mocha/browser.js` to that list.