### PR TITLE
Updated html-bundler to emit the protocols of URLs when originally given with a protocol (don't relativize them).

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ branches:
     - master
 
 install:
+  - choco install googlechrome
   - ps: Install-Product node $env:nodejs_version
   - npm i -g npm@latest
   - npm ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,6 @@ install:
   - npm ci
   - npm run bootstrap
   - npm run build
-  # NOTE(keanulee): Following needed until Chrome in AppVeyor images are
-  # updated - see https://github.com/appveyor/ci/issues/2772.
-  - choco install googlechrome
 
 test_script:
   - node --version

--- a/packages/bundler/CHANGELOG.md
+++ b/packages/bundler/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
+* URLs in bundled output will now honor developer's intent to render URLs with protocols instead of as relative URLs where applicable.
 <!-- Add new, unreleased changes here. -->
 
 ## 4.0.6 - 2019-01-18

--- a/packages/bundler/src/html-bundler.ts
+++ b/packages/bundler/src/html-bundler.ts
@@ -16,6 +16,8 @@ import * as clone from 'clone';
 import * as dom5 from 'dom5';
 import {ASTNode, parseFragment, serialize, treeAdapters} from 'parse5';
 import {Document, FileRelativeUrl, ParsedHtmlDocument, ResolvedUrl} from 'polymer-analyzer';
+import {parse as parseUrl} from 'url';
+import {isNull} from 'util';
 
 import {assertIsHtmlDocument, assertIsJsDocument, getAnalysisDocument} from './analyzer-utils';
 import {serialize as serializeEs6} from './babel-utils';
@@ -899,9 +901,20 @@ export class HtmlBundler {
       |FileRelativeUrl {
     const resolvedHref = this.bundler.analyzer.urlResolver.resolve(
         oldBaseUrl, href as string as FileRelativeUrl);
+    // If we can't resolve the href, we need to return it as-is, since we can't
+    // relativize or rewrite it.
     if (typeof resolvedHref === 'undefined') {
       return href;
     }
+
+    const parsedHref = parseUrl(href);
+    // If the href was initially expressed with a protocol in the URL, we should
+    // not attempt to relativize or rewrite it.
+    if (typeof parsedHref.protocol === 'string') {
+      return href;
+    }
+
+    // Return a new relative form of the given URL.
     return this.bundler.analyzer.urlResolver.relative(newBaseUrl, resolvedHref);
   }
 

--- a/packages/bundler/src/html-bundler.ts
+++ b/packages/bundler/src/html-bundler.ts
@@ -17,7 +17,6 @@ import * as dom5 from 'dom5';
 import {ASTNode, parseFragment, serialize, treeAdapters} from 'parse5';
 import {Document, FileRelativeUrl, ParsedHtmlDocument, ResolvedUrl} from 'polymer-analyzer';
 import {parse as parseUrl} from 'url';
-import {isNull} from 'util';
 
 import {assertIsHtmlDocument, assertIsJsDocument, getAnalysisDocument} from './analyzer-utils';
 import {serialize as serializeEs6} from './babel-utils';

--- a/packages/bundler/src/test/cli_test.ts
+++ b/packages/bundler/src/test/cli_test.ts
@@ -197,7 +197,10 @@ suite('polymer-bundler CLI', () => {
       assert.include(stdout, 'id="home-page"');
       assert.include(
           stdout,
-          'background-image: url("vendor://external-dependency/bg.png");');
+          'background-image: url("vendor://external-dependency/images/external-bg.png");');
+      assert.include(stdout, 'background-image: url("images/gear.png");');
+      assert.include(
+          stdout, 'background-image: url("myapp://images/wrench.png");');
       assert.include(stdout, 'id="settings-page"');
       const manifest = JSON.parse(fs.readFileSync(manifestPath).toString());
       assert.deepEqual(manifest, {
@@ -223,7 +226,8 @@ suite('polymer-bundler CLI', () => {
               .toString();
       assert.include(stdout, 'This is an external dependency');
       assert.include(stdout, 'id="home-page"');
-      assert.include(stdout, 'background-image: url(\'./bg.png\');');
+      assert.include(
+          stdout, 'background-image: url(\'./images/external-bg.png\');');
       assert.notInclude(stdout, 'id="settings-page"');
       const manifest = JSON.parse(fs.readFileSync(manifestPath).toString());
       assert.deepEqual(manifest, {

--- a/packages/bundler/test/html/bower_components/external-dependency/external-dependency.html
+++ b/packages/bundler/test/html/bower_components/external-dependency/external-dependency.html
@@ -2,7 +2,7 @@
   <template>
     <style>
       #id {
-        background-image: url('./bg.png');
+        background-image: url('./images/external-bg.png');
       }
     </style>
     This is an external dependency

--- a/packages/bundler/test/html/url-redirection/home.html
+++ b/packages/bundler/test/html/url-redirection/home.html
@@ -4,7 +4,7 @@
   <template>
     <style>
       #id {
-        background-image: url('./bg.png');
+        background-image: url('./images/bg.png');
       }
     </style>
   </template>

--- a/packages/bundler/test/html/url-redirection/settings.html
+++ b/packages/bundler/test/html/url-redirection/settings.html
@@ -1,5 +1,15 @@
 <link rel="import" href="vendor://external-dependency/external-dependency.html">
 
 <dom-module id="settings-page">
-  <template>settings page!</template>
+  <template>
+    <style>
+      #id {
+        background-image: url('./images/gear.png');
+      }
+      #id2 {
+        background-image: url('myapp://images/wrench.png');
+      }
+    </style>
+    settings page!
+  </template>
 </dom-module>


### PR DESCRIPTION
In bundler 3.x if a URL was given (usually in the redirected URL case) like `chrome://` etc the rewriting logic would not convert it to a relative path, but after converting to the analyzer's url resolvers to do the rewriting of URLs this behavior regressed though it was unknown until recently. Added code to ensure URLs containing protocol portion were not rewritten to relative paths in the bundled output.