### PR TITLE
Modulizer: fix readme add-import-meta default value and reference doc URL

### DIFF
--- a/packages/modulizer/README.md
+++ b/packages/modulizer/README.md
@@ -113,7 +113,7 @@ Setting the import style allows you to set whether JavaScript imports are specif
 
 #### `--add-import-meta
 
-True by default; the static `importMeta` property will be added to converted Polymer elements. See [the `importPath` documentation](https://www.polymer-project.org/2.0/docs/devguide/dom-template) for more information.
+False by default; the static `importMeta` property will be added to converted Polymer elements. See [the `importPath` documentation](https://polymer-library.polymer-project.org/2.0/docs/devguide/dom-template#urls-in-templates) for more information.
 
 
 ## Conversion Guidelines


### PR DESCRIPTION
There is a discrepancy between the Readme and the cli help docs regarding the default value of the `--add-import-meta` option.

The help docs state:
```
--add-import-meta               Whether to add a static importMeta property to elements. Defaults to false
```
Referenced value in code: [https://github.com/Polymer/tools/blob/master/packages/modulizer/src/cli/index.ts#L163]()

This also updates the referenced Polymer documentation page, for clarity.