### PR TITLE
[bundler] Tiny updates to code for removing empty bundles and trim redundant exclude processing code.

### DIFF
--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -94,7 +94,8 @@ export class Bundler {
     }
 
     this.excludes = Array.isArray(opts.excludes) ?
-        opts.excludes.map((url) => this.analyzer.resolveUrl(url)!) :
+        opts.excludes.map((url) => this.analyzer.resolveUrl(url)!)
+            .filter((url) => !!url) :
         [];
     this.stripComments = Boolean(opts.stripComments);
     this.enableCssInlining =

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -202,12 +202,8 @@ export class Bundler {
     // Remove excluded files from bundles.
     for (const bundle of bundles) {
       for (const exclude of this.excludes) {
-        const resolvedExclude = this.analyzer.resolveUrl(exclude);
-        if (!resolvedExclude) {
-          continue;
-        }
-        bundle.files.delete(resolvedExclude);
-        const excludeAsFolder = resolvedExclude.endsWith('/') ? resolvedExclude : resolvedExclude + '/';
+        bundle.files.delete(exclude);
+        const excludeAsFolder = exclude.endsWith('/') ? exclude : exclude + '/';
         for (const file of bundle.files) {
           if (file.startsWith(excludeAsFolder)) {
             bundle.files.delete(file);
@@ -218,7 +214,7 @@ export class Bundler {
 
     let b = 0;
     while (b < bundles.length) {
-      if (bundles[b].files.size < 0) {
+      if (bundles[b].files.size <= 0) {
         bundles.splice(b, 1);
         continue;
       }


### PR DESCRIPTION
This was just an opportunistic fix after encountering some redundant stuff in bundler's excludes processing code I found after merging in a community PR.