### PR TITLE
Updated the retry-failures-reporter to correctly pass the cwd from current process

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     "test": "npm run build && npm run test:unit && npm run lint",
     "test:smoke": "gulp test",
     "test:smoke-lint": "gulp test lint",
-    "test:integration": "bash -c \"TEST_RETRY_TARGET_MAX=7 mocha \\\"lib/test/integration/**/*_test.js\\\" --reporter node_modules/web-component-tester/test/retry-failures-reporter.js\"",
+    "test:integration": "bash -c \"TEST_RETRY_TARGET_MAX=7 mocha \\\"lib/test/integration/**/*_test.js\\\" --reporter \\\"./node_modules/web-component-tester/test/retry-failures-reporter.js\\\"\"",
     "test:unit": "mocha \"lib/test/unit/**/*_test.js\"",
     "test:watch": "tsc-then -- mocha \"lib/test/**/*_test.js\"",
     "test:watch:unit": "tsc-then -- mocha \"lib/test/unit/**/*_test.js\"",

--- a/packages/web-component-tester/test/retry-failures-reporter.ts
+++ b/packages/web-component-tester/test/retry-failures-reporter.ts
@@ -78,6 +78,7 @@ module.exports = class RetryFailuresReporter extends Mocha.reporters.Spec {
           fails.map((t) => ' - ' + t).join('\n')));
 
       const retryResults = spawnSync(process.argv0, args, {
+        cwd: process.cwd(),
         env: Object.assign({}, process.env, {
           'TEST_RETRY_TARGETS': JSON.stringify(fails),
           'TEST_RETRY_COUNT': `${retryCount + 1}`,


### PR DESCRIPTION
I noticed that polymer-cli was unable to retry using the retry-failures-reporter from wct due to issue with current working directory.  So I fixed that in the spawnSync call and went from this:

![screen shot 2018-10-15 at 4 18 35 pm](https://user-images.githubusercontent.com/578/46983667-6ef4aa00-d096-11e8-999b-670b673becae.png)

to this:

![screen shot 2018-10-15 at 4 18 18 pm](https://user-images.githubusercontent.com/578/46983670-72883100-d096-11e8-88df-0060f09c312c.png)

