### PR TITLE
add modules support for FF67 in polyserve

### DIFF
--- a/packages/browser-capabilities/CHANGELOG.md
+++ b/packages/browser-capabilities/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
+* Upated Firefox 67 support for modules (specifically because of dynamic import)
 
 ## [1.1.3] - 2018-11-15
 * Updated Firefox 63 support for push.

--- a/packages/browser-capabilities/CHANGELOG.md
+++ b/packages/browser-capabilities/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-<!-- ## Unreleased -->
+## Unreleased
 <!-- Add new, unreleased changes here. -->
 * Upated Firefox 67 support for modules (specifically because of dynamic import)
 

--- a/packages/browser-capabilities/CHANGELOG.md
+++ b/packages/browser-capabilities/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
-* Upated Firefox 67 support for modules (specifically because of dynamic import)
+* Updated Firefox 67 support for modules (specifically because of dynamic import)
 
 ## [1.1.3] - 2018-11-15
 * Updated Firefox 63 support for push.

--- a/packages/browser-capabilities/src/browser-capabilities.ts
+++ b/packages/browser-capabilities/src/browser-capabilities.ts
@@ -120,7 +120,7 @@ const browserPredicates: {
     // Firefox bug - https://bugzilla.mozilla.org/show_bug.cgi?id=1409570
     push: since(63),
     serviceworker: since(44),
-    modules: () => false,
+    modules: since(67),
   },
 };
 


### PR DESCRIPTION
FF 67 (released yesterday) now supports dynamic imports (also confirmed locally):

https://caniuse.com/#search=dynamic%20import

Related: #3403 (but does not fix)