### PR TITLE
Fix typings in editor-service tests to make tools build again

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ install:
   - npm ci
   - npm run bootstrap
   - npm run build
+  # NOTE(keanulee): Following needed until Chrome in AppVeyor images are
+  # updated - see https://github.com/appveyor/ci/issues/2772.
   - choco install googlechrome
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
   - npm ci
   - npm run bootstrap
   - npm run build
+  - choco install googlechrome
 
 test_script:
   - node --version

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,57 +4,56 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@lerna/add": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.5.0.tgz",
-      "integrity": "sha512-hoOqtal/ChEEtt9rxR/6xmyvTN7581XF4kWHoWPV9NbfZN9e8uTR8z4mCcJq2DiZhRuY7aA5FEROEbl12soowQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.6.0.tgz",
+      "integrity": "sha512-aFVekkHMno3hj1Vg3EiIpAwrZ4g34i8z4KrCx7ATY6BRuxVT4Nt/Nk3l2k6gEOq3tWUDtUctLHxIAo14FI8sng==",
       "dev": true,
       "requires": {
-        "@lerna/bootstrap": "^3.5.0",
-        "@lerna/command": "^3.5.0",
-        "@lerna/filter-options": "^3.5.0",
+        "@lerna/bootstrap": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
         "@lerna/npm-conf": "^3.4.1",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/validation-error": "^3.6.0",
         "dedent": "^0.7.0",
-        "npm-package-arg": "^6.0.0",
+        "libnpm": "^2.0.1",
         "p-map": "^1.2.0",
-        "pacote": "^9.1.0",
         "semver": "^5.5.0"
       }
     },
     "@lerna/batch-packages": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.1.2.tgz",
-      "integrity": "sha512-HAkpptrYeUVlBYbLScXgeCgk6BsNVXxDd53HVWgzzTWpXV4MHpbpeKrByyt7viXlNhW0w73jJbipb/QlFsHIhQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.6.0.tgz",
+      "integrity": "sha512-khG15B+EFLH3Oms6A6WsMAy54DrnKIhEAm6CCATN2BKnBkNgitYjLN2vKBzlR2LfQpTkgub67QKIJkMFQcK1Sg==",
       "dev": true,
       "requires": {
-        "@lerna/package-graph": "^3.1.2",
-        "@lerna/validation-error": "^3.0.0",
-        "npmlog": "^4.1.2"
+        "@lerna/package-graph": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/bootstrap": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.5.0.tgz",
-      "integrity": "sha512-+z4kVVJFO5EGfC2ob/4C9LetqWwDtbhZgTRllr1+zOi/2clbD+WKcVI0ku+/ckzKjz783SOc83swX7RrmiLwMQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.6.0.tgz",
+      "integrity": "sha512-z6rZQw/aLEN+ragWRYqIIVwA9rDv3QtmRc5VyIRrlV/JiuGpq67FcSR6BrCMc/A7UJ9Kx95+bESm/HUwheKoiQ==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
-        "@lerna/command": "^3.5.0",
-        "@lerna/filter-options": "^3.5.0",
+        "@lerna/batch-packages": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
         "@lerna/has-npm-version": "^3.3.0",
         "@lerna/npm-conf": "^3.4.1",
-        "@lerna/npm-install": "^3.3.0",
-        "@lerna/rimraf-dir": "^3.3.0",
-        "@lerna/run-lifecycle": "^3.4.1",
+        "@lerna/npm-install": "^3.6.0",
+        "@lerna/package-graph": "^3.6.0",
+        "@lerna/rimraf-dir": "^3.6.0",
+        "@lerna/run-lifecycle": "^3.6.0",
         "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/symlink-binary": "^3.3.0",
-        "@lerna/symlink-dependencies": "^3.3.0",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/symlink-binary": "^3.6.0",
+        "@lerna/symlink-dependencies": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
         "dedent": "^0.7.0",
         "get-port": "^3.2.0",
+        "libnpm": "^2.0.1",
         "multimatch": "^2.1.0",
-        "npm-package-arg": "^6.0.0",
-        "npmlog": "^4.1.2",
         "p-finally": "^1.0.0",
         "p-map": "^1.2.0",
         "p-map-series": "^1.0.0",
@@ -64,26 +63,26 @@
       }
     },
     "@lerna/changed": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.5.0.tgz",
-      "integrity": "sha512-p9o7/hXwFAoet7UPeHIzIPonYxLHZe9bcNcjxKztZYAne5/OgmZiF4X1UPL2S12wtkT77WQy4Oz8NjRTczcapg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.6.0.tgz",
+      "integrity": "sha512-L1SXTtQrsv+4F5Knw5sW/nGnMJq+bbOzhZX2srJ10WsuHuzk3cJWAi7dVEsS3RPKUw9DWOuHKy86o3v6byEiqA==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "^3.5.0",
-        "@lerna/command": "^3.5.0",
-        "@lerna/listable": "^3.0.0",
-        "@lerna/output": "^3.0.0",
-        "@lerna/version": "^3.5.0"
+        "@lerna/collect-updates": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/listable": "^3.6.0",
+        "@lerna/output": "^3.6.0",
+        "@lerna/version": "^3.6.0"
       }
     },
     "@lerna/check-working-tree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.5.0.tgz",
-      "integrity": "sha512-aWeIputHddeZgf7/wA1e5yuv6q9S5si2y7fzO2Ah7m3KyDyl8XHP1M0VSSDzZeiloYCryAYQAoRgcrdH65Vhow==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.6.0.tgz",
+      "integrity": "sha512-Ioy1t2aVasAwhY1Oi5kfpwbW9RDupxxVVu2t2c1EeBYYCu3jIt1A5ad34gidgsKyiG3HeBEVziI4Uaihnb96ZQ==",
       "dev": true,
       "requires": {
-        "@lerna/describe-ref": "^3.5.0",
-        "@lerna/validation-error": "^3.0.0"
+        "@lerna/describe-ref": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0"
       }
     },
     "@lerna/child-process": {
@@ -137,29 +136,29 @@
       }
     },
     "@lerna/clean": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.5.0.tgz",
-      "integrity": "sha512-bHUFF6Wv7ms81Tmwe56xk296oqU74Sg9NSkUCDG4kZLpYZx347Aw+89ZPTlaSmUwqCgEXKYLr65ZVVvKmflpcA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.6.0.tgz",
+      "integrity": "sha512-4LodI/jh8IEYtqnrY/OFSpWn5YfDWoDv+5QjiJpd91EjW9vjmkvyhzQ5fG9KtltwgYVn/NJ5zlI1WfmMEXvFFQ==",
       "dev": true,
       "requires": {
-        "@lerna/command": "^3.5.0",
-        "@lerna/filter-options": "^3.5.0",
-        "@lerna/prompt": "^3.3.1",
-        "@lerna/rimraf-dir": "^3.3.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
+        "@lerna/prompt": "^3.6.0",
+        "@lerna/rimraf-dir": "^3.6.0",
         "p-map": "^1.2.0",
         "p-map-series": "^1.0.0",
         "p-waterfall": "^1.0.0"
       }
     },
     "@lerna/cli": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.2.0.tgz",
-      "integrity": "sha512-JdbLyTxHqxUlrkI+Ke+ltXbtyA+MPu9zR6kg/n8Fl6uaez/2fZWtReXzYi8MgLxfUFa7+1OHWJv4eAMZlByJ+Q==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.6.0.tgz",
+      "integrity": "sha512-FGCx7XOLpqmU5eFOlo0Lt0hRZraxSUTEWM0bce0p+HNpOxBc91o6d2tenW1azPYFP9HzsMQey1NBtU0ofJJeog==",
       "dev": true,
       "requires": {
         "@lerna/global-options": "^3.1.3",
         "dedent": "^0.7.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "yargs": "^12.0.1"
       },
       "dependencies": {
@@ -310,34 +309,34 @@
       }
     },
     "@lerna/collect-updates": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.5.0.tgz",
-      "integrity": "sha512-rFCng14K8vHyrDJSAacj6ABKKT/TxZdpL9uPEtZN7DsoJKlKPzqFeRvRGA2+ed/I6mEm4ltauEjEpKG5O6xqtw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.6.0.tgz",
+      "integrity": "sha512-knliEz3phY51SGnwDhhYqx6SJN6y9qh/gZrZgQ7ogqz1UgA/MyJb27gszjsyyG6jUQshimBpjsG7OMwjt8+n9A==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/describe-ref": "^3.5.0",
+        "@lerna/describe-ref": "^3.6.0",
+        "libnpm": "^2.0.1",
         "minimatch": "^3.0.4",
-        "npmlog": "^4.1.2",
         "slash": "^1.0.0"
       }
     },
     "@lerna/command": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.5.0.tgz",
-      "integrity": "sha512-C/0e7qPbuKZ9vEqzRePksoKDJk4TOWzsU5qaPP/ikqc6vClJbKucsIehk3za6glSjlgLCJpzBTF2lFjHfb+JNw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.6.0.tgz",
+      "integrity": "sha512-BGpXaY2WrxPcIiZX0aATO2HQBatvYT7Qy46lqMnV9RrTePYJ1PPbX1nMzLXSxgrnnlTcTwJNEkw/TL9Xzrph7Q==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/package-graph": "^3.1.2",
-        "@lerna/project": "^3.5.0",
-        "@lerna/validation-error": "^3.0.0",
-        "@lerna/write-log-file": "^3.0.0",
+        "@lerna/package-graph": "^3.6.0",
+        "@lerna/project": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
+        "@lerna/write-log-file": "^3.6.0",
         "dedent": "^0.7.0",
         "execa": "^1.0.0",
         "is-ci": "^1.0.10",
-        "lodash": "^4.17.5",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1",
+        "lodash": "^4.17.5"
       },
       "dependencies": {
         "cross-spawn": {
@@ -380,19 +379,18 @@
       }
     },
     "@lerna/conventional-commits": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.5.0.tgz",
-      "integrity": "sha512-roKPILPYnDWiCDxOeBQ0cObJ2FbDgzJSToxr1ZwIqvJU5hGQ4RmooCf8GHcCW9maBJz7ETeestv8M2mBUgBPbg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.6.0.tgz",
+      "integrity": "sha512-KkY3wd7w/tj76EEIhTMYZlSBk/5WkT2NA9Gr/EuSwKV70PYyVA55l1OGlikBUAnuqIjwyfw9x3y+OcbYI4aNEg==",
       "dev": true,
       "requires": {
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/validation-error": "^3.6.0",
         "conventional-changelog-angular": "^5.0.2",
         "conventional-changelog-core": "^3.1.5",
         "conventional-recommended-bump": "^4.0.4",
         "fs-extra": "^7.0.0",
         "get-stream": "^4.0.0",
-        "npm-package-arg": "^6.0.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "semver": "^5.5.0"
       },
       "dependencies": {
@@ -408,21 +406,22 @@
       }
     },
     "@lerna/create": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.5.0.tgz",
-      "integrity": "sha512-ek4flHRmpMegZp9tP3RmuDhmMb9+/Hhy9B5eaZc5X5KWqDvFKJtn56sw+M9hNjiYehiimCwhaLWgE2WSikPvcQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.6.0.tgz",
+      "integrity": "sha512-21OunW25Y3Q/oynqWVk0znQFBvZ5tHyLPhzkJeomGmOj0il1RdOUiChu9G9AYsCaLDwBFR0ZFqvTgJ5iw/eaIg==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.5.0",
+        "@lerna/command": "^3.6.0",
         "@lerna/npm-conf": "^3.4.1",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/validation-error": "^3.6.0",
         "camelcase": "^4.1.0",
         "dedent": "^0.7.0",
         "fs-extra": "^7.0.0",
         "globby": "^8.0.1",
         "init-package-json": "^1.10.3",
-        "npm-package-arg": "^6.0.0",
+        "libnpm": "^2.0.1",
+        "p-reduce": "^1.0.0",
         "pify": "^3.0.0",
         "semver": "^5.5.0",
         "slash": "^1.0.0",
@@ -432,81 +431,81 @@
       }
     },
     "@lerna/create-symlink": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.3.0.tgz",
-      "integrity": "sha512-0lb88Nnq1c/GG+fwybuReOnw3+ah4dB81PuWwWwuqUNPE0n50qUf/M/7FfSb5JEh/93fcdbZI0La8t3iysNW1w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.6.0.tgz",
+      "integrity": "sha512-YG3lTb6zylvmGqKU+QYA3ylSnoLn+FyLH5XZmUsD0i85R884+EyJJeHx/zUk+yrL2ZwHS4RBUgJfC24fqzgPoA==",
       "dev": true,
       "requires": {
         "cmd-shim": "^2.0.2",
         "fs-extra": "^7.0.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/describe-ref": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.5.0.tgz",
-      "integrity": "sha512-XvecK2PSwUv4z+otib5moWJMI+h3mtAg8nFlfo4KbivVtD/sI11jfKsr3S75HuAwhVAa8tAijoAxmuBJSsTE1g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.6.0.tgz",
+      "integrity": "sha512-hVZJ2hYVbrrNiEG+dEg/Op4pYAbROkDZdiIUabAJffr0T/frcN+5es2HfmOC//4+78Cs1M9iTyQRoyC1RXS2BQ==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-iyZ0ZRPqH5Y5XEhOYoKS8H/8UXC/gZ/idlToMFHhUn1oTSd8v9HVU1c2xq1ge0u36ZH/fx/YydUk0A/KSv+p3Q==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.6.0.tgz",
+      "integrity": "sha512-p5+VyYKuAnw6NFVrT4s9eBubFZEYlJmiR1mdVlwNtohqS86gERjrPtI0unUK/pxFKb1U2ZNo4fhSlPd+pLwfHg==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.5.0",
-        "@lerna/validation-error": "^3.0.0",
-        "npmlog": "^4.1.2"
+        "@lerna/command": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/exec": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.5.0.tgz",
-      "integrity": "sha512-H5jeIueDiuNsxeuGKaP7HqTcenvMsFfBFeWr0W6knHv9NrOF8il34dBqYgApZEDSQ7+2fA3ghwWbF+jUGTSh/A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.6.0.tgz",
+      "integrity": "sha512-lwLYASpS8FoQpVYLBpoZlS7bpzkO9pD3D9XeDDKZBodDhdZeCEx2Md2CxZU1RKYDSVIXA8oObvlUh1FEhRQv2w==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
+        "@lerna/batch-packages": "^3.6.0",
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.5.0",
-        "@lerna/filter-options": "^3.5.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
         "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/validation-error": "^3.0.0"
+        "@lerna/validation-error": "^3.6.0"
       }
     },
     "@lerna/filter-options": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.5.0.tgz",
-      "integrity": "sha512-7pEQy1i5ynYOYjcSeo+Qaps4+Ais55RRdnT6/SLLBgyyHAMziflFLX5TnoyEaaXoU90iKfQ5z/ioEp6dFAXSMg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.6.0.tgz",
+      "integrity": "sha512-6iUMZuvvXPL5EAF7Zo9azaZ6FxOq6tGbiSX8fUXgCdN+jlRjorvkzR+E0HS4bEGTWmV446lnLwdQLZuySfLcbQ==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "^3.5.0",
-        "@lerna/filter-packages": "^3.0.0",
+        "@lerna/collect-updates": "^3.6.0",
+        "@lerna/filter-packages": "^3.6.0",
         "dedent": "^0.7.0"
       }
     },
     "@lerna/filter-packages": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.0.0.tgz",
-      "integrity": "sha512-zwbY1J4uRjWRZ/FgYbtVkq7I3Nduwsg2V2HwLKSzwV2vPglfGqgovYOVkND6/xqe2BHwDX4IyA2+e7OJmLaLSA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.6.0.tgz",
+      "integrity": "sha512-O/nIENV3LOqp/TiUIw3Ir6L/wUGFDeYBdJsJTQDlTAyHZsgYA1OIn9FvlW8nqBu1bNLzoBVHXh3c5azx1kE+Hg==",
       "dev": true,
       "requires": {
-        "@lerna/validation-error": "^3.0.0",
-        "multimatch": "^2.1.0",
-        "npmlog": "^4.1.2"
+        "@lerna/validation-error": "^3.6.0",
+        "libnpm": "^2.0.1",
+        "multimatch": "^2.1.0"
       }
     },
     "@lerna/get-npm-exec-opts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.0.0.tgz",
-      "integrity": "sha512-arcYUm+4xS8J3Palhl+5rRJXnZnFHsLFKHBxznkPIxjwGQeAEw7df38uHdVjEQ+HNeFmHnBgSqfbxl1VIw5DHg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.6.0.tgz",
+      "integrity": "sha512-ruH6KuLlt75aCObXfUIdVJqmfVq7sgWGq5mXa05vc1MEqxTIiU23YiJdWzofQOOUOACaZkzZ4K4Nu7wXEg4Xgg==",
       "dev": true,
       "requires": {
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/global-options": {
@@ -526,78 +525,79 @@
       }
     },
     "@lerna/import": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.5.0.tgz",
-      "integrity": "sha512-vgI6lMEzd1ODgi75cmAlfPYylaK37WY3E2fwKyO/lj6UKSGj46dVSK0KwTRHx33tu4PLvPzFi5C6nbY57o5ykQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.6.0.tgz",
+      "integrity": "sha512-8jxNRbAaa4mvMJr0u+sy75gMFPyWfxLHEp+pDs73x1oqMZhpS8O5901QMnpZyRyOvJRhoBJd5hBX2dpsLxC6Xw==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.5.0",
-        "@lerna/prompt": "^3.3.1",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/prompt": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
         "dedent": "^0.7.0",
         "fs-extra": "^7.0.0",
         "p-map-series": "^1.0.0"
       }
     },
     "@lerna/init": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.5.0.tgz",
-      "integrity": "sha512-V21/UWj34Mph+9NxIGH1kYcuJAp+uFjfG8Ku2nMy62OGL3553+YQ+Izr+R6egY8y/99UMCDpi5gkQni5eGv3MA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.6.0.tgz",
+      "integrity": "sha512-MTLy3rmMdvpXRmDdoYiVPx7I8sXH4dquq/0MxntL5VxSVh/ZS1HsbrjyRqpdkUKWD9QguxR/w0pzOjVvCeM8CQ==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.5.0",
+        "@lerna/command": "^3.6.0",
         "fs-extra": "^7.0.0",
         "p-map": "^1.2.0",
         "write-json-file": "^2.3.0"
       }
     },
     "@lerna/link": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.5.0.tgz",
-      "integrity": "sha512-KSu1mhxwNRmguqMqUTJd4c7QIk9/xmxJxbmMkA71OaJd4fwondob6DyI/B17NIWutdLbvSWQ7pRlFOPxjQVoUw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.6.0.tgz",
+      "integrity": "sha512-Xk8TTAE4EWGyhxLuPxWdyS7i7vfsM5igb6tEyhZm94XUdlA4PmMOYe25BfO7SM/9LYroFknZeDyWAebye3r+PA==",
       "dev": true,
       "requires": {
-        "@lerna/command": "^3.5.0",
-        "@lerna/package-graph": "^3.1.2",
-        "@lerna/symlink-dependencies": "^3.3.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/package-graph": "^3.6.0",
+        "@lerna/symlink-dependencies": "^3.6.0",
         "p-map": "^1.2.0",
         "slash": "^1.0.0"
       }
     },
     "@lerna/list": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.5.0.tgz",
-      "integrity": "sha512-T+NZBQ/l6FmZklgrtFuN7luMs3AC/BoS52APOPrM7ZmxW4nenvov0xMwQW1783w/t365YDkDlYd5gM0nX3D1Hg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.6.0.tgz",
+      "integrity": "sha512-hlQOJkg8K3XXUVXotofP71XsgkhXkkmU/EkqlNg15D78MjzhT+p1wCbG5m89K3tzvjcWVeZwU6L0elaOIXVyCw==",
       "dev": true,
       "requires": {
-        "@lerna/command": "^3.5.0",
-        "@lerna/filter-options": "^3.5.0",
-        "@lerna/listable": "^3.0.0",
-        "@lerna/output": "^3.0.0"
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
+        "@lerna/listable": "^3.6.0",
+        "@lerna/output": "^3.6.0"
       }
     },
     "@lerna/listable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.0.0.tgz",
-      "integrity": "sha512-HX/9hyx1HLg2kpiKXIUc1EimlkK1T58aKQ7ovO7rQdTx9ForpefoMzyLnHE1n4XrUtEszcSWJIICJ/F898M6Ag==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.6.0.tgz",
+      "integrity": "sha512-fz63+zlqrJ9KQxIiv0r7qtufM4DEinSayAuO8YJuooz+1ctIP7RvMEQNvYI/E9tDlUo9Q0de68b5HbKrpmA5rQ==",
       "dev": true,
       "requires": {
+        "@lerna/batch-packages": "^3.6.0",
         "chalk": "^2.3.1",
         "columnify": "^1.5.4"
       }
     },
     "@lerna/log-packed": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.0.4.tgz",
-      "integrity": "sha512-vVQHgMagE2wnbxhNY9nFkdu+Cx2TsyWalkJfkxbNzmo6gOCrDsxCBDj9vTEV8Q+4aWx0C0Bsc0sB2Eb8y/+ofA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.6.0.tgz",
+      "integrity": "sha512-T/J41zMkzpWB5nbiTRS5PmYTFn74mJXe6RQA2qhkdLi0UqnTp97Pux1loz3jsJf2yJtiQUnyMM7KuKIAge0Vlw==",
       "dev": true,
       "requires": {
         "byte-size": "^4.0.3",
         "columnify": "^1.5.4",
         "has-unicode": "^2.0.1",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/npm-conf": {
@@ -611,102 +611,100 @@
       }
     },
     "@lerna/npm-dist-tag": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.3.0.tgz",
-      "integrity": "sha512-EtZJXzh3w5tqXEev+EBBPrWKWWn0WgJfxm4FihfS9VgyaAW8udIVZHGkIQ3f+tBtupcAzA9Q8cQNUkGF2efwmA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.6.0.tgz",
+      "integrity": "sha512-qX6IfQPX9Tum1LRjvjgj/yr2FYbc9dfHyeh7RI9zJ8pGncWbksBmnMcvoxF0Eu4+d7MjjIGfEnIp9LIl4MHSIA==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1",
+        "npm-registry-fetch": "^3.8.0"
       }
     },
     "@lerna/npm-install": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.3.0.tgz",
-      "integrity": "sha512-WoVvKdS8ltROTGSNQwo6NDq0YKnjwhvTG4li1okcN/eHKOS3tL9bxbgPx7No0wOq5DKBpdeS9KhAfee6LFAZ5g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.6.0.tgz",
+      "integrity": "sha512-RKV31VdrBZKjmKfq25JG4mIHJ8NAOsLKq/aYSaBs8zP+uwXH7RU39saVfv9ReKiAzhKE2ghOG2JeMdIHtYnPNA==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
+        "@lerna/get-npm-exec-opts": "^3.6.0",
         "fs-extra": "^7.0.0",
-        "npm-package-arg": "^6.0.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "signal-exit": "^3.0.2",
         "write-pkg": "^3.1.0"
       }
     },
     "@lerna/npm-publish": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.3.1.tgz",
-      "integrity": "sha512-bVTlWIcBL6Zpyzqvr9C7rxXYcoPw+l7IPz5eqQDNREj1R39Wj18OWB2KTJq8l7LIX7Wf4C2A1uT5hJaEf9BuvA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.6.0.tgz",
+      "integrity": "sha512-k4yF8ursajoGRlJeRh7xdeGN0HV/ALt5qImUnpTliux0213jqxA0YigiD8WSaXpvSqxSFyvh38DbJhhy9q+NuQ==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
+        "@lerna/get-npm-exec-opts": "^3.6.0",
         "@lerna/has-npm-version": "^3.3.0",
-        "@lerna/log-packed": "^3.0.4",
+        "@lerna/log-packed": "^3.6.0",
         "fs-extra": "^7.0.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "p-map": "^1.2.0"
       }
     },
     "@lerna/npm-run-script": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.3.0.tgz",
-      "integrity": "sha512-YqDguWZzp4jIomaE4aWMUP7MIAJAFvRAf6ziQLpqwoQskfWLqK5mW0CcszT1oLjhfb3cY3MMfSTFaqwbdKmICg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.6.0.tgz",
+      "integrity": "sha512-6DRNFma30ex9r1a8mMDXziSRHf1/mo//hnvW1Zc1ctBh+7PU4I8n3A2ht/+742vtoTQH93Iqs3QSJl2KOLSsYg==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
-        "npmlog": "^4.1.2"
+        "@lerna/get-npm-exec-opts": "^3.6.0",
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/output": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.0.0.tgz",
-      "integrity": "sha512-EFxnSbO0zDEVKkTKpoCUAFcZjc3gn3DwPlyTDxbeqPU7neCfxP4rA4+0a6pcOfTlRS5kLBRMx79F2TRCaMM3DA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.6.0.tgz",
+      "integrity": "sha512-9sjQouf6p7VQtVCRnzoTGlZyURd48i3ha3WBHC/UBJnHZFuXMqWVPKNuvnMf2kRXDyoQD+2mNywpmEJg5jOnRg==",
       "dev": true,
       "requires": {
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/package": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.0.0.tgz",
-      "integrity": "sha512-djzEJxzn212wS8d9znBnlXkeRlPL7GqeAYBykAmsuq51YGvaQK67Umh5ejdO0uxexF/4r7yRwgrlRHpQs8Rfqg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.6.0.tgz",
+      "integrity": "sha512-XbXcjwPKA1V640mqjEicpBriO6QcNtocdfLAtEUP4uCKkRx5r9h7DdznQMCoSJYJF6Gh/PpLokPUItfMhJP3Hg==",
       "dev": true,
       "requires": {
-        "npm-package-arg": "^6.0.0",
+        "libnpm": "^2.0.1",
         "write-pkg": "^3.1.0"
       }
     },
     "@lerna/package-graph": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.1.2.tgz",
-      "integrity": "sha512-9wIWb49I1IJmyjPdEVZQ13IAi9biGfH/OZHOC04U2zXGA0GLiY+B3CAx6FQvqkZ8xEGfqzmXnv3LvZ0bQfc1aQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.6.0.tgz",
+      "integrity": "sha512-Xtldh3DTiC3cPDrs6OY5URiuRXGPMIN6uFKcx59rOu3TkqYRt346jRyX+hm85996Y/pboo3+JuQlonvuEP/9QQ==",
       "dev": true,
       "requires": {
-        "@lerna/validation-error": "^3.0.0",
-        "npm-package-arg": "^6.0.0",
+        "@lerna/validation-error": "^3.6.0",
+        "libnpm": "^2.0.1",
         "semver": "^5.5.0"
       }
     },
     "@lerna/project": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.5.0.tgz",
-      "integrity": "sha512-uFDzqwrD7a/tTohQoo0voTsRy2cgl9D1ZOU2pHZzHzow9S1M8E0x5q3hJI2HlwsZry9IUugmDUGO6UddTjwm3Q==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.6.0.tgz",
+      "integrity": "sha512-pEOZF1igGFqs+qWog6cJWqVyBUX21xSqrlcgeN0yzqzI36VMHozmf/u7dgclIb5MylWk5Yp87KCKswBF4hrcuQ==",
       "dev": true,
       "requires": {
-        "@lerna/package": "^3.0.0",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/package": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
         "cosmiconfig": "^5.0.2",
         "dedent": "^0.7.0",
         "dot-prop": "^4.2.0",
         "glob-parent": "^3.1.0",
         "globby": "^8.0.1",
+        "libnpm": "^2.0.1",
         "load-json-file": "^4.0.0",
-        "npmlog": "^4.1.2",
         "p-map": "^1.2.0",
         "resolve-from": "^4.0.0",
         "write-json-file": "^2.3.0"
@@ -740,42 +738,40 @@
       }
     },
     "@lerna/prompt": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.3.1.tgz",
-      "integrity": "sha512-eJhofrUCUaItMIH6et8kI7YqHfhjWqGZoTsE+40NRCfAraOMWx+pDzfRfeoAl3qeRAH2HhNj1bkYn70FbUOxuQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.6.0.tgz",
+      "integrity": "sha512-nyAjPMolJ/ZRAAVcXrUH89C4n1SiWvLh4xWNvWYKLcf3PI5yges35sDFP/HYrM4+cEbkNFuJCRq6CxaET4PRsg==",
       "dev": true,
       "requires": {
         "inquirer": "^6.2.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/publish": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.5.1.tgz",
-      "integrity": "sha512-ltw2YdWWzev9cZRAzons5ywZh9NJARPX67meeA95oMDVMrhD4Y9VHQNJ3T8ueec/W78/4sKlMSr3ecWyPNp5bg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.6.0.tgz",
+      "integrity": "sha512-F2bT96ZS7NJfid6T4a6TSanpVUQ4VOuhjPBPX2hagt5gnocm7lluvAFR7dl/cbEgmKIg2zJQnfAPTYjrtxXMVg==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
-        "@lerna/check-working-tree": "^3.5.0",
+        "@lerna/batch-packages": "^3.6.0",
+        "@lerna/check-working-tree": "^3.6.0",
         "@lerna/child-process": "^3.3.0",
-        "@lerna/collect-updates": "^3.5.0",
-        "@lerna/command": "^3.5.0",
-        "@lerna/describe-ref": "^3.5.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
+        "@lerna/collect-updates": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/describe-ref": "^3.6.0",
+        "@lerna/get-npm-exec-opts": "^3.6.0",
         "@lerna/npm-conf": "^3.4.1",
-        "@lerna/npm-dist-tag": "^3.3.0",
-        "@lerna/npm-publish": "^3.3.1",
-        "@lerna/output": "^3.0.0",
-        "@lerna/prompt": "^3.3.1",
-        "@lerna/run-lifecycle": "^3.4.1",
+        "@lerna/npm-dist-tag": "^3.6.0",
+        "@lerna/npm-publish": "^3.6.0",
+        "@lerna/output": "^3.6.0",
+        "@lerna/prompt": "^3.6.0",
+        "@lerna/run-lifecycle": "^3.6.0",
         "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/validation-error": "^3.0.0",
-        "@lerna/version": "^3.5.0",
+        "@lerna/validation-error": "^3.6.0",
+        "@lerna/version": "^3.6.0",
         "fs-extra": "^7.0.0",
-        "libnpmaccess": "^3.0.0",
-        "npm-package-arg": "^6.0.0",
+        "libnpm": "^2.0.1",
         "npm-registry-fetch": "^3.8.0",
-        "npmlog": "^4.1.2",
         "p-finally": "^1.0.0",
         "p-map": "^1.2.0",
         "p-pipe": "^1.2.0",
@@ -784,54 +780,53 @@
       }
     },
     "@lerna/resolve-symlink": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.3.0.tgz",
-      "integrity": "sha512-KmoPDcFJ2aOK2inYHbrsiO9SodedUj0L1JDvDgirVNIjMUaQe2Q6Vi4Gh+VCJcyB27JtfHioV9R2NxU72Pk2hg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.6.0.tgz",
+      "integrity": "sha512-TVOAEqHJSQVhNDMFCwEUZPaOETqHDQV1TQWQfC8ZlOqyaUQ7veZUbg0yfG7RPNzlSpvF0ZaGFeR0YhYDAW03GA==",
       "dev": true,
       "requires": {
         "fs-extra": "^7.0.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "read-cmd-shim": "^1.0.1"
       }
     },
     "@lerna/rimraf-dir": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.3.0.tgz",
-      "integrity": "sha512-vSqOcZ4kZduiSprbt+y40qziyN3VKYh+ygiCdnbBbsaxpdKB6CfrSMUtrLhVFrqUfBHIZRzHIzgjTdtQex1KLw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.6.0.tgz",
+      "integrity": "sha512-2CfyWP1lqxDET+SfwGlLUfgqGF4vz9TYDrmb7Zi//g7IFCo899uU2vWOrEcdWTgbKE3Qgwwfk9c008w5MWUhog==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "path-exists": "^3.0.0",
         "rimraf": "^2.6.2"
       }
     },
     "@lerna/run": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.5.0.tgz",
-      "integrity": "sha512-BnPD52tj794xG2Xsc4FvgksyFX2CLmSR28TZw/xASEuy14NuQYMZkvbaj61SEhyOEsq7pLhHE5PpfbIv2AIFJw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.6.0.tgz",
+      "integrity": "sha512-OYa5pQTOiES/h9rg8vwnt0nYU/wLKUQmFYhMUxdX3lXYpoIcQ28PR7qPG1CVhex4KAU2OW42a7vnm5MAOoScDg==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
-        "@lerna/command": "^3.5.0",
-        "@lerna/filter-options": "^3.5.0",
-        "@lerna/npm-run-script": "^3.3.0",
-        "@lerna/output": "^3.0.0",
+        "@lerna/batch-packages": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
+        "@lerna/npm-run-script": "^3.6.0",
+        "@lerna/output": "^3.6.0",
         "@lerna/run-parallel-batches": "^3.0.0",
         "@lerna/timer": "^3.5.0",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/validation-error": "^3.6.0",
         "p-map": "^1.2.0"
       }
     },
     "@lerna/run-lifecycle": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.4.1.tgz",
-      "integrity": "sha512-N/hi2srM9A4BWEkXccP7vCEbf4MmIuALF00DTBMvc0A/ccItwUpl3XNuM7+ADDRK0mkwE3hDw89lJ3A7f8oUQw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.6.0.tgz",
+      "integrity": "sha512-/1+vAZnckgKwHVgWG0plVO24erNWUduz9htMOO9wuOfglTnHlMRqDc3s9B/OIKxGDkyzEvxqzfzq3c6JqEolRQ==",
       "dev": true,
       "requires": {
         "@lerna/npm-conf": "^3.4.1",
-        "npm-lifecycle": "^2.0.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/run-parallel-batches": {
@@ -845,27 +840,27 @@
       }
     },
     "@lerna/symlink-binary": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.3.0.tgz",
-      "integrity": "sha512-zRo6CimhvH/VJqCFl9T4IC6syjpWyQIxEfO2sBhrapEcfwjtwbhoGgKwucsvt4rIpFazCw63jQ/AXMT27KUIHg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.6.0.tgz",
+      "integrity": "sha512-h69AQBBWgZOEzQ1RJEYQ7Ou6llrJNhNNkpqT6k8qSWZ93iXyFmLE4hWoxMXXHFmxmQ0CqjEYKmeLV1Dr5DKT4g==",
       "dev": true,
       "requires": {
-        "@lerna/create-symlink": "^3.3.0",
-        "@lerna/package": "^3.0.0",
+        "@lerna/create-symlink": "^3.6.0",
+        "@lerna/package": "^3.6.0",
         "fs-extra": "^7.0.0",
         "p-map": "^1.2.0",
         "read-pkg": "^3.0.0"
       }
     },
     "@lerna/symlink-dependencies": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.3.0.tgz",
-      "integrity": "sha512-IRngSNCmuD5uBKVv23tHMvr7Mplti0lKHilFKcvhbvhAfu6m/Vclxhkfs/uLyHzG+DeRpl/9o86SQET3h4XDhg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.6.0.tgz",
+      "integrity": "sha512-mLpbWLidAU5Xi7bc9Fj8Yt/9XvDczzWocnS/yEe0E6RqWXh2KK+4VR9H24rLywBAWTv2s4GEXrb/ofbPb8gwBQ==",
       "dev": true,
       "requires": {
-        "@lerna/create-symlink": "^3.3.0",
-        "@lerna/resolve-symlink": "^3.3.0",
-        "@lerna/symlink-binary": "^3.3.0",
+        "@lerna/create-symlink": "^3.6.0",
+        "@lerna/resolve-symlink": "^3.6.0",
+        "@lerna/symlink-binary": "^3.6.0",
         "fs-extra": "^7.0.0",
         "p-finally": "^1.0.0",
         "p-map": "^1.2.0",
@@ -879,34 +874,34 @@
       "dev": true
     },
     "@lerna/validation-error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.0.0.tgz",
-      "integrity": "sha512-5wjkd2PszV0kWvH+EOKZJWlHEqCTTKrWsvfHnHhcUaKBe/NagPZFWs+0xlsDPZ3DJt5FNfbAPAnEBQ05zLirFA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.6.0.tgz",
+      "integrity": "sha512-MWltncGO5VgMS0QedTlZCjFUMF/evRjDMMHrtVorkIB2Cp5xy0rkKa8iDBG43qpUWeG1giwi58yUlETBcWfILw==",
       "dev": true,
       "requires": {
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/version": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.5.0.tgz",
-      "integrity": "sha512-vxuGkUSfjJuvOIgPG7SDXVmk4GPwJF9F+uhDW9T/wJzTk4UaxL37GpBeJDo43eutQ7mwluP+t88Luwf8S3WXlA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.6.0.tgz",
+      "integrity": "sha512-V1f3fNM5ELGHmF824Wc8ah505SMpfiBqOHAIiW+u9soH/3W/t256c1P9UeaDh5blWAk3HeZMzbpRZ9Nlpf6aQA==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
-        "@lerna/check-working-tree": "^3.5.0",
+        "@lerna/batch-packages": "^3.6.0",
+        "@lerna/check-working-tree": "^3.6.0",
         "@lerna/child-process": "^3.3.0",
-        "@lerna/collect-updates": "^3.5.0",
-        "@lerna/command": "^3.5.0",
-        "@lerna/conventional-commits": "^3.5.0",
-        "@lerna/output": "^3.0.0",
-        "@lerna/prompt": "^3.3.1",
-        "@lerna/run-lifecycle": "^3.4.1",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/collect-updates": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/conventional-commits": "^3.6.0",
+        "@lerna/output": "^3.6.0",
+        "@lerna/prompt": "^3.6.0",
+        "@lerna/run-lifecycle": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
         "chalk": "^2.3.1",
         "dedent": "^0.7.0",
+        "libnpm": "^2.0.1",
         "minimatch": "^3.0.4",
-        "npmlog": "^4.1.2",
         "p-map": "^1.2.0",
         "p-pipe": "^1.2.0",
         "p-reduce": "^1.0.0",
@@ -917,12 +912,12 @@
       }
     },
     "@lerna/write-log-file": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.0.0.tgz",
-      "integrity": "sha512-SfbPp29lMeEVOb/M16lJwn4nnx5y+TwCdd7Uom9umd7KcZP0NOvpnX0PHehdonl7TyHZ1Xx2maklYuCLbQrd/A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.6.0.tgz",
+      "integrity": "sha512-OkLK99V6sYXsJsYg+O9wtiFS3z6eUPaiz2e6cXJt80mfIIdI1t2dnmyua0Ib5cZWExQvx2z6Y32Wlf0MnsoNsA==",
       "dev": true,
       "requires": {
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "write-file-atomic": "^2.3.0"
       }
     },
@@ -976,20 +971,20 @@
       "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww=="
     },
     "@types/node": {
-      "version": "10.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-      "integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+      "version": "10.12.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+      "integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
     },
     "@types/sinon": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-5.0.7.tgz",
-      "integrity": "sha512-opwMHufhUwkn/UUDk35LDbKJpA2VBsZT8WLU8NjayvRLGPxQkN+8XmfC2Xl35MAscBE8469koLLBjaI3XLEIww==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.0.tgz",
+      "integrity": "sha512-kcYoPw0uKioFVC/oOqafk2yizSceIQXCYnkYts9vJIwQklFRsMubTObTDrjQamUyBRd47332s85074cd/hCwxg==",
       "dev": true
     },
     "@types/sinon-chai": {
-      "version": "2.7.34",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.34.tgz",
-      "integrity": "sha512-1AxQR0Tk4Q0FYGoJrj66UKhiMmlmxg78SuC5rBJp55Nex4cd948GGJca1Qf2bf1X7P4YKcAW3uKiQB9yvJP4rA==",
+      "version": "2.7.35",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.35.tgz",
+      "integrity": "sha512-qjLSkrk27AdsRdYo9PlGI5Qsx3C8QJsRNSI71YUBaIwPOlnH5wo6WXfPijEaN3tPsVPNzvlB2zzEG1pHVRLkDA==",
       "dev": true,
       "requires": {
         "@types/chai": "*",
@@ -1314,6 +1309,19 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bin-links": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.2.tgz",
+      "integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "cmd-shim": "^2.0.2",
+        "gentle-fs": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "write-file-atomic": "^2.3.0"
       }
     },
     "block-stream": {
@@ -2406,7 +2414,7 @@
             },
             "is-accessor-descriptor": {
               "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
@@ -2426,7 +2434,7 @@
             },
             "is-data-descriptor": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
@@ -2680,6 +2688,12 @@
         "repeat-string": "^1.5.2"
       }
     },
+    "find-npm-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+      "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
+      "dev": true
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -2767,6 +2781,17 @@
         "minipass": "^2.2.1"
       }
     },
+    "fs-vacuum": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+      "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "path-is-inside": "^1.0.1",
+        "rimraf": "^2.5.2"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -2839,6 +2864,22 @@
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
       "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
       "dev": true
+    },
+    "gentle-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
+      "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.2",
+        "fs-vacuum": "^1.2.10",
+        "graceful-fs": "^4.1.11",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "path-is-inside": "^1.0.2",
+        "read-cmd-shim": "^1.0.1",
+        "slide": "^1.1.6"
+      }
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -3515,7 +3556,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -3561,7 +3602,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -3859,28 +3900,56 @@
       }
     },
     "lerna": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.5.1.tgz",
-      "integrity": "sha512-0AyxMr2UpR3RAJsyrfNtYvfcI01YVSSnbRdzum7frZAtb7S+8NSY2ip7aDbN6/YsQK2K/zOCQ4shu/nwgub8aw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.6.0.tgz",
+      "integrity": "sha512-iQFAgrgtv18SI5LtQBBca0WVeYvk2r8eYgiEQtcZBT63T5R9RVv+snsviIiOp0z6gD43tcyiWXiLvBdp1IY/Rg==",
       "dev": true,
       "requires": {
-        "@lerna/add": "^3.5.0",
-        "@lerna/bootstrap": "^3.5.0",
-        "@lerna/changed": "^3.5.0",
-        "@lerna/clean": "^3.5.0",
-        "@lerna/cli": "^3.2.0",
-        "@lerna/create": "^3.5.0",
-        "@lerna/diff": "^3.5.0",
-        "@lerna/exec": "^3.5.0",
-        "@lerna/import": "^3.5.0",
-        "@lerna/init": "^3.5.0",
-        "@lerna/link": "^3.5.0",
-        "@lerna/list": "^3.5.0",
-        "@lerna/publish": "^3.5.1",
-        "@lerna/run": "^3.5.0",
-        "@lerna/version": "^3.5.0",
+        "@lerna/add": "^3.6.0",
+        "@lerna/bootstrap": "^3.6.0",
+        "@lerna/changed": "^3.6.0",
+        "@lerna/clean": "^3.6.0",
+        "@lerna/cli": "^3.6.0",
+        "@lerna/create": "^3.6.0",
+        "@lerna/diff": "^3.6.0",
+        "@lerna/exec": "^3.6.0",
+        "@lerna/import": "^3.6.0",
+        "@lerna/init": "^3.6.0",
+        "@lerna/link": "^3.6.0",
+        "@lerna/list": "^3.6.0",
+        "@lerna/publish": "^3.6.0",
+        "@lerna/run": "^3.6.0",
+        "@lerna/version": "^3.6.0",
         "import-local": "^1.0.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
+      }
+    },
+    "libnpm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-2.0.1.tgz",
+      "integrity": "sha512-qTKoxyJvpBxHZQB6k0AhSLajyXq9ZE/lUsZzuHAplr2Bpv9G+k4YuYlExYdUCeVRRGqcJt8hvkPh4tBwKoV98w==",
+      "dev": true,
+      "requires": {
+        "bin-links": "^1.1.2",
+        "bluebird": "^3.5.3",
+        "find-npm-prefix": "^1.0.2",
+        "libnpmaccess": "^3.0.1",
+        "libnpmconfig": "^1.2.1",
+        "libnpmhook": "^5.0.2",
+        "libnpmorg": "^1.0.0",
+        "libnpmpublish": "^1.1.0",
+        "libnpmsearch": "^2.0.0",
+        "libnpmteam": "^1.0.1",
+        "lock-verify": "^2.0.2",
+        "npm-lifecycle": "^2.1.0",
+        "npm-logical-tree": "^1.2.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-profile": "^4.0.1",
+        "npm-registry-fetch": "^3.8.0",
+        "npmlog": "^4.1.2",
+        "pacote": "^9.2.3",
+        "read-package-json": "^2.0.13",
+        "stringify-package": "^1.0.0"
       }
     },
     "libnpmaccess": {
@@ -3892,6 +3961,205 @@
         "aproba": "^2.0.0",
         "get-stream": "^4.0.0",
         "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmconfig": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+      "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "find-up": "^3.0.0",
+        "ini": "^1.3.5"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "dev": true
+        }
+      }
+    },
+    "libnpmhook": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.2.tgz",
+      "integrity": "sha512-vLenmdFWhRfnnZiNFPNMog6CK7Ujofy2TWiM2CrpZUjBRIhHkJeDaAbJdYCT6W4lcHtyrJR8yXW8KFyq6UAp1g==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmorg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.0.tgz",
+      "integrity": "sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmpublish": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.0.tgz",
+      "integrity": "sha512-mQ3LT2EWlpJ6Q8mgHTNqarQVCgcY32l6xadPVPMcjWLtVLz7II4WlWkzlbYg1nHGAf+xyABDwS+3aNUiRLkyaA==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.8.0",
+        "semver": "^5.5.1",
+        "ssri": "^6.0.1"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmsearch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.0.tgz",
+      "integrity": "sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmteam": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.1.tgz",
+      "integrity": "sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
         "npm-registry-fetch": "^3.8.0"
       },
       "dependencies": {
@@ -3933,6 +4201,16 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lock-verify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.0.2.tgz",
+      "integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
+      "dev": true,
+      "requires": {
+        "npm-package-arg": "^5.1.2 || 6",
+        "semver": "^5.4.1"
+      }
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -3943,6 +4221,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.sortby": {
@@ -4181,9 +4465,9 @@
       }
     },
     "minizlib": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
-      "integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
@@ -4447,6 +4731,12 @@
         "which": "^1.3.1"
       }
     },
+    "npm-logical-tree": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+      "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
+      "dev": true
+    },
     "npm-package-arg": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
@@ -4478,6 +4768,17 @@
         "figgy-pudding": "^3.5.1",
         "npm-package-arg": "^6.0.0",
         "semver": "^5.4.1"
+      }
+    },
+    "npm-profile": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.1.tgz",
+      "integrity": "sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.2 || 2",
+        "figgy-pudding": "^3.4.1",
+        "npm-registry-fetch": "^3.8.0"
       }
     },
     "npm-registry-fetch": {
@@ -4856,6 +5157,12 @@
       "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -4979,9 +5286,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
     },
     "pump": {
@@ -5712,7 +6019,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -5810,6 +6117,12 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "stringify-package": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
+      "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -6073,9 +6386,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
-      "integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg=="
     },
     "typescript-json-schema": {
       "version": "0.25.1",

--- a/packages/analyzer/package-lock.json
+++ b/packages/analyzer/package-lock.json
@@ -113,6 +113,15 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@sinonjs/commons": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
 			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -123,12 +132,14 @@
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-			"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+			"integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
 			"dev": true,
 			"requires": {
-				"array-from": "^2.1.1"
+				"@sinonjs/commons": "^1.0.2",
+				"array-from": "^2.1.1",
+				"lodash.get": "^4.4.2"
 			}
 		},
 		"@types/babel-generator": {
@@ -204,9 +215,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -779,9 +790,9 @@
 			"integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg=="
 		},
 		"glogg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+			"integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
 			"dev": true,
 			"requires": {
 				"sparkles": "^1.0.0"
@@ -974,9 +985,9 @@
 			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
 		},
 		"just-extend": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
 			"dev": true
 		},
 		"klaw": {
@@ -1271,7 +1282,7 @@
 		},
 		"multipipe": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"resolved": "http://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
 			"dev": true,
 			"requires": {
@@ -1279,25 +1290,25 @@
 			}
 		},
 		"nise": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
-			"integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+			"integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "3.0.0",
-				"just-extend": "^3.0.0",
+				"@sinonjs/formatio": "^3.1.0",
+				"just-extend": "^4.0.2",
 				"lolex": "^2.3.2",
 				"path-to-regexp": "^1.7.0",
 				"text-encoding": "^0.6.4"
 			},
 			"dependencies": {
 				"@sinonjs/formatio": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-					"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+					"integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
 					"dev": true,
 					"requires": {
-						"@sinonjs/samsam": "2.1.0"
+						"@sinonjs/samsam": "^2 || ^3"
 					}
 				}
 			}
@@ -1695,7 +1706,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},

--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -542,6 +542,15 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@sinonjs/commons": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
 			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -552,12 +561,14 @@
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-			"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+			"integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
 			"dev": true,
 			"requires": {
-				"array-from": "^2.1.1"
+				"@sinonjs/commons": "^1.0.2",
+				"array-from": "^2.1.1",
+				"lodash.get": "^4.4.2"
 			}
 		},
 		"@types/babel-types": {
@@ -649,9 +660,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -1403,9 +1414,9 @@
 			"integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
 		},
 		"colors": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-			"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
 		},
 		"colorspace": {
 			"version": "1.1.1",
@@ -2426,7 +2437,7 @@
 				},
 				"resolve": {
 					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
 					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
 					"dev": true
 				},
@@ -2492,9 +2503,9 @@
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"just-extend": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
 			"dev": true
 		},
 		"kind-of": {
@@ -2839,7 +2850,7 @@
 		},
 		"multipipe": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
 			"integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
 			"requires": {
 				"duplexer2": "^0.1.2",
@@ -2857,25 +2868,25 @@
 			}
 		},
 		"nise": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
-			"integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+			"integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "3.0.0",
-				"just-extend": "^3.0.0",
+				"@sinonjs/formatio": "^3.1.0",
+				"just-extend": "^4.0.2",
 				"lolex": "^2.3.2",
 				"path-to-regexp": "^1.7.0",
 				"text-encoding": "^0.6.4"
 			},
 			"dependencies": {
 				"@sinonjs/formatio": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-					"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+					"integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
 					"dev": true,
 					"requires": {
-						"@sinonjs/samsam": "2.1.0"
+						"@sinonjs/samsam": "^2 || ^3"
 					}
 				}
 			}
@@ -3602,7 +3613,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},

--- a/packages/bundler/package-lock.json
+++ b/packages/bundler/package-lock.json
@@ -53,9 +53,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -1246,7 +1246,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -18,6 +18,15 @@
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
 		},
+		"@sinonjs/commons": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
 			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -28,12 +37,14 @@
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-			"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+			"integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
 			"dev": true,
 			"requires": {
-				"array-from": "^2.1.1"
+				"@sinonjs/commons": "^1.0.2",
+				"array-from": "^2.1.1",
+				"lodash.get": "^4.4.2"
 			}
 		},
 		"@types/chalk": {
@@ -147,9 +158,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/puppeteer": {
 			"version": "1.11.1",
@@ -1073,9 +1084,9 @@
 			"integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
 		},
 		"colors": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-			"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
 		},
 		"colorspace": {
 			"version": "1.1.1",
@@ -1904,7 +1915,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
 								"kind-of": "^3.0.2"
@@ -1922,7 +1933,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
 								"kind-of": "^3.0.2"
@@ -3307,7 +3318,7 @@
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
 				"kind-of": "^3.0.2"
@@ -3341,7 +3352,7 @@
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
 				"kind-of": "^3.0.2"
@@ -3634,7 +3645,7 @@
 				},
 				"resolve": {
 					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
 					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
 					"dev": true
 				},
@@ -3743,9 +3754,9 @@
 			}
 		},
 		"just-extend": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
 			"dev": true
 		},
 		"kind-of": {
@@ -4277,25 +4288,25 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"nise": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
-			"integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+			"integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "3.0.0",
-				"just-extend": "^3.0.0",
+				"@sinonjs/formatio": "^3.1.0",
+				"just-extend": "^4.0.2",
 				"lolex": "^2.3.2",
 				"path-to-regexp": "^1.7.0",
 				"text-encoding": "^0.6.4"
 			},
 			"dependencies": {
 				"@sinonjs/formatio": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-					"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+					"integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
 					"dev": true,
 					"requires": {
-						"@sinonjs/samsam": "2.1.0"
+						"@sinonjs/samsam": "^2 || ^3"
 					}
 				}
 			}
@@ -4764,9 +4775,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
 		},
 		"pump": {
 			"version": "2.0.1",
@@ -5043,7 +5054,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
 								"kind-of": "^3.0.2"
@@ -5061,7 +5072,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
 								"kind-of": "^3.0.2"
@@ -5369,7 +5380,7 @@
 		},
 		"resolve-dir": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
 			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
 			"requires": {
 				"expand-tilde": "^1.2.2",
@@ -5778,7 +5789,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -161,7 +161,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
@@ -181,7 +181,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
@@ -1784,7 +1784,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
@@ -1804,7 +1804,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
@@ -1985,9 +1985,9 @@
 			}
 		},
 		"fined": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
-			"integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
+			"integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
 			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.2",
@@ -2003,9 +2003,9 @@
 			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
 		},
 		"flagged-respawn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
-			"integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+			"integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
 			"dev": true
 		},
 		"flat-cache": {
@@ -2789,9 +2789,9 @@
 			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
 		},
 		"glogg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+			"integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
 			"requires": {
 				"sparkles": "^1.0.0"
 			}
@@ -3509,7 +3509,7 @@
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
@@ -3545,7 +3545,7 @@
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
@@ -4103,7 +4103,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
@@ -4123,7 +4123,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
@@ -4459,7 +4459,7 @@
 		},
 		"multipipe": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"resolved": "http://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
 			"requires": {
 				"duplexer2": "0.0.2"
@@ -5142,7 +5142,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
@@ -5162,7 +5162,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
@@ -5823,7 +5823,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"stack-trace": {

--- a/packages/dom5/package-lock.json
+++ b/packages/dom5/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",

--- a/packages/editor-service/package-lock.json
+++ b/packages/editor-service/package-lock.json
@@ -28,9 +28,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -130,9 +130,9 @@
 			"integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
 		},
 		"colors": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-			"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
 		},
 		"colorspace": {
 			"version": "1.1.1",
@@ -475,18 +475,18 @@
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.13.0.tgz",
-			"integrity": "sha512-2ZGKwI+P2ovQll2PGAp+2UfJH+FK9eait86VBUdkPd9HRlm8e58aYT9pV/NYanHOcp3pL6x2yTLVCFMcTer0mg==",
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
+			"integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
 			"requires": {
 				"vscode-jsonrpc": "^4.0.0",
-				"vscode-languageserver-types": "3.13.0"
+				"vscode-languageserver-types": "3.14.0"
 			}
 		},
 		"vscode-languageserver-types": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz",
-			"integrity": "sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA=="
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
+			"integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
 		},
 		"vscode-uri": {
 			"version": "1.0.6",

--- a/packages/editor-service/src/test/util.ts
+++ b/packages/editor-service/src/test/util.ts
@@ -18,7 +18,7 @@ import * as path from 'path';
 import {PackageUrlResolver, SourcePosition, SourceRange, UrlLoader, UrlResolver} from 'polymer-analyzer';
 import {CodeUnderliner as BaseUnderliner} from 'polymer-analyzer/lib/test/test-utils';
 import {Duplex} from 'stream';
-import {ClientCapabilities, CodeLens, CodeLensParams, CodeLensRequest, CompletionList, CompletionRequest, createConnection, Definition, Diagnostic, DidChangeConfigurationNotification, DidChangeConfigurationParams, DidChangeTextDocumentNotification, DidChangeTextDocumentParams, DidChangeWatchedFilesNotification, DidChangeWatchedFilesParams, DidCloseTextDocumentNotification, DidCloseTextDocumentParams, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DocumentSymbolParams, DocumentSymbolRequest, FileChangeType, Hover, HoverRequest, IConnection, InitializeParams, Location, PublishDiagnosticsNotification, PublishDiagnosticsParams, ReferenceParams, ReferencesRequest, SymbolInformation, TextDocumentPositionParams, TextDocuments, WorkspaceSymbolParams, WorkspaceSymbolRequest} from 'vscode-languageserver';
+import {ClientCapabilities, CodeLens, CodeLensParams, CodeLensRequest, CompletionList, CompletionRequest, createConnection, Definition, Diagnostic, DidChangeConfigurationNotification, DidChangeConfigurationParams, DidChangeTextDocumentNotification, DidChangeTextDocumentParams, DidChangeWatchedFilesNotification, DidChangeWatchedFilesParams, DidCloseTextDocumentNotification, DidCloseTextDocumentParams, DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DocumentSymbolParams, DocumentSymbolRequest, FileChangeType, Hover, HoverRequest, IConnection, InitializeParams, Location, LocationLink, PublishDiagnosticsNotification, PublishDiagnosticsParams, ReferenceParams, ReferencesRequest, SymbolInformation, TextDocumentPositionParams, TextDocuments, WorkspaceSymbolParams, WorkspaceSymbolRequest} from 'vscode-languageserver';
 import {CancellationToken, DefinitionRequest, InitializeRequest, InitializeResult} from 'vscode-languageserver-protocol';
 import URI from 'vscode-uri';
 
@@ -119,7 +119,7 @@ export class Underliner extends BaseUnderliner {
   underline(references: Array<SourceRange|undefined>): Promise<string[]>;
   underline(location: Location|undefined): Promise<string>;
   underline(location: Array<Location|undefined>): Promise<string[]>;
-  underline(location: Location|Array<Location>|undefined|
+  underline(location: Location|Array<Location>|Array<LocationLink>|undefined|
             null): Promise<string|Array<string>>;
   underline(location: undefined|null): Promise<string>;
   // tslint:disable-next-line: no-any Crazily overloaded function.
@@ -164,6 +164,7 @@ export const defaultClientCapabilities: ClientCapabilities = {
     typeDefinition: {},
     colorProvider: {},
     foldingRange: {},
+    declaration: {}
   },
   workspace: {
     applyEdit: true,
@@ -249,7 +250,7 @@ export class TestClient {
   }
 
   async getDefinition(path: string, position: SourcePosition):
-      Promise<Definition|undefined> {
+      Promise<Definition|LocationLink[]|null> {
     const params: TextDocumentPositionParams = {
       position: this.converter.convertSourcePosition(position),
       textDocument: {uri: this.converter.getUriForLocalPath(path)}

--- a/packages/gen-typescript-declarations/package-lock.json
+++ b/packages/gen-typescript-declarations/package-lock.json
@@ -58,9 +58,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -460,9 +460,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.1.tgz",
-			"integrity": "sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg=="
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+			"integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg=="
 		},
 		"typical": {
 			"version": "2.6.1",

--- a/packages/linter/package-lock.json
+++ b/packages/linter/package-lock.json
@@ -31,9 +31,9 @@
 			"integrity": "sha1-OjYVzxc2Rcj8pY0FHk4ygk5L0oY="
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",

--- a/packages/modulizer/package-lock.json
+++ b/packages/modulizer/package-lock.json
@@ -82,9 +82,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/node-fetch": {
 			"version": "1.6.9",
@@ -1168,9 +1168,9 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"colors": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-			"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
 		},
 		"command-line-args": {
 			"version": "4.0.7",
@@ -1371,9 +1371,9 @@
 			}
 		},
 		"flow-parser": {
-			"version": "0.87.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.87.0.tgz",
-			"integrity": "sha512-Yal9dssXDtme83dHDN2Mc+5FmnrTgnG1OS7imCaSjUdMFZJ8ZmvBhdxeSIHSr2GPsSK07PrR3nBdZLRieVeK3Q=="
+			"version": "0.89.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.89.0.tgz",
+			"integrity": "sha512-vC8YuwhAPE+tbkz49DA/TjtFyfhcqM48occMdRQiZ/HL+Wg97IcuebMZUGVB4oBq7aHw0iJJtnvmlnmOQF7Ydg=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -2163,7 +2163,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"string-width": {

--- a/packages/polyserve/package-lock.json
+++ b/packages/polyserve/package-lock.json
@@ -4,6 +4,15 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@sinonjs/commons": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
 			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -14,18 +23,20 @@
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-			"integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+			"integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
 			"dev": true,
 			"requires": {
-				"array-from": "^2.1.1"
+				"@sinonjs/commons": "^1.0.2",
+				"array-from": "^2.1.1",
+				"lodash.get": "^4.4.2"
 			}
 		},
 		"@types/bluebird": {
-			"version": "3.5.24",
-			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.24.tgz",
-			"integrity": "sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg=="
+			"version": "3.5.25",
+			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.25.tgz",
+			"integrity": "sha512-yfhIBix+AIFTmYGtkC0Bi+XGjSkOINykqKvO/Wqdz/DuXlAKK7HmhLAXdPIGsV4xzKcL3ev/zYc4yLNo+OvGaw=="
 		},
 		"@types/body-parser": {
 			"version": "1.17.0",
@@ -114,9 +125,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/opn": {
 			"version": "3.0.28",
@@ -140,9 +151,9 @@
 			"integrity": "sha512-+hHbGi9PAyHVeRdMJN6yNuMWoshJ+7oTqYuhBB1/vHq0Tfu46ucbvgxmhwBfe0GCiJZvCa20VHhHsA0mY5W6hQ=="
 		},
 		"@types/range-parser": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
-			"integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw=="
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
 		},
 		"@types/resolve": {
 			"version": "0.0.6",
@@ -964,9 +975,9 @@
 			}
 		},
 		"just-extend": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
 			"dev": true
 		},
 		"kind-of": {
@@ -1193,25 +1204,25 @@
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
 		},
 		"nise": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
-			"integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+			"integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "3.0.0",
-				"just-extend": "^3.0.0",
+				"@sinonjs/formatio": "^3.1.0",
+				"just-extend": "^4.0.2",
 				"lolex": "^2.3.2",
 				"path-to-regexp": "^1.7.0",
 				"text-encoding": "^0.6.4"
 			},
 			"dependencies": {
 				"@sinonjs/formatio": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-					"integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+					"integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
 					"dev": true,
 					"requires": {
-						"@sinonjs/samsam": "2.1.0"
+						"@sinonjs/samsam": "^2 || ^3"
 					}
 				},
 				"isarray": {

--- a/packages/project-config/package-lock.json
+++ b/packages/project-config/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/parse5": {
 			"version": "2.2.34",
@@ -82,9 +82,9 @@
 			"integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
 		},
 		"colors": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-			"integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
 		},
 		"colorspace": {
 			"version": "1.1.1",

--- a/packages/wct-browser-legacy/package-lock.json
+++ b/packages/wct-browser-legacy/package-lock.json
@@ -353,7 +353,7 @@
 		},
 		"samsam": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+			"resolved": "http://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
 			"integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
 		},
 		"sinon": {

--- a/packages/wct-local/package-lock.json
+++ b/packages/wct-local/package-lock.json
@@ -62,14 +62,14 @@
 			"integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/range-parser": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
-			"integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw=="
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
 		},
 		"@types/serve-static": {
 			"version": "1.13.2",
@@ -598,9 +598,9 @@
 			"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg=="
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
 		},
 		"punycode": {
 			"version": "2.1.1",

--- a/packages/wct-mocha/package-lock.json
+++ b/packages/wct-mocha/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==",
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
 			"dev": true
 		},
 		"@types/socket.io": {

--- a/packages/wct-sauce/package-lock.json
+++ b/packages/wct-sauce/package-lock.json
@@ -402,9 +402,9 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
 		},
 		"punycode": {
 			"version": "2.1.1",

--- a/packages/web-component-tester/package-lock.json
+++ b/packages/web-component-tester/package-lock.json
@@ -122,9 +122,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==",
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
 			"dev": true
 		},
 		"@types/nomnom": {
@@ -150,9 +150,9 @@
 			"dev": true
 		},
 		"@types/range-parser": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
-			"integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
 			"dev": true
 		},
 		"@types/resolve": {
@@ -2148,9 +2148,9 @@
 			}
 		},
 		"fined": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
-			"integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
+			"integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
 			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.2",
@@ -2167,9 +2167,9 @@
 			"dev": true
 		},
 		"flagged-respawn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
-			"integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+			"integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
 			"dev": true
 		},
 		"for-in": {
@@ -2520,9 +2520,9 @@
 			}
 		},
 		"glogg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
+			"integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
 			"dev": true,
 			"requires": {
 				"sparkles": "^1.0.0"
@@ -3624,7 +3624,7 @@
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
 				"kind-of": "^3.0.2"
@@ -3671,7 +3671,7 @@
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
 				"kind-of": "^3.0.2"
@@ -3965,9 +3965,9 @@
 			}
 		},
 		"lazypipe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lazypipe/-/lazypipe-1.0.1.tgz",
-			"integrity": "sha1-FHGu9rN6NA1Rw030Rpnc7wZMGUA=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/lazypipe/-/lazypipe-1.0.2.tgz",
+			"integrity": "sha512-CrU+NYdFHW8ElaeXCWz5IbmetiYVYq1fOCmpdAeZ8L+khbv1e7EnshyjlKqkO+pJbVPrsJQnHbVxEiLujG6qhQ==",
 			"dev": true,
 			"requires": {
 				"stream-combiner": "*"
@@ -4445,7 +4445,7 @@
 		},
 		"multipipe": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"resolved": "http://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
 			"dev": true,
 			"requires": {
@@ -5029,9 +5029,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -5922,7 +5922,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},

--- a/packages/workspaces/package-lock.json
+++ b/packages/workspaces/package-lock.json
@@ -47,9 +47,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-			"integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A=="
+			"version": "10.12.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/rimraf": {
 			"version": "2.0.2",


### PR DESCRIPTION
This seems to make builds go again after `npm run nuke` at least. Let's see if the tests pass...