### PR TITLE
Updated wct-local to override the out-of-date geckodriver setting from current version of selenium-standalone package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
   - node_js: '8'
     addons:
       chrome: stable
-      firefox: "62.0"
+      firefox: latest
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 
   - node_js: '10'
     addons:
       chrome: stable
-      firefox: "62.0"
+      firefox: latest
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 

--- a/packages/wct-local/CHANGELOG.md
+++ b/packages/wct-local/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- Updated postinstall.js script to specify latest geckodriver to support Firefox 63.
 <!-- Add unreleased changes here. -->
 
 ## [v2.1.2] - 2018-09-17

--- a/packages/wct-local/package.json
+++ b/packages/wct-local/package.json
@@ -42,6 +42,30 @@
       }
     }
   },
+  "selenium-overrides": {
+    "baseURL": "https://selenium-release.storage.googleapis.com",
+    "version": "3.12.0",
+    "drivers": {
+      "chrome": {
+        "version": "2.41",
+        "arch": "process.arch",
+        "baseURL": "https://chromedriver.storage.googleapis.com"
+      },
+      "ie": {
+        "version": "3.12.0",
+        "arch": "process.arch",
+        "baseURL": "https://selenium-release.storage.googleapis.com"
+      },
+      "firefox": {
+        "version": "0.23.0",
+        "arch": "process.arch",
+        "baseURL": "https://github.com/mozilla/geckodriver/releases/download"
+      },
+      "edge": {
+        "version": "17134"
+      }
+    }
+  },
   "dependencies": {
     "@types/express": "^4.0.30",
     "@types/freeport": "^1.0.19",


### PR DESCRIPTION
The issue with Firefox 63 stems from our use of selenium-standalone npm package which hasn't updated to use the latest version (0.23.0) of geckodriver.  See https://github.com/vvo/selenium-standalone/issues/409 / https://github.com/vvo/selenium-standalone/pulls/408

Until they do, we have to override the version we download on postinstall.