### PR TITLE
Upgrade selenium standalone server to support Java 10+

### DIFF
--- a/packages/wct-local/CHANGELOG.md
+++ b/packages/wct-local/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- Updated selenium version to 3.141.59 to support latest JDK versions.
 <!-- Add unreleased changes here. -->
 
 ## [v2.1.3] - 2018-10-24

--- a/packages/wct-local/selenium-overrides.js
+++ b/packages/wct-local/selenium-overrides.js
@@ -1,7 +1,7 @@
 module.exports = {
   'selenium-overrides': {
     'baseURL': 'https://selenium-release.storage.googleapis.com',
-    'version': '3.12.0',
+    'version': '3.141.59',
     'drivers': {
       'chrome': {
         'version': '2.43',


### PR DESCRIPTION
Tested this change locally using openjdk@1.13.0 which did not work until this change was introduced and now it works.  By "did not work" I mean that selenium threw a bunch of exceptions and wasn't useable.