### PR TITLE
Updated bundler CHANGELOG and patch version number for release.

### DIFF
--- a/packages/bundler/CHANGELOG.md
+++ b/packages/bundler/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
-* Fixed issue with newer version of chalk that broke `polymer-bundler -h` output. https://github.com/Polymer/tools/issues/741
+<!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
+
+## 4.0.4 - 2018-10-18
+* Fixed issue with newer version of chalk that broke `polymer-bundler -h` output. https://github.com/Polymer/tools/issues/741
 
 ## 4.0.3 - 2018-10-15
 * Fix issue with multiple dynamic imports of the same fragment.  https://github.com/Polymer/tools/issues/568

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-bundler",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Process Web Components into one output file",
   "homepage": "https://github.com/Polymer/tools/tree/master/packages/bundler",
   "repository": "github:Polymer/tools",


### PR DESCRIPTION
This is a patch release to fix the broken polymer-bundler CLI `-h` option (was due to breaking change in chalk brought in by command-line-usage package.