### PR TITLE
Update wct-mocha package for official 1.0 release.

### DIFF
--- a/packages/wct-mocha/CHANGELOG.md
+++ b/packages/wct-mocha/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
 
+## 1.0.0
+* Official initial release of `wct-mocha` as a drop-in replacement for `wct-browser-legacy`.
+
 ## 1.0.0-pre.3
 * Minor refactorings, updated typings, but no functional differences intentionally introduced.
 

--- a/packages/wct-mocha/package.json
+++ b/packages/wct-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wct-mocha",
-  "version": "1.0.0-pre.3",
+  "version": "1.0.0",
   "description": "Client-side library for testing web-components with Mocha.",
   "main": "lib/index.js",
   "files": [

--- a/packages/wct-mocha/test/package.json
+++ b/packages/wct-mocha/test/package.json
@@ -17,7 +17,7 @@
     "@webcomponents/webcomponentsjs": "^2.1.1",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
-    "wct-mocha": "^1.0.0-pre.3",
+    "wct-mocha": "^1.0.0",
     "web-component-tester": "^6.9.0"
   }
 }


### PR DESCRIPTION
Need to release this one separately before the templates in CLI can be updated to use 1.0 instead of prerelease because integration tests would fail.

- [x] wct-mocha@1.0.0