### PR TITLE
Fix injected WCT hack to prevent dynamic modules run Mocha multiple times

### DIFF
--- a/packages/build/src/html-transform.ts
+++ b/packages/build/src/html-transform.ts
@@ -284,6 +284,7 @@ function addWctTimingHack(wctScript: dom5.Node, amdLoaderScript: dom5.Node) {
         moduleCount--;
         if (moduleCount === 0) {
           window._wctCallback();
+          window.define = originalDefine;
         }
       });
     };

--- a/packages/polyserve/test/bower_components/test-modules/golden/test-suite-wct.html
+++ b/packages/polyserve/test/bower_components/test-modules/golden/test-suite-wct.html
@@ -37,6 +37,7 @@
         moduleCount--;
         if (moduleCount === 0) {
           window._wctCallback();
+          window.define = originalDefine;
         }
       });
     };


### PR DESCRIPTION
Fixes https://github.com/Polymer/tools/issues/726

As far as I understand the intention of the injected code it should be safe to assume that all static modules will be loaded by the time the callback is run for the first time. This is why I just disable it for future calls so that dynamic imports do not cause the issues.

I tested this fix on our code containing multiple suites all using components which use dynamic imports. Works well.