### PR TITLE
Absolute urls should remain absolute

### DIFF
--- a/packages/bundler/CHANGELOG.md
+++ b/packages/bundler/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
+* Fixed issue involving absolute paths being rewritten as relative paths when bundled https://github.com/Polymer/tools/issues/3348.
 <!-- Add new, unreleased changes here. -->
 
 ## 4.0.7 - 2019-01-31

--- a/packages/bundler/src/html-bundler.ts
+++ b/packages/bundler/src/html-bundler.ts
@@ -30,7 +30,7 @@ import {findAncestor, insertAfter, insertAllBefore, inSourceOrder, isSameNode, p
 import {addOrUpdateSourcemapComment} from './source-map';
 import {updateSourcemapLocations} from './source-map';
 import encodeString from './third_party/UglifyJS2/encode-string';
-import {ensureTrailingSlash, getFileExtension, isTemplatedUrl, stripUrlFileSearchAndHash} from './url-utils';
+import {ensureTrailingSlash, getFileExtension, isAbsolutePath, isTemplatedUrl, stripUrlFileSearchAndHash} from './url-utils';
 import {find, rewriteObject} from './utils';
 
 /**
@@ -907,9 +907,16 @@ export class HtmlBundler {
     }
 
     const parsedHref = parseUrl(href);
+
     // If the href was initially expressed with a protocol in the URL, we should
     // not attempt to relativize or rewrite it.
     if (typeof parsedHref.protocol === 'string') {
+      return href;
+    }
+
+    // If the href was originally expressed as an absolute path, we should not
+    // attempt to relativize it.
+    if (parsedHref.pathname && isAbsolutePath(parsedHref.pathname)) {
       return href;
     }
 

--- a/packages/bundler/src/test/html-bundler_test.ts
+++ b/packages/bundler/src/test/html-bundler_test.ts
@@ -39,7 +39,7 @@ suite('HtmlBundler', () => {
       `,
       'module.js': heredoc`
         console.log('import/export-free code');
-      `
+      `,
     });
     const bundler = new Bundler({analyzer});
     const entrypointUrl = analyzer.resolveUrl('entrypoint.html')!;
@@ -81,7 +81,7 @@ suite('HtmlBundler', () => {
     const analyzer = new Analyzer({
       urlResolver: new FsUrlResolver(root),
       urlLoader: new FsUrlLoader(root),
-      moduleResolution: 'node'
+      moduleResolution: 'node',
     });
     const bundler = new Bundler({analyzer});
     const importUsingNodeModuleResolutionUrl =
@@ -237,6 +237,8 @@ suite('HtmlBundler', () => {
             </template>
             <script>Polymer({is: "my-element"})</script>
             </dom-module>
+            <a href="/absolute/path">Absolute Path</a>
+            <a href="relative/path">Relative Path</a>
             <template is="dom-bind">
             <style>.outside-dom-module { background-image: url(outside-dom-module.png); }</style>
             </template>
@@ -253,6 +255,8 @@ suite('HtmlBundler', () => {
             </template>
             <script>Polymer({is: "my-element"})</script>
             </dom-module>
+            <a href="/absolute/path">Absolute Path</a>
+            <a href="my-element/relative/path">Relative Path</a>
             <template is="dom-bind">
             <style>.outside-dom-module { background-image: url(outside-dom-module.png); }</style>
             </template>

--- a/packages/bundler/src/test/html-bundler_test.ts
+++ b/packages/bundler/src/test/html-bundler_test.ts
@@ -225,6 +225,24 @@ suite('HtmlBundler', () => {
       });
 
       suite('Resolve Paths', () => {
+        test('rewrite relative paths, not absolute paths', () => {
+          const html = `
+            <a href="/absolute/path">Absolute Path</a>
+            <a href="relative/path">Relative Path</a>
+          `;
+
+          const expected = `
+            <a href="/absolute/path">Absolute Path</a>
+            <a href="my-element/relative/path">Relative Path</a>
+          `;
+
+          const ast = parse(html);
+          htmlBundler['_rewriteAstBaseUrl'](ast, importDocUrl, mainDocUrl);
+
+          const actual = parse5.serialize(ast);
+          assert.deepEqual(stripSpace(actual), stripSpace(expected));
+        });
+
         test('excluding template elements', () => {
           const html = `
             <link rel="import" href="../polymer/polymer.html">
@@ -237,8 +255,6 @@ suite('HtmlBundler', () => {
             </template>
             <script>Polymer({is: "my-element"})</script>
             </dom-module>
-            <a href="/absolute/path">Absolute Path</a>
-            <a href="relative/path">Relative Path</a>
             <template is="dom-bind">
             <style>.outside-dom-module { background-image: url(outside-dom-module.png); }</style>
             </template>
@@ -255,8 +271,6 @@ suite('HtmlBundler', () => {
             </template>
             <script>Polymer({is: "my-element"})</script>
             </dom-module>
-            <a href="/absolute/path">Absolute Path</a>
-            <a href="my-element/relative/path">Relative Path</a>
             <template is="dom-bind">
             <style>.outside-dom-module { background-image: url(outside-dom-module.png); }</style>
             </template>


### PR DESCRIPTION
Preserves the absoluteness of URLs in elements when bundling, where they were all being relativized and that's not fair.