### PR TITLE
Resolve bare specifiers PRIOR to compilation.

### DIFF
--- a/packages/build/src/babel-plugin-dynamic-import-amd.ts
+++ b/packages/build/src/babel-plugin-dynamic-import-amd.ts
@@ -71,9 +71,9 @@ export const dynamicImportAmd = {
           // assume is running next will rewrite `require` from a function to a
           // module object with the function at `default`.
           importPath.replaceWith(ast`(
-          new Promise((res, rej) => ${requireId}.default([${
+            new Promise((res, rej) => ${requireId}.default([${
               specifier}], res, rej))
-        )`);
+          )`);
         }
       },
     },

--- a/packages/build/src/babel-plugin-dynamic-import-amd.ts
+++ b/packages/build/src/babel-plugin-dynamic-import-amd.ts
@@ -26,54 +26,56 @@ export const dynamicImportAmd = {
   inherits: dyanamicImportSyntax,
 
   visitor: {
-    Program(path: NodePath<Program>) {
-      // We transform dynamic import() into a Promise whose initializer calls
-      // require(). We must use the "local" require - the one provided by the
-      // AMD loaded when a module explicitly depends on the "require" module ID.
-      // To get the emitted define() call to depend on "require", we inject an
-      // import of a module called "require".
+    Program: {
+      exit(path: NodePath<Program>) {
+        // We transform dynamic import() into a Promise whose initializer calls
+        // require(). We must use the "local" require - the one provided by the
+        // AMD loaded when a module explicitly depends on the "require" module
+        // ID. To get the emitted define() call to depend on "require", we
+        // inject an import of a module called "require".
 
-      // Collect all the NodePaths to dynamic import() expressions
-      // and all the identifiers in scope for them.
-      const identifiers = new Set<string>();
-      const dynamicImports: NodePath<CallExpression>[] = [];
-      path.traverse({
-        CallExpression(path: NodePath<CallExpression>) {
-          if (path.node.callee.type as string === 'Import') {
-            dynamicImports.push(path);
-            const bindings = path.scope.getAllBindings();
-            for (const name of Object.keys(bindings)) {
-              identifiers.add(name);
+        // Collect all the NodePaths to dynamic import() expressions
+        // and all the identifiers in scope for them.
+        const identifiers = new Set<string>();
+        const dynamicImports: NodePath<CallExpression>[] = [];
+        path.traverse({
+          CallExpression(path: NodePath<CallExpression>) {
+            if (path.node.callee.type as string === 'Import') {
+              dynamicImports.push(path);
+              const bindings = path.scope.getAllBindings();
+              for (const name of Object.keys(bindings)) {
+                identifiers.add(name);
+              }
             }
           }
+        });
+
+        if (dynamicImports.length === 0) {
+          return;
         }
-      });
 
-      if (dynamicImports.length === 0) {
-        return;
-      }
+        // Choose a unique name to import "require" as.
+        let requireId: Identifier|undefined = undefined;
+        do {
+          requireId = path.scope.generateUidIdentifier('require');
+        } while (identifiers.has(requireId.name));
 
-      // Choose a unique name to import "require" as.
-      let requireId: Identifier|undefined = undefined;
-      do {
-        requireId = path.scope.generateUidIdentifier('require');
-      } while (identifiers.has(requireId.name));
+        // Inject the import of "require"
+        const statements = path.node.body as Statement[];
+        statements.unshift(ast`import * as ${requireId} from 'require';`);
 
-      // Inject the import of "require"
-      const statements = path.node.body as Statement[];
-      statements.unshift(ast`import * as ${requireId} from 'require';`);
-
-      // Transform the dynamic import callsites
-      for (const importPath of dynamicImports) {
-        const specifier = importPath.node.arguments[0];
-        // Call as `require.default` because the AMD transformer that we assume
-        // is running next will rewrite `require` from a function to a module
-        // object with the function at `default`.
-        importPath.replaceWith(ast`(
+        // Transform the dynamic import callsites
+        for (const importPath of dynamicImports) {
+          const specifier = importPath.node.arguments[0];
+          // Call as `require.default` because the AMD transformer that we
+          // assume is running next will rewrite `require` from a function to a
+          // module object with the function at `default`.
+          importPath.replaceWith(ast`(
           new Promise((res, rej) => ${requireId}.default([${
-            specifier}], res, rej))
+              specifier}], res, rej))
         )`);
-      }
+        }
+      },
     },
   },
 };

--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -201,6 +201,19 @@ export function jsTransform(js: string, options: JsTransformOptions): string {
     // Minify last, so push first.
     presets.push(babelPresetMinify);
   }
+  if (options.moduleResolution === 'node') {
+    if (!options.filePath) {
+      throw new Error(
+          'Cannot perform node module resolution without filePath.');
+    }
+    doBabelTransform = true;
+    plugins.push(resolveBareSpecifiers(
+        options.filePath,
+        !!options.isComponentRequest,
+        options.packageName,
+        options.componentDir,
+        options.rootDir));
+  }
   if (options.compile === true || options.compile === 'es5') {
     doBabelTransform = true;
     plugins.push(...babelTransformEs2015);
@@ -219,19 +232,6 @@ export function jsTransform(js: string, options: JsTransformOptions): string {
   } else if (options.compile === 'es2017') {
     doBabelTransform = true;
     plugins.push(...babelTransformEs2018);
-  }
-  if (options.moduleResolution === 'node') {
-    if (!options.filePath) {
-      throw new Error(
-          'Cannot perform node module resolution without filePath.');
-    }
-    doBabelTransform = true;
-    plugins.push(resolveBareSpecifiers(
-        options.filePath,
-        !!options.isComponentRequest,
-        options.packageName,
-        options.componentDir,
-        options.rootDir));
   }
 
   // When the AMD option is "auto", these options will change based on whether


### PR DESCRIPTION
There's an issue about specifiers NOT being transformed when the AMD transform is involved as reported in https://github.com/Polymer/tools/issues/3402 https://github.com/Polymer/tools/issues/3403

This PR is a possible alternative to https://github.com/Polymer/tools/pull/3404, inferring from that work that the ordering of babel transform plugins was at issue.  This simply moves specifier resolution to the beginning of the js-transform sequence.