### PR TITLE
trasform using { retainLines: true } to ensure correct working of sou…

### DIFF
--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -283,7 +283,7 @@ export function jsTransform(js: string, options: JsTransformOptions): string {
     }
 
     if (doBabelTransform) {
-      const result = babelCore.transformFromAst(ast, js, {presets, plugins});
+      const result = babelCore.transformFromAst(ast, js, {presets, plugins, retainLines: true});
       if (result.code === undefined) {
         throw new Error(
             'Babel transform failed: resulting code was undefined.');


### PR DESCRIPTION
…rce mapping

I am using polymer cli to host and serve static precompiles typescript files, without this configuration, source mapping (in .js.map file) is easily broken because polymer adds and removes empty lines. In fact most of my files becomes undebuggable because of that. The proposed change solves this problem, at least for me.
Alternatively, Polymer could serve a 'transformed' version of the .js.map file as well, but that seems much harder to do.