### PR TITLE
Added --allow-origin to the polymer serve command

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
 * Added `--allow-origin` flag support for `polymer serve`.
 <!-- Add new, unreleased changes here. -->
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
+* Added `--allow-origin` flag support for `polymer serve`.
 <!-- Add new, unreleased changes here. -->
 
 ## v1.9.10 [06-05-2019]

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -58,6 +58,7 @@ export class ServeCommand implements Command {
 
     const serverOptions: ServerOptions = {
       root: options['root'],
+      allowOrigin: options['allow-origin'],
       entrypoint: config.entrypoint,
       compile: options['compile'],
       port: options['port'],


### PR DESCRIPTION
--allow-origin was supported by polyserve, but we never brought that flag into the CLI.  This PR brings that in.  Thanks to @T99rots