### PR TITLE
Update polymer-bundler's package files to eliminate test and config

### DIFF
--- a/packages/bundler/.npmignore
+++ b/packages/bundler/.npmignore
@@ -1,7 +1,10 @@
-node_modules
-# npmignore
-example
-CHANGELOG.md
-README.md
-util
-test
+/.editorconfig
+/.gitattributes
+/.vscode/
+/CHANGELOG.md
+/README.md
+/lib/test/
+/src/
+/test/
+/tsconfig.json
+/tslint.json

--- a/packages/bundler/CHANGELOG.md
+++ b/packages/bundler/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Removed non-essential files from published package, such as tests.
 <!-- Add new, unreleased changes here. -->
 
 ## 4.0.4 - 2018-10-18

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -9,11 +9,6 @@
   "author": "The Polymer Project Authors",
   "main": "lib/bundler.js",
   "typings": "lib/bundler.d.ts",
-  "files": [
-    "LICENSE",
-    "lib/",
-    "custom_typings/"
-  ],
   "bin": {
     "polymer-bundler": "lib/bin/polymer-bundler.js"
   },


### PR DESCRIPTION
- Before: 107 files, 607.9 kB
- After: 62 files, 345.5 kB

List of files no longer npm published after this update:
```
lib/test/bundle-manifest_test.d.ts
lib/test/bundle-manifest_test.js
lib/test/bundle-manifest_test.js.map
lib/test/bundler_test.d.ts
lib/test/bundler_test.js
lib/test/bundler_test.js.map
lib/test/constants_test.d.ts
lib/test/constants_test.js
lib/test/constants_test.js.map
lib/test/deps-index_test.d.ts
lib/test/deps-index_test.js
lib/test/deps-index_test.js.map
lib/test/es6-module-bundler_test.d.ts
lib/test/es6-module-bundler_test.js
lib/test/es6-module-bundler_test.js.map
lib/test/es6-module-bundling-scenarios_test.d.ts
lib/test/es6-module-bundling-scenarios_test.js
lib/test/es6-module-bundling-scenarios_test.js.map
lib/test/html-bundler_test.d.ts
lib/test/html-bundler_test.js
lib/test/html-bundler_test.js.map
lib/test/import-meta-url_test.d.ts
lib/test/import-meta-url_test.js
lib/test/import-meta-url_test.js.map
lib/test/parse5-utils_test.d.ts
lib/test/parse5-utils_test.js
lib/test/parse5-utils_test.js.map
lib/test/polymer-bundler_test.d.ts
lib/test/polymer-bundler_test.js
lib/test/polymer-bundler_test.js.map
lib/test/shards_test.d.ts
lib/test/shards_test.js
lib/test/shards_test.js.map
lib/test/sourcemap_test.d.ts
lib/test/sourcemap_test.js
lib/test/sourcemap_test.js.map
lib/test/test-utils_test.d.ts
lib/test/test-utils_test.js
lib/test/test-utils_test.js.map
lib/test/test-utils.d.ts
lib/test/test-utils.js
lib/test/test-utils.js.map
lib/test/url-utils_test.d.ts
lib/test/url-utils_test.js
lib/test/url-utils_test.js.map
```