### PR TITLE
build: (RFC) Provide the filePath to babel if it is known

### DIFF
--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -283,7 +283,7 @@ export function jsTransform(js: string, options: JsTransformOptions): string {
     }
 
     if (doBabelTransform) {
-      const result = babelCore.transformFromAst(ast, js, {presets, plugins});
+      const result = babelCore.transformFromAst(ast, js, {filename: options.filePath, presets, plugins});
       if (result.code === undefined) {
         throw new Error(
             'Babel transform failed: resulting code was undefined.');

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -3,6 +3,14 @@
     "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
+    "types": [
+        "chai",
+        "chai-as-promised",
+        "chai-subset",
+        "mocha",
+        "node",
+        "sinon-chai"
+    ],
 
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
This has a side-effect of making babel load the relevant configuration files, which in turn allows
one to configure babel -- for example to set 'sourceMaps' to 'inline'.

---
I was trying really hard to debug our Polymer 3.x application, but essentially the development setup of using `polymer serve` isn't able to produce source maps. I noticed that when stepping through the code that `polymer serve` internally uses @babel/core though, which can produce suitable source maps.

Simply creating a `.babelrc` with `{"sourceMaps": "inline"}` didn't work though, it seems this got completely ignored.

I then applied brute-force and modified https://github.com/Polymer/tools/blob/d626bc73df2e3efcdbe8be8c6326b3608b6309bd/packages/build/src/js-transform.ts#L277 with `sourceMaps: "inline"`. This produced source maps, but without file name information that was still useless. The next attempt was to use `filename: options.filePath`, which started to produce the correct source maps. But, at that point something else happens: Babel now started reading the `.babelrc` file as well (and then crashed, because I left garbage in it from the first test!).

So, this PR proposes a very non-intrusive thing, that allows developers to enable source maps, as well as likely a lot of more options for babel in the future: when transforming JS code provide the original filename to babel, and let babel handle the rest.

I'm not sure whether this is acceptable as-is, but given the potential I think it makes sense to discuss it :)
