### PR TITLE
[bundler] Use the analyzer's urlResolver to produce updated relative URLs when rewriting base URLs when inlining html imports.

### DIFF
--- a/packages/bundler/CHANGELOG.md
+++ b/packages/bundler/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 * Fixed issue involving rewriting relative URLs involving crossing `--redirect` boundaries (polymer-bundler CLI feature).
+* Removed a couple of exported functions from `url-utils`: `pathPosixRelative` and `rewriteHrefBaseUrl`.
 <!-- Add new, unreleased changes here. -->
 
 ## 4.0.5 - 2019-01-10

--- a/packages/bundler/CHANGELOG.md
+++ b/packages/bundler/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Fixed issue involving rewriting relative URLs involving crossing `--redirect` boundaries (polymer-bundler CLI feature).
 <!-- Add new, unreleased changes here. -->
 
 ## 4.0.5 - 2019-01-10

--- a/packages/bundler/src/test/cli_test.ts
+++ b/packages/bundler/src/test/cli_test.ts
@@ -208,7 +208,6 @@ suite('polymer-bundler CLI', () => {
           'myapp://app/settings.html'
         ],
       });
-      console.log(stdout);
     });
 
     test('handles excludes which are redirected URLs', async () => {

--- a/packages/bundler/src/test/cli_test.ts
+++ b/packages/bundler/src/test/cli_test.ts
@@ -189,11 +189,15 @@ suite('polymer-bundler CLI', () => {
                        `node ${cliPath} myapp://app/index.html ` +
                            `--redirect="myapp://app/|../url-redirection/" ` +
                            `--redirect="vendor://|../bower_components/" ` +
+                           `--rewrite-urls-in-templates ` +
                            `--manifest-out ${manifestPath}`
                      ].join(' && '))
                          .toString();
       assert.include(stdout, 'This is an external dependency');
       assert.include(stdout, 'id="home-page"');
+      assert.include(
+          stdout,
+          'background-image: url("vendor://external-dependency/bg.png");');
       assert.include(stdout, 'id="settings-page"');
       const manifest = JSON.parse(fs.readFileSync(manifestPath).toString());
       assert.deepEqual(manifest, {
@@ -204,6 +208,7 @@ suite('polymer-bundler CLI', () => {
           'myapp://app/settings.html'
         ],
       });
+      console.log(stdout);
     });
 
     test('handles excludes which are redirected URLs', async () => {
@@ -219,6 +224,7 @@ suite('polymer-bundler CLI', () => {
               .toString();
       assert.include(stdout, 'This is an external dependency');
       assert.include(stdout, 'id="home-page"');
+      assert.include(stdout, 'background-image: url(\'./bg.png\');');
       assert.notInclude(stdout, 'id="settings-page"');
       const manifest = JSON.parse(fs.readFileSync(manifestPath).toString());
       assert.deepEqual(manifest, {

--- a/packages/bundler/src/test/url-utils_test.ts
+++ b/packages/bundler/src/test/url-utils_test.ts
@@ -17,7 +17,6 @@
 
 import * as chai from 'chai';
 
-import {FileRelativeUrl, ResolvedUrl} from 'polymer-analyzer';
 import * as urlUtils from '../url-utils';
 
 
@@ -57,73 +56,6 @@ suite('URL Utils', () => {
       assert.equal(
           urlUtils.stripUrlFileSearchAndHash('relative/path/to/file'),
           'relative/path/to/');
-    });
-  });
-
-  suite('Rewrite imported relative paths', () => {
-    function rewrite(
-        href: string, oldBaseUrl: string, newBaseUrl: string): string {
-      return urlUtils.rewriteHrefBaseUrl(
-          href as FileRelativeUrl,
-          oldBaseUrl as ResolvedUrl,
-          newBaseUrl as ResolvedUrl);
-    }
-
-    test('Some URL forms are not rewritten', () => {
-      const importBase = '/could/be/anything/local/import.html';
-      const mainBase = '/foo/bar/index.html';
-      assert.equal(
-          rewrite('#foo', importBase, mainBase), '#foo', 'just a hash');
-      assert.equal(
-          rewrite('http://foo/biz.jpg', importBase, mainBase),
-          'http://foo/biz.jpg',
-          'remote URLs');
-      assert.equal(
-          rewrite('/a/b/c/', importBase, mainBase),
-          '/a/b/c/',
-          'local absolute href');
-    });
-
-    test('Rewrite Paths when base URL pathnames are absolute paths', () => {
-      const importBase = '/foo/bar/my-element/index.html';
-      const mainBase = '/foo/bar/index.html';
-      assert.equal(
-          rewrite('biz.jpg', importBase, mainBase),
-          'my-element/biz.jpg',
-          'relative');
-      assert.equal(
-          rewrite('/biz.jpg', importBase, mainBase), '/biz.jpg', 'absolute');
-    });
-
-    test('Rewrite paths when base URL pathnames have no leading slash', () => {
-      assert.equal(
-          rewrite('/foo.html', 'bar.html', 'index.html'),
-          '/foo.html',
-          'href has ^/');
-      assert.equal(
-          rewrite('foo.html', '/bar.html', 'index.html'),
-          'foo.html',
-          'only new has ^/');
-      assert.equal(
-          rewrite('foo.html', 'bar.html', '/index.html'),
-          'foo.html',
-          'only old has ^/');
-      assert.equal(
-          rewrite('foo.html', 'bar.html', 'index.html'),
-          'foo.html',
-          'neither has ^/');
-    });
-
-    test('Rewrite paths even when they are outside package root', () => {
-      assert.equal(
-          rewrite('../../foo.html', 'bar.html', 'index.html'),
-          '../../foo.html',
-          'neither has ^/');
-    });
-
-    test('Rewrite paths when new base URL has trailing slash', () => {
-      assert.equal(
-          rewrite('pic.png', 'foo/bar/baz.html', 'foo/'), 'bar/pic.png');
     });
   });
 });

--- a/packages/bundler/src/url-utils.ts
+++ b/packages/bundler/src/url-utils.ts
@@ -111,16 +111,6 @@ export function isTemplatedUrl(href: string): boolean {
 }
 
 /**
- * TODO(usergenic): Remove this hack if nodejs bug is fixed:
- * https://github.com/nodejs/node/issues/13683
- */
-function pathPosixRelative(from: string, to: string): string {
-  const relative = path.posix.relative(from, to);
-  return path === path.win32 ? relative.replace(/\.\.\.\./g, '../..') :
-                               relative;
-}
-
-/**
  * The path library's resolve function drops the trailing slash from the input
  * when returning the result.  This is bad because clients of the function then
  * have to ensure it is reapplied conditionally.  This function resolves the
@@ -134,45 +124,4 @@ export function resolvePath(...segments: string[]): string {
   const lastSegment = segments[segments.length - 1];
   const resolved = path.resolve(...segments);
   return lastSegment.endsWith('/') ? ensureTrailingSlash(resolved) : resolved;
-}
-
-/**
- * Modifies an href by the relative difference between the old base URL and
- * the new base URL.
- */
-export function rewriteHrefBaseUrl<T extends string>(
-    href: T, oldBaseUrl: ResolvedUrl, newBaseUrl: ResolvedUrl): T|
-    FileRelativeUrl {
-  if (isAbsolutePath(href)) {
-    return href;
-  }
-  const relativeUrl = url.resolve(oldBaseUrl, href);
-  const parsedFrom = url.parse(newBaseUrl);
-  const parsedTo = url.parse(relativeUrl);
-  if (parsedFrom.protocol === parsedTo.protocol &&
-      parsedFrom.host === parsedTo.host) {
-    let dirFrom = path.posix.dirname(
-        // Have to append a '_' to the path because path.posix.dirname('foo/')
-        // returns '.' instead of 'foo'.
-        parsedFrom.pathname ? parsedFrom.pathname + '_' : '');
-    let pathTo = parsedTo.pathname || '';
-    if (isAbsolutePath(oldBaseUrl) || isAbsolutePath(newBaseUrl)) {
-      dirFrom = ensureLeadingSlash(dirFrom);
-      pathTo = ensureLeadingSlash(pathTo);
-    }
-    const pathname = pathPosixRelative(dirFrom, pathTo);
-    return url.format({
-      pathname: pathname,
-      search: parsedTo.search,
-      hash: parsedTo.hash,
-    }) as FileRelativeUrl;
-  }
-  return relativeUrl as FileRelativeUrl;
-}
-
-/**
- * Ensures a leading slash on given string.
- */
-function ensureLeadingSlash(path: string): string {
-  return path.startsWith('/') ? path : '/' + path;
 }

--- a/packages/bundler/test/html/bower_components/external-dependency/external-dependency.html
+++ b/packages/bundler/test/html/bower_components/external-dependency/external-dependency.html
@@ -1,3 +1,10 @@
-<div id="external-dependency">
-  This is an external dependency
-</div>
+<dom-module id="external-dependency">
+  <template>
+    <style>
+      #id {
+        background-image: url('./bg.png');
+      }
+    </style>
+    This is an external dependency
+  </template>
+</dom-module>

--- a/packages/bundler/test/html/url-redirection/home.html
+++ b/packages/bundler/test/html/url-redirection/home.html
@@ -1,5 +1,11 @@
 <link rel="import" href="vendor://external-dependency/external-dependency.html">
 
 <dom-module id="home-page">
-  ...
+  <template>
+    <style>
+      #id {
+        background-image: url('./bg.png');
+      }
+    </style>
+  </template>
 </dom-module>


### PR DESCRIPTION
Fixes issue #3329 

Bundler had its own way of rewriting URLs which predated the analyzer's UrlResolver's ability to do so.  By delegating to the analyzer now, we fix an edge case that involved relative URL recalculations for `--redirect` effected URLs with the polymer-bundler CLI.

Changes:
* Fixed issue involving rewriting relative URLs involving crossing `--redirect` boundaries (polymer-bundler CLI feature).
* Removed a couple of exported functions from `url-utils`: `pathPosixRelative` and `rewriteHrefBaseUrl`.