### PR TITLE
fix(polymer-build): prevent scoped variables become global after transpilation

### DIFF
--- a/packages/build/package-lock.json
+++ b/packages/build/package-lock.json
@@ -1024,6 +1024,11 @@
 				"babel-helper-is-void-0": "^0.4.3"
 			}
 		},
+		"babel-plugin-transform-block-scope-to-iife": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-block-scope-to-iife/-/babel-plugin-transform-block-scope-to-iife-1.1.2.tgz",
+			"integrity": "sha512-27ZGNZyh4SMHWvbDs3Slr+9dIkcXdpzXWyHkOwfZu1n4/VogwVCaZS6M3CS/I1HuKSTMbXD/3Da0tYHUmbqaCw=="
+		},
 		"babel-plugin-transform-inline-consecutive-adds": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -65,6 +65,7 @@
     "@types/vinyl": "^2.0.0",
     "@types/vinyl-fs": "^2.4.8",
     "babel-plugin-minify-guarded-expressions": "^0.4.3",
+    "babel-plugin-transform-block-scope-to-iife": "^1.1.2",
     "babel-preset-minify": "^0.5.0",
     "babylon": "^7.0.0-beta.42",
     "css-slam": "^2.1.2",

--- a/packages/build/src/js-transform.ts
+++ b/packages/build/src/js-transform.ts
@@ -35,6 +35,7 @@ import * as externalJs from './external-js';
 // constructor to be called so that it can supply the element being upgraded as
 // the object to use for `this`.
 const babelTransformEs2015 = [
+  require('babel-plugin-transform-block-scope-to-iife'),
   require('@babel/plugin-transform-template-literals'),
   require('@babel/plugin-transform-literals'),
   require('@babel/plugin-transform-function-name'),


### PR DESCRIPTION
Includes a [Babel plugin](https://www.npmjs.com/package/babel-plugin-transform-block-scope-to-iife) in polymer-build package to transform block scopes used at the top level of a file to an IIFE. This prevents side effects caused by exposing variables like `Element` (native) in `window`. This global variable exposing happens after transpilation to ES5, that transforms `const` and `let` to `var`, so the block scope has no effect.

Original code:

```js
{
  const { Element } = Polymer;
}
```

After transpilation:

```js
{
  var Element = _Polymer.Element;
}
```

Using the included Babel plugin:

```js
(function() {
  'use strict';
  var Element = _Polymer.Element;
}());
```