### PR TITLE
Disable deadcode removal in babel-minify

### DIFF
--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- Unreleased -->
+* Fix issue with deadcode removal in babel-minify, by turning it off, as it can be error prone and result in removal of code which should not be removed and cause hard to debug errors. https://github.com/Polymer/tools/issues/724
 <!-- Add new, unreleased changes here. -->
 
 ## [3.1.0] - 2018-10-15

--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -99,8 +99,7 @@ const babelSyntaxPlugins = [
 
 const babelPresetMinify = require('babel-preset-minify')({}, {
   // Disable the minify-constant-folding plugin because it has a bug relating
-  // to
-  // invalid substitution of constant values into export specifiers:
+  // to invalid substitution of constant values into export specifiers:
   // https://github.com/babel/minify/issues/820
   evaluate: false,
 
@@ -108,8 +107,7 @@ const babelPresetMinify = require('babel-preset-minify')({}, {
   simplifyComparisons: false,
 
   // Prevent removal of things that babel thinks are unreachable, but sometimes
-  // gets wrong:
-  // https://github.com/Polymer/tools/issues/724
+  // gets wrong: https://github.com/Polymer/tools/issues/724
   deadcode: false,
 
   // Disable the simplify plugin because it can eat some statements preceeding

--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -98,13 +98,19 @@ const babelSyntaxPlugins = [
 ];
 
 const babelPresetMinify = require('babel-preset-minify')({}, {
-  // Disable the minify-constant-folding plugin because it has a bug relating to
+  // Disable the minify-constant-folding plugin because it has a bug relating
+  // to
   // invalid substitution of constant values into export specifiers:
   // https://github.com/babel/minify/issues/820
   evaluate: false,
 
   // TODO(aomarks) Find out why we disabled this plugin.
   simplifyComparisons: false,
+
+  // Prevent removal of things that babel thinks are unreachable, but sometimes
+  // gets wrong:
+  // https://github.com/Polymer/tools/issues/724
+  deadcode: false,
 
   // Disable the simplify plugin because it can eat some statements preceeding
   // loops. https://github.com/babel/minify/issues/824

--- a/packages/build/src/test/js-transform_test.ts
+++ b/packages/build/src/test/js-transform_test.ts
@@ -82,6 +82,12 @@ suite('jsTransform', () => {
           jsTransform('const foo = 3;', {compile: true, minify: true}),
           'var foo=3;');
     });
+
+    test('minifies but does not try to remove dead code', () => {
+      assert.equal(
+          jsTransform('if (false) { never(); } always();', {minify: true}),
+          'if(!1){never()}always();');
+    });
   });
 
   suite('babel helpers', () => {


### PR DESCRIPTION
Fix issue https://github.com/Polymer/tools/issues/724 where deadcode removal in babel-minify can be error prone and result in removal of code which should not be removed and cause hard to debug errors. 