### PR TITLE
fixed --allow-origin switch not being added to serverOptions

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -58,6 +58,7 @@ export class ServeCommand implements Command {
 
     const serverOptions: ServerOptions = {
       root: options['root'],
+      allowOrigin: options['allow-origin'],
       entrypoint: config.entrypoint,
       compile: options['compile'],
       port: options['port'],


### PR DESCRIPTION
Currently when using polyserve with the polymer-cli the --alow-origin switch does not work, this is because --allow-origin is not being added to the serverOptions, i now added it in and tested it and now it's working as it's supposed to.