### PR TITLE
[modulizer] update iron-component-page dependency to 4.0.0

### DIFF
--- a/packages/modulizer/dependency-map.json
+++ b/packages/modulizer/dependency-map.json
@@ -89,7 +89,7 @@
   },
   "iron-component-page": {
     "npm": "@polymer/iron-component-page",
-    "semver": "^3.0.0"
+    "semver": "^4.0.0"
   },
   "iron-jsonp-library": {
     "npm": "@polymer/iron-jsonp-library",

--- a/packages/modulizer/fixtures/packages/iron-icon/expected/package.json
+++ b/packages/modulizer/fixtures/packages/iron-icon/expected/package.json
@@ -17,7 +17,7 @@
     "@polymer/promise-polyfill": "^3.0.0-pre.18",
     "@polymer/iron-iconset": "^3.0.0",
     "@polymer/iron-icons": "^3.0.0",
-    "@polymer/iron-component-page": "^3.0.0",
+    "@polymer/iron-component-page": "^4.0.0",
     "wct-browser-legacy": "^1.0.1",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "@polymer/iron-demo-helpers": "^3.0.0"

--- a/packages/modulizer/fixtures/packages/paper-button/expected/package.json
+++ b/packages/modulizer/fixtures/packages/paper-button/expected/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.2.0",
     "bower": "^1.8.0",
-    "@polymer/iron-component-page": "^3.0.0",
+    "@polymer/iron-component-page": "^4.0.0",
     "@polymer/iron-demo-helpers": "^3.0.0",
     "@polymer/iron-icon": "^3.0.0",
     "@polymer/iron-icons": "^3.0.0",

--- a/packages/modulizer/fixtures/packages/polymer/expected/package.json
+++ b/packages/modulizer/fixtures/packages/polymer/expected/package.json
@@ -39,7 +39,7 @@
     "web-component-tester": "^6.9.0",
     "wct-browser-legacy": "^1.0.1",
     "@polymer/test-fixture": "^4.0.0",
-    "@polymer/iron-component-page": "^3.0.0"
+    "@polymer/iron-component-page": "^4.0.0"
   },
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
Looks like there is no 3.0.0 version for `@polymer/iron-component-page`:

![wtf](https://user-images.githubusercontent.com/10589913/50276175-f4eff100-0449-11e9-8a5b-3d553008b8d8.png)

 So in #703 I have broken modulizer by accident and 0.4.2 is not working 😱

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/tools/825)
<!-- Reviewable:end -->
