### PR TITLE
Use the "resolved" exclude path

### DIFF
--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -205,7 +205,7 @@ export class Bundler {
           continue;
         }
         bundle.files.delete(resolvedExclude);
-        const excludeAsFolder = exclude.endsWith('/') ? exclude : exclude + '/';
+        const excludeAsFolder = resolvedExclude.endsWith('/') ? resolvedExclude : resolvedExclude + '/';
         for (const file of bundle.files) {
           if (file.startsWith(excludeAsFolder)) {
             bundle.files.delete(file);


### PR DESCRIPTION
Not sure if this was intentional or I'm just using it wrong but it seems as though paths / dirs specified via the excludes param must be absolute.

The following small change uses the resolved path so that relative paths work.