### PR TITLE
Updated version and CHANGELOG for prerelease of wct-mocha

### DIFF
--- a/packages/wct-mocha/CHANGELOG.md
+++ b/packages/wct-mocha/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
-* Created `wct-mocha` as a dependency-free alternative to running browser-side test suites; code has been extracted from and is fully compatible with `web-component-tester@^6.8.1`
+<!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
+
+## 1.0.0-pre.2
+* Created `wct-mocha` as a dependency-free alternative to running browser-side test suites; code has been extracted from and is fully compatible with `web-component-tester@^6.9.0-pre.1`

--- a/packages/wct-mocha/package.json
+++ b/packages/wct-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wct-mocha",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "description": "Client-side library for testing web-components with Mocha.",
   "main": "lib/index.js",
   "files": [

--- a/packages/wct-mocha/test/package.json
+++ b/packages/wct-mocha/test/package.json
@@ -17,7 +17,7 @@
     "@webcomponents/webcomponentsjs": "^2.1.1",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
-    "wct-mocha": "^1.0.0-pre.1",
+    "wct-mocha": "^1.0.0-pre.2",
     "web-component-tester": "^6.9.0-pre.1"
   }
 }


### PR DESCRIPTION
A version of wct-mocha 1.0.0-pre.1 was accidentally published as "latest" (and then unpublished) a month or so ago, which consumed the 1.0.0-pre.1 version, so this will be published as 1.0.0-pre.2