### PR TITLE
docs: add lerna badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Travis Build Status](https://travis-ci.org/Polymer/tools.svg?branch=master)](https://travis-ci.org/Polymer/tools/branches)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/4ss50o7t0312c2v1/branch/master?svg=true)](https://ci.appveyor.com/project/Polymer/tools/branch/master)
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)
 
 ## Workflow
 


### PR DESCRIPTION
Polymer tools are organized as a monorepo using [Lerna](https://lernajs.io). So I think we should either add lerna badge
[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/) or some kind of acknowledgment in Readme (If addition of badge is not acceptable).
