### PR TITLE
Add additional hostname and port for running tests from docker

### DIFF
--- a/packages/web-component-tester/CHANGELOG.md
+++ b/packages/web-component-tester/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 <!-- Add new, unreleased items here. -->
+* Added additional hostname and port for running tests from another network like a docker network
 
 ## 6.9.2 - 2018-12-23
 * Fix gulpfile to actually build browser.js.

--- a/packages/web-component-tester/runner/config.ts
+++ b/packages/web-component-tester/runner/config.ts
@@ -60,6 +60,17 @@ export interface Config {
     // The hostname used when generating URLs for the webdriver client.
     hostname: string;
 
+    // An additional hostname for calling the tests. By default 'hostname' is used 
+    // to format the tests url. If the tests are called from an external network
+    // an addition hostname can be defined for running tests. For example calling tests 
+    // from selenium running in docker testsHostname can be defined as 'host.docker.internal'
+    testsHostname: string,
+  
+    // An additional port for calling the tests. By default 'port' is used 
+    // to format the tests url. If the tests are called from an external network
+    // an addition port can be defined for running tests.
+    testsPort: number,
+    
     _generatedIndexContent?: string;
     _servers?: {variant: string, url: string}[];
   };
@@ -227,6 +238,17 @@ export function defaults(): Config {
       // runtime if none is provided.
       port: undefined,
       hostname: 'localhost',
+      
+      // An additional hostname for calling the tests. By default 'hostname' is used 
+      // to format the tests url. If the tests are called from an external network
+      // an addition hostname can be defined for running tests. For example calling tests 
+      // from selenium running in docker testsHostname can be defined as 'host.docker.internal'
+      testsHostname: undefined,
+  
+      // An additional port for calling the tests. By default 'port' is used 
+      // to format the tests url. If the tests are called from an external network
+      // an addition port can be defined for running tests.
+      testsPort: undefined      
     },
     // The name of the NPM package that is vending wct's browser.js will be
     // determined automatically if no name is specified.
@@ -320,6 +342,14 @@ const ARG_CONFIG = {
     full: 'webserver-hostname',
     hidden: true,
   },
+  'webserver.testsPort': {
+    full: 'webserver-tests-port',
+    hidden: true,
+  },
+  'webserver.testsHostname': {
+    full: 'webserver-tests-hostname',
+    hidden: true,
+  },  
   // Managed by supports-color; let's not freak out if we see it.
   color: {flag: true},
 

--- a/packages/web-component-tester/runner/webserver.ts
+++ b/packages/web-component-tester/runner/webserver.ts
@@ -323,11 +323,13 @@ Expected to find a ${mdFilenames.join(' or ')} at: ${pathToLocalWct}/
 
     options.webserver._servers = servers.map((s) => {
       const address = s.server.address();
-      const port = typeof address === 'string' ? '' : `:${address.port}`;
-      const hostname = s.options.hostname;
+      const serverPort = typeof address === 'string' ? '' : `:${address.port}`;
+      const port = options.webserver.testsPort ? options.webserver.testsPort : serverPort;
+      const hostname = options.webserver.testsHostname ? options.webserver.testsHostname :  s.options.hostname;
       const url = `http://${hostname}${port}${pathToGeneratedIndex}`;
       return {url, variant: s.kind === 'mainline' ? '' : s.variantName};
     });
+
 
     // TODO(rictic): re-enable this stuff. need to either move this code
     // into polyserve or let the polyserve API expose this stuff.


### PR DESCRIPTION
When running tests from for example selenium in a docker container selenium need to call the tests on the host. For mac and windows the way to call the host is by using the hostname 'host.docker.internal'.

Currently the tests are called on the same hostname and port number as the configured webserver. With two extra properties on the webserver 'testsHostname' and 'testsPort' the host and port on which the tests are called can be configure separately from the hostname and port of the webserver.

By default the hostname and port of the webserver are used to call the tests. But for cases like calling tests from a docker container or maybe through a proxy these extra configuration properties are added.