### PR TITLE
Turn off deadcode removal

### DIFF
--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -109,6 +109,7 @@ const babelPresetMinify = require('babel-preset-minify')({}, {
   // Disable the simplify plugin because it can eat some statements preceeding
   // loops. https://github.com/babel/minify/issues/824
   simplify: false,
+  deadcode: false,
 
   // This is breaking ES6 output. https://github.com/Polymer/tools/issues/261
   mangle: false,


### PR DESCRIPTION
Fixes #724

As per https://github.com/babel/minify/issues/574#issuecomment-307390713 there are times when actual code can be removed as if it were dead code.

I'm working on a better solution, but wanted to get a better run on the tests here than I'm having luck for locally.