### PR TITLE
[wct-local] Update geckodriver to 0.24.0 (for non-windows)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
   - node_js: '8'
     addons:
       chrome: stable
-      firefox: 66
+      firefox: '66.0'
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 
   - node_js: '10'
     addons:
       chrome: stable
-      firefox: 66
+      firefox: '66.0'
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
   - node_js: '8'
     addons:
       chrome: stable
-      firefox: latest
+      firefox: 66
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 
   - node_js: '10'
     addons:
       chrome: stable
-      firefox: latest
+      firefox: 66
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
   - node_js: '8'
     addons:
       chrome: stable
-      firefox: '65.0'
+      firefox: '66.0'
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 
   - node_js: '10'
     addons:
       chrome: stable
-      firefox: '65.0'
+      firefox: '66.0'
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
   - node_js: '8'
     addons:
       chrome: stable
-      firefox: '66.0'
+      firefox: '65.0'
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 
   - node_js: '10'
     addons:
       chrome: stable
-      firefox: '66.0'
+      firefox: '65.0'
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 

--- a/packages/wct-local/CHANGELOG.md
+++ b/packages/wct-local/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- Updated geckodriver to version 0.24.0
 <!-- Add unreleased changes here. -->
 
 ## [v2.1.3] - 2018-10-24
@@ -28,7 +29,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update to cleankill@^2.0.0. This fixes an issue in WCT v6.4.0 where the tests would finish and the browsers would close, but the WCT process would not end. This was because the versions of cleankill diverged and so they used different event queues for handling cleanup.
 
 ## [v2.0.15] - 2017-05-09
-
 - Update launchpad@v0.6.0
 
 

--- a/packages/wct-local/selenium-overrides.js
+++ b/packages/wct-local/selenium-overrides.js
@@ -14,7 +14,7 @@ module.exports = {
         'baseURL': 'https://selenium-release.storage.googleapis.com'
       },
       'firefox': {
-        'version': '0.24.0', // process.platform === 'win32' ? '0.24.0' : '0.24.0',
+        'version': process.platform === 'win32' ? '0.20.1' : '0.20.1',
         'arch': process.arch,
         'baseURL': 'https://github.com/mozilla/geckodriver/releases/download'
       },

--- a/packages/wct-local/selenium-overrides.js
+++ b/packages/wct-local/selenium-overrides.js
@@ -14,7 +14,7 @@ module.exports = {
         'baseURL': 'https://selenium-release.storage.googleapis.com'
       },
       'firefox': {
-        'version': process.platform === 'win32' ? '0.20.1' : '0.20.1',
+        'version': process.platform === 'win32' ? '0.20.1' : '0.24.0',
         'arch': process.arch,
         'baseURL': 'https://github.com/mozilla/geckodriver/releases/download'
       },

--- a/packages/wct-local/selenium-overrides.js
+++ b/packages/wct-local/selenium-overrides.js
@@ -21,4 +21,4 @@ module.exports = {
       'edge': {'version': '17134'}
     }
   }
-}
+};

--- a/packages/wct-local/selenium-overrides.js
+++ b/packages/wct-local/selenium-overrides.js
@@ -14,7 +14,7 @@ module.exports = {
         'baseURL': 'https://selenium-release.storage.googleapis.com'
       },
       'firefox': {
-        'version': process.platform === '0.24.0', // 'win32' ? '0.24.0' : '0.24.0',
+        'version': '0.24.0', // process.platform === 'win32' ? '0.24.0' : '0.24.0',
         'arch': process.arch,
         'baseURL': 'https://github.com/mozilla/geckodriver/releases/download'
       },

--- a/packages/wct-local/selenium-overrides.js
+++ b/packages/wct-local/selenium-overrides.js
@@ -14,11 +14,11 @@ module.exports = {
         'baseURL': 'https://selenium-release.storage.googleapis.com'
       },
       'firefox': {
-        'version': process.platform === 'win32' ? '0.20.1' : '0.23.0',
+        'version': process.platform === '0.24.0', // 'win32' ? '0.24.0' : '0.24.0',
         'arch': process.arch,
         'baseURL': 'https://github.com/mozilla/geckodriver/releases/download'
       },
       'edge': {'version': '17134'}
     }
   }
-};
+}


### PR DESCRIPTION
I'm having issues with FF67 on travis and am hoping latest geckdriver will solve.  In the meantime, testing out latest geckodriver on windows too.