### PR TITLE
Fix Firefox support on iOS

### DIFF
--- a/packages/browser-capabilities/src/browser-capabilities.ts
+++ b/packages/browser-capabilities/src/browser-capabilities.ts
@@ -131,8 +131,8 @@ export function browserCapabilities(userAgent: string): Set<BrowserCapability> {
   const ua = new UAParser(userAgent);
   const capabilities = new Set<BrowserCapability>();
   let browserName = ua.getBrowser().name || '';
-  if (browserName === 'Chrome' && ua.getOS().name === 'iOS') {
-    // Chrome on iOS is really Safari.
+  if (ua.getOS().name === 'iOS') {
+    // iOS is really Safari.
     browserName = 'Mobile Safari';
   }
   const predicates = browserPredicates[browserName] || {};


### PR DESCRIPTION
Currently prpl-server sends the wrong build to Firefox on iOS. This patch changes the browser detection so that all browsers on iOS are treated as Mobile Safari, not just Chrome.