### PR TITLE
Remove run-sequence; fix ordering of gulp tasks

### DIFF
--- a/packages/web-component-tester/package.json
+++ b/packages/web-component-tester/package.json
@@ -113,7 +113,6 @@
     "gulp-typescript": "^3.1.2",
     "rimraf": "^2.5.4",
     "rollup": "^0.25.1",
-    "run-sequence": "^1.0.1",
     "source-map-support": "^0.5.4",
     "watch": "^0.18.0",
     "wct-local": "^2.1.1",


### PR DESCRIPTION
Sorry for the churn, but it appears that upgrading to gulp 4 broke some of the tasks used in the release process. This PR should fix that and unblock the #820 release process.

Tested gulp tasks locally and they worked.