### PR TITLE
Firefox push fixed in 63

### DIFF
--- a/packages/browser-capabilities/src/browser-capabilities.ts
+++ b/packages/browser-capabilities/src/browser-capabilities.ts
@@ -118,7 +118,7 @@ const browserPredicates: {
     es2017: since(52),
     es2018: since(58),  // Except RegEx additions
     // Firefox bug - https://bugzilla.mozilla.org/show_bug.cgi?id=1409570
-    push: () => false,
+    push: since(63),
     serviceworker: since(44),
     modules: () => false,
   },


### PR DESCRIPTION
Verified with https://20170915t110514-dot-polymer-shop.appspot.com/, the last version of Shop pushed with an older version of browser-capabilities that pushed to Firefox. Ref https://bugzilla.mozilla.org/show_bug.cgi?id=1409570