### PR TITLE
Updated polymer-cli polymer 3.x templates to use wct-mocha

### DIFF
--- a/packages/cli/templates/application/polymer-3.x/package.json
+++ b/packages/cli/templates/application/polymer-3.x/package.json
@@ -8,6 +8,8 @@
   },
   "devDependencies": {
     "@webcomponents/webcomponentsjs": "^2.0.0",
-    "wct-browser-legacy": "^1.0.0"
+    "chai": "^4.2.0",
+    "mocha": "^5.2.0",
+    "wct-mocha": "^1.0.0-pre.2"
   }
 }

--- a/packages/cli/templates/application/polymer-3.x/test/_element/_element_test.html
+++ b/packages/cli/templates/application/polymer-3.x/test/_element/_element_test.html
@@ -7,7 +7,9 @@
     <title><%= elementName %> test</title>
 
     <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-    <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+    <script src="../../node_modules/mocha/mocha.js"></script>
+    <script src="../../node_modules/chai/chai.js"></script>
+    <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
 
     <script type="module" src="../../src/<%= elementName %>/<%= elementName %>.js"></script>
   </head>

--- a/packages/cli/templates/element/polymer-3.x/package.json
+++ b/packages/cli/templates/element/polymer-3.x/package.json
@@ -10,6 +10,8 @@
   "devDependencies": {
     "@polymer/iron-demo-helpers": "^3.0.0-pre.19",
     "@webcomponents/webcomponentsjs": "^2.0.0",
-    "wct-browser-legacy": "^1.0.0"
+    "chai": "^4.2.0",
+    "mocha": "^5.2.0",
+    "wct-mocha": "^1.0.0-pre.2"
   }
 }

--- a/packages/cli/templates/element/polymer-3.x/test/_element_test.html
+++ b/packages/cli/templates/element/polymer-3.x/test/_element_test.html
@@ -7,7 +7,9 @@
     <title><%= name %> test</title>
 
     <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-    <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/chai/chai.js"></script>
+    <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
 
     <script type="module" src="../<%= name %>.js"></script>
   </head>

--- a/packages/cli/templates/element/polymer-3.x/test/index.html
+++ b/packages/cli/templates/element/polymer-3.x/test/index.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
   </head>
   <body>
     <script>


### PR DESCRIPTION
Note that mocha and chai are now explicit dev dependencies and are loaded explicitly in the test html files.