### PR TITLE
[polymer-build] #3402 resolveBareSpecifiers must be a Program

### DIFF
--- a/packages/build/src/babel-plugin-bare-specifiers.ts
+++ b/packages/build/src/babel-plugin-bare-specifiers.ts
@@ -14,7 +14,7 @@
 
 import dynamicImportSyntax from '@babel/plugin-syntax-dynamic-import';
 import {NodePath} from '@babel/traverse';
-import {CallExpression, ExportAllDeclaration, ExportNamedDeclaration, ImportDeclaration} from 'babel-types';
+import {CallExpression, ExportAllDeclaration, ExportNamedDeclaration, ImportDeclaration, Program} from 'babel-types';
 import {resolve} from 'polymer-analyzer/lib/javascript/resolve-specifier-node';
 
 const isPathSpecifier = (s: string) => /^\.{0,2}\//.test(s);

--- a/packages/build/src/babel-plugin-bare-specifiers.ts
+++ b/packages/build/src/babel-plugin-bare-specifiers.ts
@@ -35,23 +35,26 @@ export const resolveBareSpecifiers = (
   inherits: dynamicImportSyntax,
 
   visitor: {
-    CallExpression(path: NodePath<CallExpression>) {
-      const node = path.node;
-      if (node.callee.type as string === 'Import') {
-        const specifierArg = node.arguments[0];
-        if (specifierArg.type !== 'StringLiteral') {
-          // Should never happen
-          return;
+    Program(path: NodePath<Program>) {
+      path.traverse({
+        CallExpression(path: NodePath<CallExpression>) {
+          if (path.node.callee.type as string === 'Import') {
+            const specifierArg = path.node.arguments[0];
+            if (specifierArg.type !== 'StringLiteral') {
+              // Should never happen
+              return;
+            }
+            const specifier = specifierArg.value;
+            specifierArg.value = maybeResolve(
+              specifier,
+              filePath,
+              isComponentRequest,
+              packageName,
+              componentDir,
+              rootDir);
+          }
         }
-        const specifier = specifierArg.value;
-        specifierArg.value = maybeResolve(
-            specifier,
-            filePath,
-            isComponentRequest,
-            packageName,
-            componentDir,
-            rootDir);
-      }
+      });
     },
     'ImportDeclaration|ExportNamedDeclaration|ExportAllDeclaration'(
         path: NodePath<HasSpecifier>) {


### PR DESCRIPTION
Babel's life cycle appears to make the following combination not possible with the current configuration of polymer's build process.
- `"moduleResolution": "node"`
- `"transformModulesToAmd": true`
- `"bundle": false,`

## What ends up happening now:
- Babel processes the tree and transforms `ast` for AMD compilation and/or ES5 syntax in the Program level callback
- This happens PRIOR to processing `babel-plugin-bare-specifiers` `resolveBareSpecifiers` export because it is running in a `CallExpression` which fires later
- The `CallExpression` seeks out things marked 'Import' but because the compiling has already happened, it can't find everything
- Dynamic imports get borked as a result, not being correctly resolved to their actual location in node_modules because it doesn't process it as an Object tree but instead as compiled code.

## This change fixes this by..
This shifts it to process at the Program level and traverse the path to execute `CallExpression`'s. This should ensure that the timing is correct so that the Objects can be resolved to their correct node_modules / relative location, prior to the ES5 / AMD transformations processing the tree into text.

## Gains via this PR
- Users will be able to user polymer.json as expected
- Polymer build will correctly resolve dynamic imports regardless of compiling or module resolution used

## Outstanding issues
#3403 is most likely related to this but I haven't been able to see what the issue is as to why this wouldn't overlap.