### PR TITLE
Fix WCT for bower: use Polymer version of sinon.js

### DIFF
--- a/packages/web-component-tester/bower.json
+++ b/packages/web-component-tester/bower.json
@@ -32,7 +32,7 @@
     "lodash": "^3.7.0",
     "mocha": "^3.1.2",
     "sinon-chai": "^2.7.0",
-    "sinonjs": "^1.14.1",
+    "sinonjs": "Polymer/sinon.js#~1.17.1",
     "stacky": "^1.3.0",
     "test-fixture": "^3.0.0"
   },


### PR DESCRIPTION
Fixes #3488

This is a fix for the critical issue that affects our bower installations:

```
bower sinonjs#^1.14.1                                ECMDERR Failed to execute "git ls-remote --tags --heads https://github.com/blittle/sinon.js.git", exit code of #128 remote: Invalid username or password. fatal: Authentication failed for 'https://github.com/blittle/sinon.js.git/'
Additional error details:
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/blittle/sinon.js.git/'
```

Ping @justinfagnani @usergenic. 