### PR TITLE
Fixed issue #3323 where external module script tag content not inlined

### DIFF
--- a/packages/bundler/CHANGELOG.md
+++ b/packages/bundler/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 * Fixed issue where excluded URLs were not resolved by the analyzer when bundler was initialized, resulting in some imports not being treated as excluded.
+* Fixed issue where `<script type="module" src="x.js">` tags would not inline if the referenced script contained no `import` or `export` statements.
 * Removed non-essential files from published package, such as tests.
 <!-- Add new, unreleased changes here. -->
 

--- a/packages/bundler/src/deps-index.ts
+++ b/packages/bundler/src/deps-index.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {Analyzer, Document, Import, ResolvedUrl} from 'polymer-analyzer';
-import {JavaScriptDocument} from 'polymer-analyzer/lib/javascript/javascript-document';
+import {ScriptTagImport} from 'polymer-analyzer/lib/html/html-script-tag';
 
 import {getAnalysisDocument} from './analyzer-utils';
 
@@ -165,8 +165,7 @@ function getDependencies(
         [...document.getFeatures({kind: 'html-script', ...getFeaturesOptions})]
             .filter(
                 (i) => i.document !== undefined &&
-                    (i.document.parsedDocument as JavaScriptDocument)
-                            .parsedAsSourceType === 'module');
+                    i instanceof ScriptTagImport && i.isModule);
     for (const htmlScript of htmlScripts) {
       const relativeUrl =
           analyzer.urlResolver.relative(document.url, htmlScript.document!.url);

--- a/packages/bundler/src/html-bundler.ts
+++ b/packages/bundler/src/html-bundler.ts
@@ -511,7 +511,7 @@ export class HtmlBundler {
       if (!this.assignedBundle.bundle.files.has(resolvedImportUrl)) {
         return;
       }
-      const scriptContent = `import ${JSON.stringify(scriptHref)};`;
+      const scriptContent = `import ${JSON.stringify(resolvedImportUrl)};`;
       dom5.removeAttribute(scriptTag, 'src');
       dom5.setTextContent(scriptTag, encodeString(scriptContent, true));
     }


### PR DESCRIPTION
Old logic tried to check Analyzer's assessment of the imported JavaScriptDocument to find out if it was a module, but that assessment is based on the presence of import/export statements instead of the script tag's `type` attribute.

This fix uses the ScriptTagImport instance's `isModule` attribute now, which is consistent regardless of the JavaScriptDocument properties.