### PR TITLE
Pin Firefox to version 66.0 on Travis because of geckodriver+67.0 bug.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
   - node_js: '8'
     addons:
       chrome: stable
-      firefox: latest
+      firefox: '66.0'
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 
   - node_js: '10'
     addons:
       chrome: stable
-      firefox: latest
+      firefox: '66.0'
     env:
     - TEST_COMMAND="xvfb-run npm run test:integration"
 


### PR DESCRIPTION
https://github.com/mozilla/geckodriver/issues/1560

The bug linked to above indicates issue with v66+ but v66 is okay for us, v67 broken, so pinning to v66.