### PR TITLE
Bump bower to 1.8.8 to avoid security issues

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "@types/vinyl": "^2.0.0",
     "@types/vinyl-fs": "0.0.28",
     "@types/yeoman-generator": "^2.0.3",
-    "bower": "1.8.2",
+    "bower": "1.8.8",
     "bower-json": "^0.8.1",
     "bower-logger": "^0.2.2",
     "chalk": "^1.1.3",


### PR DESCRIPTION
I get following message when installing polymer-cli:

bower@1.8.2: This Bower version has SECURITY BUG THAT ALLOWS TO WRITE TO ARBITRARY FILE ON YOUR COMPUTER when you install malicious package. Please upgrade Bower to at least version 1.8.8 if you don't want to get hacked. More info: https://snyk.io/blog/severe-security-vulnerability-in-bowers-zip-archive-extraction/