### PR TITLE
Updated web-component-tester to support wct-mocha/wct-mocha.js instead of wct-mocha/browser.js

### DIFF
--- a/packages/web-component-tester/runner/config.ts
+++ b/packages/web-component-tester/runner/config.ts
@@ -330,8 +330,10 @@ const ARG_CONFIG = {
   },
   wctPackageName: {
     full: 'wct-package-name',
-    help: 'NPM package name that contains web-component-tester\'s browser.js.' +
-        ' Defaults to wct-browser-legacy. This is only used in NPM projects.'
+    help: 'NPM package name that contains web-component-tester\'s browser ' +
+        'code.  By default, WCT will detect the installed package, but ' +
+        'this flag allows explicitly naming the package. ' +
+        'This is only to be used with --npm option.'
   },
 
   // Deprecated

--- a/packages/web-component-tester/runner/webserver.ts
+++ b/packages/web-component-tester/runner/webserver.ts
@@ -97,7 +97,12 @@ export function webserver(wct: Context): void {
           resolveFrom(fromPath, options.wctPackageName + '/package.json'));
 
       if (npmPackageRootPath) {
-        browserScript = `${npmPackageRootPath}/browser.js`.slice(
+        const wctPackageScriptName =
+            ['web-component-tester', 'wct-browser-legacy'].includes(
+                options.wctPackageName) ?
+            'browser.js' :
+            `${options.wctPackageName}.js`;
+        browserScript = `${npmPackageRootPath}/${wctPackageScriptName}`.slice(
             npmPackageRootPath.length - options.wctPackageName.length);
       }
 


### PR DESCRIPTION
Putting this into WCT ahead of the wct-mocha release so we can start testing with version of CLI we are releasing shortly.