### PR TITLE
dom5: update to latest parse5

### DIFF
--- a/packages/dom5/package-lock.json
+++ b/packages/dom5/package-lock.json
@@ -1,53 +1,111 @@
 {
-	"name": "dom5",
-	"version": "3.0.1",
-	"lockfileVersion": 1,
-	"requires": true,
-	"dependencies": {
-		"@types/clone": {
-			"version": "0.1.30",
-			"resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
-			"integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
-			"dev": true
-		},
-		"@types/parse5": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
-			"integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
-		},
-		"clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-		},
-		"parse5": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-		},
-		"semver": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-			"dev": true
-		},
-		"tsc-then": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/tsc-then/-/tsc-then-1.1.0.tgz",
-			"integrity": "sha512-830G8SK8tewOxfKVBC5YWqZ2C7wS1D4dh9267ebLxR7Gvh3UuI6aKU5Hxo+L3Kkcy6CuxZp4PMGl066DZ3Hlmw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "^8.0.53",
-				"semver": "^5.4.1"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "8.10.50",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.50.tgz",
-					"integrity": "sha512-+ZbcUwJdaBgOZpwXeT0v+gHC/jQbEfzoc9s4d0rN0JIKeQbuTrT+A2n1aQY6LpZjrLXJT7avVUqiCecCJeeZxA==",
-					"dev": true
-				}
-			}
-		}
-	}
+  "name": "dom5",
+  "version": "3.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "3.0.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/parse5": "^6.0.0",
+        "clone": "^2.1.0",
+        "parse5": "^6.0.1"
+      },
+      "devDependencies": {
+        "@types/clone": "^0.1.29",
+        "tsc-then": "^1.1.0"
+      }
+    },
+    "node_modules/@types/clone": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
+      "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
+      "dev": true
+    },
+    "node_modules/@types/parse5": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.0.tgz",
+      "integrity": "sha512-oPwPSj4a1wu9rsXTEGIJz91ISU725t0BmSnUhb57sI+M8XEmvUop84lzuiYdq0Y5M6xLY8DBPg0C2xEQKLyvBA=="
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
+    "node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
+    },
+    "node_modules/tsc-then": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tsc-then/-/tsc-then-1.1.0.tgz",
+      "integrity": "sha512-830G8SK8tewOxfKVBC5YWqZ2C7wS1D4dh9267ebLxR7Gvh3UuI6aKU5Hxo+L3Kkcy6CuxZp4PMGl066DZ3Hlmw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^8.0.53",
+        "semver": "^5.4.1"
+      }
+    },
+    "node_modules/tsc-then/node_modules/@types/node": {
+      "version": "8.10.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.50.tgz",
+      "integrity": "sha512-+ZbcUwJdaBgOZpwXeT0v+gHC/jQbEfzoc9s4d0rN0JIKeQbuTrT+A2n1aQY6LpZjrLXJT7avVUqiCecCJeeZxA==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@types/clone": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
+      "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
+      "dev": true
+    },
+    "@types/parse5": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.0.tgz",
+      "integrity": "sha512-oPwPSj4a1wu9rsXTEGIJz91ISU725t0BmSnUhb57sI+M8XEmvUop84lzuiYdq0Y5M6xLY8DBPg0C2xEQKLyvBA=="
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
+    },
+    "tsc-then": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tsc-then/-/tsc-then-1.1.0.tgz",
+      "integrity": "sha512-830G8SK8tewOxfKVBC5YWqZ2C7wS1D4dh9267ebLxR7Gvh3UuI6aKU5Hxo+L3Kkcy6CuxZp4PMGl066DZ3Hlmw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^8.0.53",
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.50.tgz",
+          "integrity": "sha512-+ZbcUwJdaBgOZpwXeT0v+gHC/jQbEfzoc9s4d0rN0JIKeQbuTrT+A2n1aQY6LpZjrLXJT7avVUqiCecCJeeZxA==",
+          "dev": true
+        }
+      }
+    }
+  }
 }

--- a/packages/dom5/package-lock.json
+++ b/packages/dom5/package-lock.json
@@ -10,18 +10,10 @@
 			"integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
 			"dev": true
 		},
-		"@types/node": {
-			"version": "12.6.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.1.tgz",
-			"integrity": "sha512-rp7La3m845mSESCgsJePNL/JQyhkOJA6G4vcwvVgkDAwHhGdq5GCumxmPjEk1MZf+8p5ZQAUE7tqgQRQTXN7uQ=="
-		},
 		"@types/parse5": {
-			"version": "2.2.34",
-			"resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
-			"integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
-			"requires": {
-				"@types/node": "*"
-			}
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+			"integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
 		},
 		"clone": {
 			"version": "2.1.2",
@@ -29,9 +21,9 @@
 			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
 		"parse5": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
 		},
 		"semver": {
 			"version": "5.7.0",

--- a/packages/dom5/package.json
+++ b/packages/dom5/package.json
@@ -17,9 +17,9 @@
     "test:watch": "tsc-then -- mocha -c --ui tdd \"lib/test/*_test.js\""
   },
   "dependencies": {
-    "@types/parse5": "^2.2.34",
+    "@types/parse5": "^5.0.3",
     "clone": "^2.1.0",
-    "parse5": "^4.0.0"
+    "parse5": "^6.0.1"
   },
   "devDependencies": {
     "@types/clone": "^0.1.29",

--- a/packages/dom5/package.json
+++ b/packages/dom5/package.json
@@ -17,7 +17,7 @@
     "test:watch": "tsc-then -- mocha -c --ui tdd \"lib/test/*_test.js\""
   },
   "dependencies": {
-    "@types/parse5": "^5.0.3",
+    "@types/parse5": "^6.0.0",
     "clone": "^2.1.0",
     "parse5": "^6.0.1"
   },

--- a/packages/dom5/src/iteration.ts
+++ b/packages/dom5/src/iteration.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {DefaultTreeNode as Node} from 'parse5';
+import {Node} from 'parse5';
 
 import {isChildNode, isElement, Predicate, predicates as p} from './predicates';
 import {childNodesIncludeTemplate, defaultChildNodes, GetChildNodes} from './util';
@@ -85,9 +85,7 @@ export function* ancestors(node: Node): IterableIterator<Node> {
   let currNode: Node|undefined = node;
   while (currNode !== undefined) {
     yield currNode;
-    if (isChildNode(currNode)) {
-      currNode = currNode.parentNode;
-    }
+    currNode = isChildNode(currNode) ? currNode.parentNode : undefined;
   }
 }
 

--- a/packages/dom5/src/iteration.ts
+++ b/packages/dom5/src/iteration.ts
@@ -12,12 +12,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {ASTNode as Node} from 'parse5';
+import {DefaultTreeNode as Node} from 'parse5';
 
-import {isElement, Predicate, predicates as p} from './predicates';
+import {isChildNode, isElement, Predicate, predicates as p} from './predicates';
 import {childNodesIncludeTemplate, defaultChildNodes, GetChildNodes} from './util';
 
-export {ASTNode as Node} from 'parse5';
+export {Node};
 
 /**
  * Applies `mapfn` to `node` and the tree below `node`, yielding a flattened
@@ -85,7 +85,9 @@ export function* ancestors(node: Node): IterableIterator<Node> {
   let currNode: Node|undefined = node;
   while (currNode !== undefined) {
     yield currNode;
-    currNode = currNode.parentNode;
+    if (isChildNode(currNode)) {
+      currNode = currNode.parentNode;
+    }
   }
 }
 
@@ -97,6 +99,9 @@ export function* ancestors(node: Node): IterableIterator<Node> {
  * closest to `node`)
  */
 export function* previousSiblings(node: Node): IterableIterator<Node> {
+  if (!isChildNode(node)) {
+    return;
+  }
   const parent = node.parentNode;
   if (parent === undefined) {
     return;
@@ -147,10 +152,12 @@ export function* prior(node: Node): IterableIterator<Node> {
   for (const previousSibling of previousSiblings(node)) {
     yield* depthFirstReversed(previousSibling);
   }
-  const parent = node.parentNode;
-  if (parent) {
-    yield parent;
-    yield* prior(parent);
+  if (isChildNode(node)) {
+    const parent = node.parentNode;
+    if (parent) {
+      yield parent;
+      yield* prior(parent);
+    }
   }
 }
 

--- a/packages/dom5/src/modification.ts
+++ b/packages/dom5/src/modification.ts
@@ -62,7 +62,7 @@ function newDocumentFragment(): DocumentFragment {
   };
 }
 
-export function cloneNode(node: Node): Node {
+export function cloneNode<T extends Node>(node: T): T {
   // parent is a backreference, and we don't want to clone the whole tree, so
   // make it null before cloning.
   let clone;

--- a/packages/dom5/src/modification.ts
+++ b/packages/dom5/src/modification.ts
@@ -12,75 +12,79 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import * as cloneObject from 'clone';
-import {ASTNode as Node} from 'parse5';
+import {
+  DefaultTreeNode as Node,
+  DefaultTreeTextNode as TextNode,
+  DefaultTreeElement as Element,
+  DefaultTreeDocumentFragment as DocumentFragment,
+  DefaultTreeCommentNode as CommentNode,
+  DefaultTreeParentNode as ParentNode,
+  DefaultTreeChildNode as ChildNode
+} from 'parse5';
 
-import {isDocumentFragment, predicates as p} from './predicates';
+import {isChildNode, isDocumentFragment, predicates as p} from './predicates';
 import {queryAll} from './walking';
 
-export {ASTNode as Node} from 'parse5';
+export {Node};
 
-function newTextNode(value: string): Node {
+function newTextNode(value: string): TextNode {
   return {
     nodeName: '#text',
     value: value,
-    parentNode: undefined,
-    attrs: [],
-    __location: <any>undefined,
+    // TODO (43081j): maybe pass in what we're going to append it to?
+    parentNode: undefined as unknown as ParentNode
   };
 }
 
-function newCommentNode(comment: string): Node {
+function newCommentNode(comment: string): CommentNode {
   return {
     nodeName: '#comment',
     data: comment,
-    parentNode: undefined,
-    attrs: [],
-    __location: <any>undefined
+    parentNode: undefined as unknown as ParentNode
   };
 }
 
-function newElement(tagName: string, namespace?: string): Node {
+function newElement(tagName: string, namespace?: string): Element {
   return {
     nodeName: tagName,
     tagName: tagName,
     childNodes: [],
     namespaceURI: namespace || 'http://www.w3.org/1999/xhtml',
     attrs: [],
-    parentNode: undefined,
-    __location: <any>undefined
+    parentNode: undefined as unknown as ParentNode
   };
 }
 
-function newDocumentFragment(): Node {
+function newDocumentFragment(): DocumentFragment {
   return {
     nodeName: '#document-fragment',
-    childNodes: [],
-    parentNode: undefined,
-    quirksMode: false,
-    // TODO(rictic): update parse5 typings upstream to mention that attrs and
-    //     __location are optional and not always present.
-    attrs: undefined as any,
-    __location: null as any
+    childNodes: []
   };
 }
 
 export function cloneNode(node: Node): Node {
   // parent is a backreference, and we don't want to clone the whole tree, so
   // make it null before cloning.
-  const parent = node.parentNode;
-  node.parentNode = undefined;
-  const clone = cloneObject(node);
-  node.parentNode = parent;
+  let clone;
+
+  if (isChildNode(node)) {
+    const parent = node.parentNode;
+    node.parentNode = undefined as unknown as ParentNode;
+    clone = cloneObject(node);
+    node.parentNode = parent;
+  } else {
+    clone = cloneObject(node);
+  }
   return clone;
 }
 
 /**
- * Inserts `newNode` into `parent` at `index`, optionally replaceing the
+ * Inserts `newNode` into `parent` at `index`, optionally replacing the
  * current node at `index`. If `newNode` is a DocumentFragment, its childNodes
  * are inserted and removed from the fragment.
  */
 function insertNode(
-    parent: Node, index: number, newNode: Node, replace?: boolean) {
+    parent: ParentNode, index: number, newNode: Node, replace?: boolean) {
   if (!parent.childNodes) {
     parent.childNodes = [];
   }
@@ -106,37 +110,45 @@ function insertNode(
   Array.prototype.splice.apply(
       parent.childNodes, (<any>[index, replace ? 1 : 0]).concat(newNodes));
 
-  newNodes.forEach(function(n) {
-    n.parentNode = parent;
+  newNodes.forEach((n) => {
+    (n as ChildNode).parentNode = parent;
   });
 
   if (removedNode) {
-    removedNode.parentNode = undefined;
+    (removedNode as ChildNode).parentNode = undefined as unknown as ParentNode;
   }
 }
 
 export function replace(oldNode: Node, newNode: Node) {
+  // we can't replace something that isn't a child of anything.
+  if (!isChildNode(oldNode)) {
+    return;
+  }
   const parent = oldNode.parentNode;
-  const index = parent!.childNodes!.indexOf(oldNode);
-  insertNode(parent!, index, newNode, true);
+  const index = parent.childNodes.indexOf(oldNode);
+  insertNode(parent, index, newNode, true);
 }
 
 export function remove(node: Node) {
+  // if it isn't a child, there's nothing to remove it from
+  if (!isChildNode(node)) {
+    return;
+  }
   const parent = node.parentNode;
   if (parent && parent.childNodes) {
     const idx = parent.childNodes.indexOf(node);
     parent.childNodes.splice(idx, 1);
   }
-  node.parentNode = undefined;
+  node.parentNode = undefined as unknown as ParentNode;
 }
 
-export function insertBefore(parent: Node, target: Node, newNode: Node) {
-  const index = parent.childNodes!.indexOf(target);
+export function insertBefore(parent: ParentNode, target: Node, newNode: Node) {
+  const index = parent.childNodes.indexOf(target);
   insertNode(parent, index, newNode);
 }
 
-export function insertAfter(parent: Node, target: Node, newNode: Node) {
-  const index = parent.childNodes!.indexOf(target);
+export function insertAfter(parent: ParentNode, target: Node, newNode: Node) {
+  const index = parent.childNodes.indexOf(target);
   insertNode(parent, index + 1, newNode);
 }
 
@@ -144,7 +156,7 @@ export function insertAfter(parent: Node, target: Node, newNode: Node) {
  * Removes a node and places its children in its place.  If the node
  * has no parent, the operation is impossible and no action takes place.
  */
-export function removeNodeSaveChildren(node: Node) {
+export function removeNodeSaveChildren(node: ParentNode & ChildNode) {
   // We can't save the children if there's no parent node to provide
   // for them.
   const fosterParent = node.parentNode;

--- a/packages/dom5/src/modification.ts
+++ b/packages/dom5/src/modification.ts
@@ -56,10 +56,7 @@ function newElement(tagName: string, namespace?: string): Element {
 }
 
 function newDocumentFragment(): DocumentFragment {
-  return {
-    nodeName: '#document-fragment',
-    childNodes: []
-  };
+  return {nodeName: '#document-fragment', childNodes: []};
 }
 
 export function cloneNode<T extends Node>(node: T): T {
@@ -156,7 +153,7 @@ export function insertAfter(parent: ParentNode, target: Node, newNode: Node) {
  * Removes a node and places its children in its place.  If the node
  * has no parent, the operation is impossible and no action takes place.
  */
-export function removeNodeSaveChildren(node: ParentNode & ChildNode) {
+export function removeNodeSaveChildren(node: ParentNode&ChildNode) {
   // We can't save the children if there's no parent node to provide
   // for them.
   const fosterParent = node.parentNode;
@@ -180,17 +177,20 @@ export function removeFakeRootElements(ast: Node) {
   const injectedNodes = queryAll(
       ast,
       p.AND(
-          (node) => !node.__location,
+          (node) => !(node as Element).sourceCodeLocation,
           p.hasMatchingTagName(/^(html|head|body)$/i)),
       undefined,
       // Don't descend past 3 levels 'document > html > head|body'
-      (node) => node.parentNode && node.parentNode.parentNode ?
-          undefined :
-          node.childNodes);
+      (node) => {
+        const nodeAsElement = node as Element;
+        const parentAsElement =
+            (nodeAsElement && nodeAsElement.parentNode) as Element;
+        return parentAsElement ? undefined : nodeAsElement.childNodes;
+      })
   injectedNodes.reverse().forEach(removeNodeSaveChildren);
 }
 
-export function append(parent: Node, newNode: Node) {
+export function append(parent: ParentNode, newNode: Node) {
   const index = parent.childNodes && parent.childNodes.length || 0;
   insertNode(parent, index, newNode);
 }

--- a/packages/dom5/src/modification.ts
+++ b/packages/dom5/src/modification.ts
@@ -12,15 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import * as cloneObject from 'clone';
-import {
-  DefaultTreeNode as Node,
-  DefaultTreeTextNode as TextNode,
-  DefaultTreeElement as Element,
-  DefaultTreeDocumentFragment as DocumentFragment,
-  DefaultTreeCommentNode as CommentNode,
-  DefaultTreeParentNode as ParentNode,
-  DefaultTreeChildNode as ChildNode
-} from 'parse5';
+import {ChildNode, CommentNode, DocumentFragment, Element, Node, ParentNode, TextNode} from 'parse5';
 
 import {isChildNode, isDocumentFragment, predicates as p} from './predicates';
 import {queryAll} from './walking';
@@ -112,7 +104,7 @@ function insertNode(
   });
 
   if (removedNode) {
-    (removedNode as ChildNode).parentNode = undefined as unknown as ParentNode;
+    removedNode.parentNode = undefined as unknown as ParentNode;
   }
 }
 
@@ -139,12 +131,14 @@ export function remove(node: Node) {
   node.parentNode = undefined as unknown as ParentNode;
 }
 
-export function insertBefore(parent: ParentNode, target: Node, newNode: Node) {
+export function insertBefore(
+    parent: ParentNode, target: ChildNode, newNode: Node) {
   const index = parent.childNodes.indexOf(target);
   insertNode(parent, index, newNode);
 }
 
-export function insertAfter(parent: ParentNode, target: Node, newNode: Node) {
+export function insertAfter(
+    parent: ParentNode, target: ChildNode, newNode: Node) {
   const index = parent.childNodes.indexOf(target);
   insertNode(parent, index + 1, newNode);
 }
@@ -182,11 +176,11 @@ export function removeFakeRootElements(ast: Node) {
       undefined,
       // Don't descend past 3 levels 'document > html > head|body'
       (node) => {
-        const nodeAsElement = node as Element;
-        const parentAsElement =
-            (nodeAsElement && nodeAsElement.parentNode) as Element;
-        return parentAsElement ? undefined : nodeAsElement.childNodes;
-      })
+        return isChildNode(node) && node.parentNode &&
+                isChildNode(node.parentNode) && node.parentNode.parentNode ?
+            undefined :
+            (node as ParentNode).childNodes;
+      });
   injectedNodes.reverse().forEach(removeNodeSaveChildren);
 }
 

--- a/packages/dom5/src/predicates.ts
+++ b/packages/dom5/src/predicates.ts
@@ -12,16 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {
-  DefaultTreeNode as Node,
-  DefaultTreeChildNode as ChildNode,
-  DefaultTreeDocumentFragment as DocumentFragment,
-  DefaultTreeDocument as Document,
-  DefaultTreeElement as Element,
-  DefaultTreeCommentNode as CommentNode,
-  DefaultTreeParentNode as ParentNode,
-  DefaultTreeTextNode as TextNode
-} from 'parse5';
+import {ChildNode, CommentNode, Document, DocumentFragment, Element, Node, ParentNode, TextNode} from 'parse5';
 
 import {getAttribute, getAttributeIndex, getTextContent} from './util';
 

--- a/packages/dom5/src/predicates.ts
+++ b/packages/dom5/src/predicates.ts
@@ -164,23 +164,23 @@ export function hasSpaceSeparatedAttrValue(
 }
 
 export function isDocument(node: Node): node is Document {
-  return (node as Document).nodeName === '#document';
+  return node.nodeName === '#document';
 }
 
 export function isDocumentFragment(node: Node): node is DocumentFragment {
-  return (node as DocumentFragment).nodeName === '#document-fragment';
+  return node.nodeName === '#document-fragment';
 }
 
 export function isElement(node: Node): node is Element {
-  return (node as Element).nodeName === (node as Element).tagName;
+  return node.nodeName === (node as Element).tagName;
 }
 
 export function isTextNode(node: Node): node is TextNode {
-  return (node as TextNode).nodeName === '#text';
+  return node.nodeName === '#text';
 }
 
 export function isCommentNode(node: Node): node is CommentNode {
-  return (node as CommentNode).nodeName === '#comment';
+  return node.nodeName === '#comment';
 }
 
 export function isChildNode(node: Node): node is ChildNode {

--- a/packages/dom5/src/predicates.ts
+++ b/packages/dom5/src/predicates.ts
@@ -12,11 +12,20 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {ASTNode as Node} from 'parse5';
+import {
+  DefaultTreeNode as Node,
+  DefaultTreeChildNode as ChildNode,
+  DefaultTreeDocumentFragment as DocumentFragment,
+  DefaultTreeDocument as Document,
+  DefaultTreeElement as Element,
+  DefaultTreeCommentNode as CommentNode,
+  DefaultTreeParentNode as ParentNode,
+  DefaultTreeTextNode as TextNode
+} from 'parse5';
 
 import {getAttribute, getAttributeIndex, getTextContent} from './util';
 
-export {ASTNode as Node} from 'parse5';
+export {Node};
 
 
 /**
@@ -86,10 +95,16 @@ function NOT(predicateFn: Predicate): Predicate {
  */
 function parentMatches(predicateFn: Predicate): Predicate {
   return function(node) {
+    if (!isChildNode(node)) {
+      return false;
+    }
     let parent = node.parentNode;
     while (parent !== undefined) {
       if (predicateFn(parent)) {
         return true;
+      }
+      if (!isChildNode(parent)) {
+        return false;
       }
       parent = parent.parentNode;
     }
@@ -116,7 +131,7 @@ function hasClass(name: string): Predicate {
 function hasTagName(name: string): Predicate {
   const n = name.toLowerCase();
   return function(node) {
-    if (!node.tagName) {
+    if (!isElement(node) || !node.tagName) {
       return false;
     }
     return node.tagName.toLowerCase() === n;
@@ -130,7 +145,7 @@ function hasTagName(name: string): Predicate {
  */
 function hasMatchingTagName(regex: RegExp): Predicate {
   return function(node) {
-    if (!node.tagName) {
+    if (!isElement(node) || !node.tagName) {
       return false;
     }
     return regex.test(node.tagName.toLowerCase());
@@ -148,24 +163,32 @@ export function hasSpaceSeparatedAttrValue(
   };
 }
 
-export function isDocument(node: Node): boolean {
+export function isDocument(node: Node): node is Document {
   return node.nodeName === '#document';
 }
 
-export function isDocumentFragment(node: Node): boolean {
+export function isDocumentFragment(node: Node): node is DocumentFragment {
   return node.nodeName === '#document-fragment';
 }
 
-export function isElement(node: Node): boolean {
-  return node.nodeName === node.tagName;
+export function isElement(node: Node): node is Element {
+  return node.nodeName === (node as Element).tagName;
 }
 
-export function isTextNode(node: Node): boolean {
+export function isTextNode(node: Node): node is TextNode {
   return node.nodeName === '#text';
 }
 
-export function isCommentNode(node: Node): boolean {
+export function isCommentNode(node: Node): node is CommentNode {
   return node.nodeName === '#comment';
+}
+
+export function isChildNode(node: Node): node is ChildNode {
+  return (node as ChildNode).parentNode !== undefined;
+}
+
+export function isParentNode(node: Node): node is ParentNode {
+  return (node as ParentNode).childNodes !== undefined;
 }
 
 export const predicates = {

--- a/packages/dom5/src/predicates.ts
+++ b/packages/dom5/src/predicates.ts
@@ -105,12 +105,18 @@ function parentMatches(predicateFn: Predicate): Predicate {
 
 function hasAttr(attr: string): Predicate {
   return function(node) {
+    if (!isElement(node)) {
+      return false;
+    }
     return getAttributeIndex(node, attr) > -1;
   };
 }
 
 function hasAttrValue(attr: string, value: string): Predicate {
   return function(node) {
+    if (!isElement(node)) {
+      return false;
+    }
     return getAttribute(node, attr) === value;
   };
 }
@@ -146,6 +152,9 @@ function hasMatchingTagName(regex: RegExp): Predicate {
 export function hasSpaceSeparatedAttrValue(
     name: string, value: string): Predicate {
   return function(element: Node) {
+    if (!isElement(element)) {
+      return false;
+    }
     const attributeValue = getAttribute(element, name);
     if (typeof attributeValue !== 'string') {
       return false;
@@ -155,23 +164,23 @@ export function hasSpaceSeparatedAttrValue(
 }
 
 export function isDocument(node: Node): node is Document {
-  return node.nodeName === '#document';
+  return (node as Document).nodeName === '#document';
 }
 
 export function isDocumentFragment(node: Node): node is DocumentFragment {
-  return node.nodeName === '#document-fragment';
+  return (node as DocumentFragment).nodeName === '#document-fragment';
 }
 
 export function isElement(node: Node): node is Element {
-  return node.nodeName === (node as Element).tagName;
+  return (node as Element).nodeName === (node as Element).tagName;
 }
 
 export function isTextNode(node: Node): node is TextNode {
-  return node.nodeName === '#text';
+  return (node as TextNode).nodeName === '#text';
 }
 
 export function isCommentNode(node: Node): node is CommentNode {
-  return node.nodeName === '#comment';
+  return (node as CommentNode).nodeName === '#comment';
 }
 
 export function isChildNode(node: Node): node is ChildNode {

--- a/packages/dom5/src/test/dom5_test.ts
+++ b/packages/dom5/src/test/dom5_test.ts
@@ -10,7 +10,18 @@
  */
 
 import {assert} from 'chai';
-import * as parse5 from 'parse5';
+import {
+  parse,
+  parseFragment,
+  serialize,
+  DefaultTreeNode as Node,
+  DefaultTreeElement as Element,
+  DefaultTreeParentNode as ParentNode,
+  DefaultTreeTextNode as TextNode,
+  DefaultTreeChildNode as ChildNode,
+  DefaultTreeDocument as Document,
+  DefaultTreeDocumentFragment as DocumentFragment
+} from 'parse5';
 
 import * as dom5 from '../index';
 
@@ -23,95 +34,128 @@ suite('dom5', () => {
         `<div bar='b3 b4'>b3 b4</div>` +
         `<!-- comment -->`;
 
-    let doc = parse5.parse(docText);
+    let doc: Document;
 
     setup(() => {
-      doc = parse5.parse(docText);
+      doc = parse(docText);
     });
 
     suite('Node Identity', () => {
       test('isElement', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         assert(dom5.isElement(divA));
       });
 
       test('isTextNode', () => {
         const textA1 =
-            doc.childNodes![1].childNodes![1].childNodes![0].childNodes![0];
+            (((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes![0] as ParentNode)
+              .childNodes![0];
         assert(dom5.isTextNode(textA1));
       });
 
       test('isCommentNode', () => {
         const commentEnd =
-            doc.childNodes![1].childNodes![1].childNodes!.slice(-1)[0];
+            ((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes!.slice(-1)[0];
         assert(dom5.isCommentNode(commentEnd));
       });
     });
 
     suite('getAttribute', () => {
       test('returns null for a non-set attribute', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         assert.equal(dom5.getAttribute(divA, 'foo'), null);
       });
 
       test('returns the value for a set attribute', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         assert.equal(dom5.getAttribute(divA, 'id'), 'A');
       });
 
       test('returns the first value for a doubly set attribute', () => {
         const divB =
-            doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+            (((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes![0] as ParentNode)
+              .childNodes![1];
         assert.equal(dom5.getAttribute(divB, 'bar'), 'b1');
       });
     });
 
     suite('hasAttribute', () => {
       test('returns false for a non-set attribute', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         assert.equal(dom5.hasAttribute(divA, 'foo'), false);
       });
 
       test('returns true for a set attribute', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         assert.equal(dom5.hasAttribute(divA, 'id'), true);
       });
 
       test('returns true for a doubly set attribute', () => {
         const divB =
-            doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+            (((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes![0] as ParentNode)
+              .childNodes![1];
         assert.equal(dom5.hasAttribute(divB, 'bar'), true);
       });
 
       test('returns true for attribute with no value', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         assert.equal(dom5.hasAttribute(divA, 'qux'), true);
       });
     });
 
     suite('setAttribute', () => {
       test('sets a non-set attribute', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         dom5.setAttribute(divA, 'foo', 'bar');
         assert.equal(dom5.getAttribute(divA, 'foo'), 'bar');
       });
 
       test('sets and already set attribute', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         dom5.setAttribute(divA, 'id', 'qux');
         assert.equal(dom5.getAttribute(divA, 'id'), 'qux');
       });
 
       test('sets the first value for a doubly set attribute', () => {
         const divB =
-            doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+            (((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes![0] as ParentNode)
+              .childNodes![1];
         dom5.setAttribute(divB, 'bar', 'baz');
         assert.equal(dom5.getAttribute(divB, 'bar'), 'baz');
       });
 
       test('throws when called on a text node', () => {
         const text =
-            doc.childNodes![1].childNodes![1].childNodes![0].childNodes![0];
+            (((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes![0] as ParentNode)
+              .childNodes![0];
         assert.throws(() => {
           dom5.setAttribute(text, 'bar', 'baz');
         });
@@ -120,14 +164,18 @@ suite('dom5', () => {
 
     suite('removeAttribute', () => {
       test('removes a set attribute', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         dom5.removeAttribute(divA, 'foo');
         assert.equal(dom5.getAttribute(divA, 'foo'), null);
       });
 
       test(
           'does not throw when called on a node without that attribute', () => {
-            const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+            const divA = ((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes![0];
             assert.doesNotThrow(() => {
               dom5.removeAttribute(divA, 'ZZZ');
             });
@@ -135,14 +183,16 @@ suite('dom5', () => {
     });
 
     suite('getTextContent', () => {
-      let body = doc.childNodes![1].childNodes![1];
+      let body: ParentNode;
 
       suiteSetup(() => {
-        body = doc.childNodes![1].childNodes![1];
+        body = (doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode;
       });
 
       test('text node', () => {
-        const node = body.childNodes![0].childNodes![0];
+        const node = (body.childNodes![0] as ParentNode)
+          .childNodes![0];
         const expected = 'a1';
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
@@ -156,7 +206,8 @@ suite('dom5', () => {
       });
 
       test('leaf element', () => {
-        const node = body.childNodes![0].childNodes![1];
+        const node = (body.childNodes![0] as ParentNode)
+          .childNodes![1];
         const expected = 'b1';
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
@@ -170,15 +221,17 @@ suite('dom5', () => {
     });
 
     suite('setTextContent', () => {
-      let body: parse5.ASTNode;
+      let body: ParentNode;
       const expected = 'test';
 
       suiteSetup(() => {
-        body = doc.childNodes![1].childNodes![1];
+        body = (doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode
       });
 
       test('text node', () => {
-        const node = body.childNodes![0].childNodes![0];
+        const node = (body.childNodes![0] as ParentNode)
+          .childNodes![0];
         dom5.setTextContent(node, expected);
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
@@ -192,7 +245,8 @@ suite('dom5', () => {
       });
 
       test('leaf element', () => {
-        const node = body.childNodes![0].childNodes![1];
+        const node = (body.childNodes![0] as ParentNode)
+          .childNodes![1] as ParentNode;
         dom5.setTextContent(node, expected);
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
@@ -209,18 +263,26 @@ suite('dom5', () => {
 
     suite('Replace node', () => {
       test('New node replaces old node', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         const newNode = dom5.constructors.element('ul');
         dom5.replace(divA, newNode);
-        assert.equal(divA.parentNode, null);
+        assert.equal((divA as ChildNode).parentNode, null);
         assert.equal(
-            doc.childNodes![1].childNodes![1].childNodes!.indexOf(divA), -1);
+            ((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes!.indexOf(divA), -1);
         assert.equal(
-            doc.childNodes![1].childNodes![1].childNodes!.indexOf(newNode), 0);
+            ((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes!.indexOf(newNode), 0);
       });
 
       test('accepts document fragments', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0];
         const fragment = dom5.constructors.fragment();
         const span = dom5.constructors.element('span');
         const text = dom5.constructors.text('foo');
@@ -229,19 +291,27 @@ suite('dom5', () => {
 
         dom5.replace(divA, fragment);
 
-        assert.equal(divA.parentNode, null);
+        assert.equal((divA as ChildNode).parentNode, null);
         assert.equal(
-            doc.childNodes![1].childNodes![1].childNodes!.indexOf(divA), -1);
+            ((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes!.indexOf(divA), -1);
         assert.equal(
-            doc.childNodes![1].childNodes![1].childNodes!.indexOf(span), 0);
+            ((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes!.indexOf(span), 0);
         assert.equal(
-            doc.childNodes![1].childNodes![1].childNodes!.indexOf(text), 1);
+            ((doc.childNodes![1] as ParentNode)
+              .childNodes![1] as ParentNode)
+              .childNodes!.indexOf(text), 1);
       });
     });
 
     suite('Remove node', () => {
       test('node is removed from parentNode', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0] as ChildNode;
         const parent = divA.parentNode!;
         dom5.remove(divA);
         assert.equal(divA.parentNode, null);
@@ -249,7 +319,9 @@ suite('dom5', () => {
       });
 
       test('removed nodes do not throw', () => {
-        const divA = doc.childNodes![1].childNodes![1].childNodes![0];
+        const divA = ((doc.childNodes![1] as ParentNode)
+          .childNodes![1] as ParentNode)
+          .childNodes![0] as ChildNode;
         dom5.remove(divA);
         dom5.remove(divA);
         assert.equal(divA.parentNode, null);
@@ -259,11 +331,12 @@ suite('dom5', () => {
     suite('Remove node, save children', () => {
       test('node is removed and children at same position', () => {
         const html = '<div><em>x</em><span><em>a</em><em>c</em></span>y</div>';
-        const ast = parse5.parseFragment(html);
-        const span = ast.childNodes![0]!.childNodes![1]!;
+        const ast = parseFragment(html);
+        const span = (ast.childNodes![0] as ParentNode)
+          .childNodes![1]! as Element;
         dom5.removeNodeSaveChildren(span);
         assert.deepEqual(
-            parse5.serialize(ast),
+            serialize(ast),
             '<div><em>x</em><em>a</em><em>c</em>y</div>');
       });
     });
@@ -271,35 +344,35 @@ suite('dom5', () => {
     suite('Remove fake root elements from tree', () => {
       test('Fake root elements will be removed', () => {
         const html = `<div>Just a div</div>`;
-        const ast = parse5.parse(html, {locationInfo: true});
+        const ast = parse(html, {sourceCodeLocationInfo: true});
         assert.deepEqual(
-            parse5.serialize(ast),
+            serialize(ast),
             '<html><head></head><body><div>Just a div</div></body></html>');
         dom5.removeFakeRootElements(ast);
-        assert.deepEqual(parse5.serialize(ast), html);
+        assert.deepEqual(serialize(ast), html);
       });
 
       test('Real root elements will be preserved', () => {
         const html =
             '<html><head></head><body><div>Just a div</div></body></html>';
-        const ast = parse5.parse(html, {locationInfo: true});
-        assert.deepEqual(parse5.serialize(ast), html);
+        const ast = parse(html, {sourceCodeLocationInfo: true});
+        assert.deepEqual(serialize(ast), html);
         dom5.removeFakeRootElements(ast);
-        assert.deepEqual(parse5.serialize(ast), html);
+        assert.deepEqual(serialize(ast), html);
       });
     });
 
     suite('Append Node', () => {
-      let dom: parse5.ASTNode, div: parse5.ASTNode, span: parse5.ASTNode;
+      let dom: DocumentFragment, div: Element, span: Element;
 
       setup(() => {
-        dom = parse5.parseFragment('<div>a</div><span></span>b');
-        div = dom.childNodes![0];
-        span = dom.childNodes![1];
+        dom = parseFragment('<div>a</div><span></span>b');
+        div = dom.childNodes![0] as Element;
+        span = dom.childNodes![1] as Element;
       });
 
       test('node is only in one parent', () => {
-        const b = dom.childNodes!.slice(-1)[0];
+        const b = dom.childNodes!.slice(-1)[0] as Element;
         dom5.append(span, b);
         assert.equal(b.parentNode, span);
         assert.equal(dom.childNodes!.indexOf(b), -1);
@@ -341,7 +414,7 @@ suite('dom5', () => {
       });
 
       test('append to node with no children', () => {
-        const emptyBody = parse5.parse('<head></head><body></body>');
+        const emptyBody = parse('<head></head><body></body>');
         const body = emptyBody.childNodes![0].childNodes![1];
         const span = dom5.constructors.element('span');
         dom5.append(body, span);
@@ -351,20 +424,20 @@ suite('dom5', () => {
     });
 
     suite('InsertBefore', () => {
-      let dom: parse5.ASTNode, div: parse5.ASTNode, span: parse5.ASTNode,
-          text: parse5.ASTNode;
+      let dom: DocumentFragment, div: Element, span: Element,
+          text: Node;
 
       setup(() => {
-        dom = parse5.parseFragment('<div></div><span></span>text');
-        div = dom.childNodes![0];
-        span = dom.childNodes![1];
+        dom = parseFragment('<div></div><span></span>text');
+        div = dom.childNodes![0] as Element;
+        span = dom.childNodes![1] as Element;
         text = dom.childNodes![2];
       });
 
       test('ordering is correct', () => {
         dom5.insertBefore(dom, span, text);
         assert.equal(dom.childNodes!.indexOf(text), 1);
-        const newHtml = parse5.serialize(dom);
+        const newHtml = serialize(dom);
         assert.equal(newHtml, '<div></div>text<span></span>');
         dom5.insertBefore(dom, div, text);
         assert.equal(dom.childNodes!.indexOf(text), 0);
@@ -387,28 +460,28 @@ suite('dom5', () => {
     });
 
     suite('insertAfter', () => {
-      let dom: parse5.ASTNode;
-      let div: parse5.ASTNode;
-      let span: parse5.ASTNode;
-      let text: parse5.ASTNode;
+      let dom: DocumentFragment;
+      let div: Node;
+      let span: Node;
+      let text: Node;
 
       setup(() => {
-        dom = parse5.parseFragment('<div></div><span></span>text');
+        dom = parseFragment('<div></div><span></span>text');
         [div, span, text] = dom.childNodes!;
       });
 
       test('ordering is correct', () => {
         dom5.insertAfter(dom, div, text);
-        assert.equal(parse5.serialize(dom), '<div></div>text<span></span>');
+        assert.equal(serialize(dom), '<div></div>text<span></span>');
         dom5.insertAfter(dom, span, text);
-        assert.equal(parse5.serialize(dom), '<div></div><span></span>text');
+        assert.equal(serialize(dom), '<div></div><span></span>text');
       });
 
       test('accepts document fragments', () => {
-        const fragment = parse5.parseFragment('<span></span>foo');
+        const fragment = parseFragment('<span></span>foo');
         dom5.insertAfter(dom, span, fragment);
         assert.equal(
-            parse5.serialize(dom),
+            serialize(dom),
             '<div></div><span></span><span></span>footext');
         assert.equal(fragment.childNodes!.length, 0);
       });
@@ -416,9 +489,9 @@ suite('dom5', () => {
 
     suite('cloneNode', () => {
       test('clones a node', () => {
-        const dom = parse5.parseFragment('<div><span foo="bar">a</span></div>');
-        const div = dom.childNodes![0];
-        const span = div.childNodes![0];
+        const dom = parseFragment('<div><span foo="bar">a</span></div>');
+        const div = dom.childNodes![0] as Element;
+        const span = div.childNodes![0] as Element;
 
         const clone = dom5.cloneNode(span);
 
@@ -429,9 +502,9 @@ suite('dom5', () => {
         assert.equal(dom5.getAttribute(clone, 'foo'), 'bar');
 
         assert.equal(clone.childNodes![0].nodeName, '#text');
-        assert.equal(clone.childNodes![0].value, 'a');
+        assert.equal((clone.childNodes![0] as TextNode).value, 'a');
         assert.equal(span.childNodes![0].nodeName, '#text');
-        assert.equal(span.childNodes![0].value, 'a');
+        assert.equal((span.childNodes![0] as TextNode).value, 'a');
         assert.notStrictEqual(clone.childNodes![0], span.childNodes![0]);
       });
     });
@@ -440,9 +513,10 @@ suite('dom5', () => {
   suite('Query Predicates', () => {
     const fragText =
         '<div id="a" class="b c"><!-- nametag -->Hello World</div>';
-    let frag: parse5.ASTNode;
+    let frag: DocumentFragment;
+
     suiteSetup(() => {
-      frag = parse5.parseFragment(fragText).childNodes![0];
+      frag = parseFragment(fragText).childNodes![0];
     });
 
     test('hasTagName', () => {
@@ -555,7 +629,7 @@ suite('dom5', () => {
     test('parentMatches', () => {
       const fragText =
           '<div class="a"><div class="b"><div class="c"></div></div></div>';
-      const frag = parse5.parseFragment(fragText);
+      const frag = parseFragment(fragText);
       const fn = dom5.predicates.parentMatches(dom5.predicates.hasClass('a'));
       assert.isFalse(fn(frag.childNodes![0]));                // a
       assert.isTrue(fn(frag.childNodes![0].childNodes![0]));  // b
@@ -673,7 +747,7 @@ suite('dom5', () => {
     });
 
     test('document can be normalized', () => {
-      const doc = parse5.parse('<!DOCTYPE html>');
+      const doc = parse('<!DOCTYPE html>');
       const body = doc.childNodes![1].childNodes![1];
       const div = con.element('div');
       const tn1 = con.text('foo');

--- a/packages/dom5/src/test/dom5_test.ts
+++ b/packages/dom5/src/test/dom5_test.ts
@@ -10,18 +10,7 @@
  */
 
 import {assert} from 'chai';
-import {
-  parse,
-  parseFragment,
-  serialize,
-  DefaultTreeNode as Node,
-  DefaultTreeElement as Element,
-  DefaultTreeParentNode as ParentNode,
-  DefaultTreeTextNode as TextNode,
-  DefaultTreeChildNode as ChildNode,
-  DefaultTreeDocument as Document,
-  DefaultTreeDocumentFragment as DocumentFragment
-} from 'parse5';
+import {ChildNode, Document, DocumentFragment, Element, Node, ParentNode, parse, parseFragment, serialize, TextNode} from 'parse5';
 
 import * as dom5 from '../index';
 
@@ -37,119 +26,107 @@ suite('dom5', () => {
     let doc: Document;
 
     setup(() => {
-      doc = parse(docText) as Document;
+      doc = parse(docText);
     });
 
     suite('Node Identity', () => {
       test('isElement', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         assert(dom5.isElement(divA));
       });
 
       test('isTextNode', () => {
         const textA1 =
-            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                 .childNodes![0] as ParentNode)
-                .childNodes![0];
+            (((doc.childNodes[1] as Element).childNodes[1] as Element)
+                 .childNodes[0] as Element)
+                .childNodes[0];
         assert(dom5.isTextNode(textA1));
       });
 
       test('isCommentNode', () => {
         const commentEnd =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes!.slice(-1)[0];
+            ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                .childNodes.slice(-1)[0];
         assert(dom5.isCommentNode(commentEnd));
       });
     });
 
     suite('getAttribute', () => {
       test('returns null for a non-set attribute', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         assert.equal(dom5.getAttribute(divA, 'foo'), null);
       });
 
       test('returns the value for a set attribute', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         assert.equal(dom5.getAttribute(divA, 'id'), 'A');
       });
 
       test('returns the first value for a doubly set attribute', () => {
-        const divB =
-            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                 .childNodes![0] as ParentNode)
-                .childNodes![1];
+        const divB = (((doc.childNodes[1] as Element).childNodes[1] as Element)
+                          .childNodes[0] as Element)
+                         .childNodes[1];
         assert.equal(dom5.getAttribute(divB, 'bar'), 'b1');
       });
     });
 
     suite('hasAttribute', () => {
       test('returns false for a non-set attribute', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         assert.equal(dom5.hasAttribute(divA, 'foo'), false);
       });
 
       test('returns true for a set attribute', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         assert.equal(dom5.hasAttribute(divA, 'id'), true);
       });
 
       test('returns true for a doubly set attribute', () => {
-        const divB =
-            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                 .childNodes![0] as ParentNode)
-                .childNodes![1];
+        const divB = (((doc.childNodes[1] as Element).childNodes[1] as Element)
+                          .childNodes[0] as Element)
+                         .childNodes[1];
         assert.equal(dom5.hasAttribute(divB, 'bar'), true);
       });
 
       test('returns true for attribute with no value', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         assert.equal(dom5.hasAttribute(divA, 'qux'), true);
       });
     });
 
     suite('setAttribute', () => {
       test('sets a non-set attribute', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         dom5.setAttribute(divA, 'foo', 'bar');
         assert.equal(dom5.getAttribute(divA, 'foo'), 'bar');
       });
 
       test('sets and already set attribute', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         dom5.setAttribute(divA, 'id', 'qux');
         assert.equal(dom5.getAttribute(divA, 'id'), 'qux');
       });
 
       test('sets the first value for a doubly set attribute', () => {
-        const divB =
-            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                 .childNodes![0] as ParentNode)
-                .childNodes![1];
+        const divB = (((doc.childNodes[1] as Element).childNodes[1] as Element)
+                          .childNodes[0] as Element)
+                         .childNodes[1];
         dom5.setAttribute(divB, 'bar', 'baz');
         assert.equal(dom5.getAttribute(divB, 'bar'), 'baz');
       });
 
       test('throws when called on a text node', () => {
-        const text =
-            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                 .childNodes![0] as ParentNode)
-                .childNodes![0];
+        const text = (((doc.childNodes[1] as Element).childNodes[1] as Element)
+                          .childNodes[0] as Element)
+                         .childNodes[0];
         assert.throws(() => {
           dom5.setAttribute(text, 'bar', 'baz');
         });
@@ -158,18 +135,17 @@ suite('dom5', () => {
 
     suite('removeAttribute', () => {
       test('removes a set attribute', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         dom5.removeAttribute(divA, 'foo');
         assert.equal(dom5.getAttribute(divA, 'foo'), null);
       });
 
       test(
           'does not throw when called on a node without that attribute', () => {
-            const divA = ((doc.childNodes![1] as ParentNode).childNodes![1] as
-                          ParentNode)
-                             .childNodes![0];
+            const divA =
+                ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                    .childNodes[0];
             assert.doesNotThrow(() => {
               dom5.removeAttribute(divA, 'ZZZ');
             });
@@ -180,25 +156,25 @@ suite('dom5', () => {
       let body: ParentNode;
 
       suiteSetup(() => {
-        body = (doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode;
+        body = (doc.childNodes[1] as Element).childNodes[1] as Element;
       });
 
       test('text node', () => {
-        const node = (body.childNodes![0] as ParentNode).childNodes![0];
+        const node = (body.childNodes[0] as Element).childNodes[0];
         const expected = 'a1';
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
       });
 
       test('comment node', () => {
-        const node = body.childNodes!.slice(-1)[0];
+        const node = body.childNodes.slice(-1)[0];
         const expected = ' comment ';
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
       });
 
       test('leaf element', () => {
-        const node = (body.childNodes![0] as ParentNode).childNodes![1];
+        const node = (body.childNodes[0] as Element).childNodes[1];
         const expected = 'b1';
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
@@ -215,102 +191,97 @@ suite('dom5', () => {
       let body: ParentNode;
       const expected = 'test';
 
-      suiteSetup(
-          () => {body = (doc.childNodes![1] as ParentNode).childNodes![1] as
-                     ParentNode});
+      suiteSetup(() => {
+        body = (doc.childNodes[1] as Element).childNodes[1] as Element;
+      });
 
       test('text node', () => {
-        const node = (body.childNodes![0] as ParentNode).childNodes![0];
+        const node = (body.childNodes[0] as Element).childNodes[0];
         dom5.setTextContent(node, expected);
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
       });
 
       test('comment node', () => {
-        const node = body.childNodes!.slice(-1)[0];
+        const node = body.childNodes.slice(-1)[0];
         dom5.setTextContent(node, expected);
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
       });
 
       test('leaf element', () => {
-        const node =
-            (body.childNodes![0] as ParentNode).childNodes![1] as ParentNode;
+        const node = (body.childNodes[0] as Element).childNodes[1] as Element;
         dom5.setTextContent(node, expected);
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
-        assert.equal(node.childNodes!.length, 1);
+        assert.equal(node.childNodes.length, 1);
       });
 
       test('recursive element', () => {
         dom5.setTextContent(body, expected);
         const actual = dom5.getTextContent(body);
         assert.equal(actual, expected);
-        assert.equal(body.childNodes!.length, 1);
+        assert.equal(body.childNodes.length, 1);
       });
     });
 
     suite('Replace node', () => {
       test('New node replaces old node', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         const newNode = dom5.constructors.element('ul');
         dom5.replace(divA, newNode);
-        assert.equal((divA as ChildNode).parentNode, null);
+        assert.equal(divA.parentNode, null);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes!.indexOf(divA),
+            ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                .childNodes.indexOf(divA),
             -1);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes!.indexOf(newNode),
+            ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                .childNodes.indexOf(newNode),
             0);
       });
 
       test('accepts document fragments', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0];
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0];
         const fragment = dom5.constructors.fragment();
         const span = dom5.constructors.element('span');
         const text = dom5.constructors.text('foo');
-        fragment.childNodes!.push(span);
-        fragment.childNodes!.push(text);
+        fragment.childNodes.push(span);
+        fragment.childNodes.push(text);
 
         dom5.replace(divA, fragment);
 
-        assert.equal((divA as ChildNode).parentNode, null);
+        assert.equal(divA.parentNode, null);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes!.indexOf(divA),
+            ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                .childNodes.indexOf(divA),
             -1);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes!.indexOf(span),
+            ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                .childNodes.indexOf(span),
             0);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes!.indexOf(text),
+            ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                .childNodes.indexOf(text),
             1);
       });
     });
 
     suite('Remove node', () => {
       test('node is removed from parentNode', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0] as ChildNode;
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0] as ChildNode;
         const parent = divA.parentNode!;
         dom5.remove(divA);
         assert.equal(divA.parentNode, null);
-        assert.equal(parent.childNodes!.indexOf(divA), -1);
+        assert.equal(parent.childNodes.indexOf(divA), -1);
       });
 
       test('removed nodes do not throw', () => {
-        const divA =
-            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-                .childNodes![0] as ChildNode;
+        const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0] as ChildNode;
         dom5.remove(divA);
         dom5.remove(divA);
         assert.equal(divA.parentNode, null);
@@ -320,9 +291,8 @@ suite('dom5', () => {
     suite('Remove node, save children', () => {
       test('node is removed and children at same position', () => {
         const html = '<div><em>x</em><span><em>a</em><em>c</em></span>y</div>';
-        const ast = parseFragment(html) as DocumentFragment;
-        const span =
-            (ast.childNodes![0] as ParentNode).childNodes![1]! as Element;
+        const ast = parseFragment(html);
+        const span = (ast.childNodes[0] as Element).childNodes[1] as Element;
         dom5.removeNodeSaveChildren(span);
         assert.deepEqual(
             serialize(ast), '<div><em>x</em><em>a</em><em>c</em>y</div>');
@@ -332,7 +302,7 @@ suite('dom5', () => {
     suite('Remove fake root elements from tree', () => {
       test('Fake root elements will be removed', () => {
         const html = `<div>Just a div</div>`;
-        const ast = parse(html, {sourceCodeLocationInfo: true}) as Document;
+        const ast = parse(html, {sourceCodeLocationInfo: true});
         assert.deepEqual(
             serialize(ast),
             '<html><head></head><body><div>Just a div</div></body></html>');
@@ -343,7 +313,7 @@ suite('dom5', () => {
       test('Real root elements will be preserved', () => {
         const html =
             '<html><head></head><body><div>Just a div</div></body></html>';
-        const ast = parse(html, {sourceCodeLocationInfo: true}) as Document;
+        const ast = parse(html, {sourceCodeLocationInfo: true});
         assert.deepEqual(serialize(ast), html);
         dom5.removeFakeRootElements(ast);
         assert.deepEqual(serialize(ast), html);
@@ -354,34 +324,34 @@ suite('dom5', () => {
       let dom: DocumentFragment, div: Element, span: Element;
 
       setup(() => {
-        dom = parseFragment('<div>a</div><span></span>b') as DocumentFragment;
-        div = dom.childNodes![0] as Element;
-        span = dom.childNodes![1] as Element;
+        dom = parseFragment('<div>a</div><span></span>b');
+        div = dom.childNodes[0] as Element;
+        span = dom.childNodes[1] as Element;
       });
 
       test('node is only in one parent', () => {
-        const b = dom.childNodes!.slice(-1)[0] as Element;
+        const b = dom.childNodes.slice(-1)[0] as Element;
         dom5.append(span, b);
         assert.equal(b.parentNode, span);
-        assert.equal(dom.childNodes!.indexOf(b), -1);
+        assert.equal(dom.childNodes.indexOf(b), -1);
       });
 
       test('node is appended to the end of childNodes', () => {
-        let bidx = dom.childNodes!.length - 1;
-        const b = dom.childNodes![bidx];
+        let bidx = dom.childNodes.length - 1;
+        const b = dom.childNodes[bidx];
         dom5.append(div, b);
-        bidx = div.childNodes!.length - 1;
-        assert.equal(div.childNodes![bidx], b);
+        bidx = div.childNodes.length - 1;
+        assert.equal(div.childNodes[bidx], b);
       });
 
       test('a node that is appended to its current parent is reordered', () => {
-        const bidx = dom.childNodes!.length - 1;
-        const b = dom.childNodes![bidx];
-        const a = div.childNodes![0];
+        const bidx = dom.childNodes.length - 1;
+        const b = dom.childNodes[bidx];
+        const a = div.childNodes[0];
         dom5.append(div, b);
         dom5.append(div, a);
-        assert.equal(div.childNodes![0], b);
-        assert.equal(div.childNodes![1], a);
+        assert.equal(div.childNodes[0], b);
+        assert.equal(div.childNodes[1], a);
       });
 
       test('accepts document fragments', () => {
@@ -389,73 +359,76 @@ suite('dom5', () => {
         const span = dom5.constructors.element('span');
         const text = dom5.constructors.text('foo');
         // hold a reference to make sure append() clears childNodes
-        const fragmentChildren = fragment.childNodes!;
+        const fragmentChildren = fragment.childNodes;
         fragmentChildren.push(span);
         fragmentChildren.push(text);
 
         dom5.append(div, fragment);
 
-        assert.equal(div.childNodes!.indexOf(span), 1);
-        assert.equal(div.childNodes!.indexOf(text), 2);
-        assert.equal(fragment.childNodes!.length, 0);
+        assert.equal(div.childNodes.indexOf(span), 1);
+        assert.equal(div.childNodes.indexOf(text), 2);
+        assert.equal(fragment.childNodes.length, 0);
         assert.equal(fragmentChildren.length, 0);
       });
 
       test('append to node with no children', () => {
-        const emptyBody = parse('<head></head><body></body>') as Document;
-        const body = (emptyBody.childNodes![0] as ParentNode).childNodes![1] as
-            ParentNode;
+        const emptyBody = parse('<head></head><body></body>');
+        const body =
+            (emptyBody.childNodes[0] as Element).childNodes[1] as Element;
         const span = dom5.constructors.element('span');
         dom5.append(body, span);
 
-        assert.equal(body.childNodes!.length, 1);
+        assert.equal(body.childNodes.length, 1);
       });
     });
 
     suite('InsertBefore', () => {
-      let dom: DocumentFragment, div: Element, span: Element, text: Node;
+      let dom: DocumentFragment;
+      let div: Element;
+      let span: Element;
+      let text: ChildNode;
 
       setup(() => {
-        dom = parseFragment('<div></div><span></span>text') as DocumentFragment;
-        div = dom.childNodes![0] as Element;
-        span = dom.childNodes![1] as Element;
-        text = dom.childNodes![2];
+        dom = parseFragment('<div></div><span></span>text');
+        div = dom.childNodes[0] as Element;
+        span = dom.childNodes[1] as Element;
+        text = dom.childNodes[2];
       });
 
       test('ordering is correct', () => {
         dom5.insertBefore(dom, span, text);
-        assert.equal(dom.childNodes!.indexOf(text), 1);
+        assert.equal(dom.childNodes.indexOf(text), 1);
         const newHtml = serialize(dom);
         assert.equal(newHtml, '<div></div>text<span></span>');
         dom5.insertBefore(dom, div, text);
-        assert.equal(dom.childNodes!.indexOf(text), 0);
+        assert.equal(dom.childNodes.indexOf(text), 0);
       });
 
       test('accepts document fragments', () => {
         const fragment = dom5.constructors.fragment();
         const span2 = dom5.constructors.element('span');
         const text2 = dom5.constructors.text('foo');
-        fragment.childNodes!.push(span2);
-        fragment.childNodes!.push(text2);
+        fragment.childNodes.push(span2);
+        fragment.childNodes.push(text2);
 
         dom5.insertBefore(dom, span, fragment);
-        assert.equal(dom.childNodes!.indexOf(span2), 1);
-        assert.equal(dom.childNodes!.indexOf(text2), 2);
-        assert.equal(dom.childNodes!.indexOf(span), 3);
-        assert.equal(dom.childNodes!.indexOf(text), 4);
-        assert.equal(fragment.childNodes!.length, 0);
+        assert.equal(dom.childNodes.indexOf(span2), 1);
+        assert.equal(dom.childNodes.indexOf(text2), 2);
+        assert.equal(dom.childNodes.indexOf(span), 3);
+        assert.equal(dom.childNodes.indexOf(text), 4);
+        assert.equal(fragment.childNodes.length, 0);
       });
     });
 
     suite('insertAfter', () => {
       let dom: DocumentFragment;
-      let div: Node;
-      let span: Node;
-      let text: Node;
+      let div: ChildNode;
+      let span: ChildNode;
+      let text: ChildNode;
 
       setup(() => {
-        dom = parseFragment('<div></div><span></span>text') as DocumentFragment;
-        [div, span, text] = dom.childNodes!;
+        dom = parseFragment('<div></div><span></span>text');
+        [div, span, text] = dom.childNodes;
       });
 
       test('ordering is correct', () => {
@@ -466,11 +439,11 @@ suite('dom5', () => {
       });
 
       test('accepts document fragments', () => {
-        const fragment = parseFragment('<span></span>foo') as DocumentFragment;
+        const fragment = parseFragment('<span></span>foo');
         dom5.insertAfter(dom, span, fragment);
         assert.equal(
             serialize(dom), '<div></div><span></span><span></span>footext');
-        assert.equal(fragment.childNodes!.length, 0);
+        assert.equal(fragment.childNodes.length, 0);
       });
     });
 
@@ -478,8 +451,8 @@ suite('dom5', () => {
       test('clones a node', () => {
         const dom = parseFragment('<div><span foo="bar">a</span></div>') as
             DocumentFragment;
-        const div = dom.childNodes![0] as Element;
-        const span = div.childNodes![0] as Element;
+        const div = dom.childNodes[0] as Element;
+        const span = div.childNodes[0] as Element;
 
         const clone = dom5.cloneNode(span);
 
@@ -489,11 +462,11 @@ suite('dom5', () => {
         assert.equal(clone.tagName, 'span');
         assert.equal(dom5.getAttribute(clone, 'foo'), 'bar');
 
-        assert.equal(clone.childNodes![0].nodeName, '#text');
-        assert.equal((clone.childNodes![0] as TextNode).value, 'a');
-        assert.equal(span.childNodes![0].nodeName, '#text');
-        assert.equal((span.childNodes![0] as TextNode).value, 'a');
-        assert.notStrictEqual(clone.childNodes![0], span.childNodes![0]);
+        assert.equal(clone.childNodes[0].nodeName, '#text');
+        assert.equal((clone.childNodes[0] as TextNode).value, 'a');
+        assert.equal(span.childNodes[0].nodeName, '#text');
+        assert.equal((span.childNodes[0] as TextNode).value, 'a');
+        assert.notStrictEqual(clone.childNodes[0], span.childNodes[0]);
       });
     });
   });
@@ -504,8 +477,7 @@ suite('dom5', () => {
     let frag: Element;
 
     suiteSetup(() => {
-      frag = (parseFragment(fragText) as DocumentFragment).childNodes![0] as
-          Element;
+      frag = parseFragment(fragText).childNodes[0] as Element;
     });
 
     test('hasTagName', () => {
@@ -562,9 +534,9 @@ suite('dom5', () => {
       let fn = dom5.predicates.hasTextValue('Hello World');
       assert.isFunction(fn);
       assert.isTrue(fn(frag));
-      const textNode = frag.childNodes![1];
+      const textNode = frag.childNodes[1];
       assert.isTrue(fn(textNode));
-      const commentNode = frag.childNodes![0];
+      const commentNode = frag.childNodes[0];
       fn = dom5.predicates.hasTextValue(' nametag ');
       assert.isTrue(fn(commentNode));
     });
@@ -618,14 +590,13 @@ suite('dom5', () => {
     test('parentMatches', () => {
       const fragText =
           '<div class="a"><div class="b"><div class="c"></div></div></div>';
-      const frag = parseFragment(fragText) as DocumentFragment;
+      const frag = parseFragment(fragText);
       const fn = dom5.predicates.parentMatches(dom5.predicates.hasClass('a'));
-      assert.isFalse(fn(frag.childNodes![0]));  // a
+      assert.isFalse(fn(frag.childNodes[0]));                            // a
+      assert.isTrue(fn((frag.childNodes[0] as Element).childNodes[0]));  // b
       assert.isTrue(
-          fn((frag.childNodes![0] as ParentNode).childNodes![0]));  // b
-      assert.isTrue(
-          fn(((frag.childNodes![0] as ParentNode).childNodes![0] as ParentNode)
-                 .childNodes![0]));  // c
+          fn(((frag.childNodes[0] as Element).childNodes[0] as Element)
+                 .childNodes[0]));  // c
     });
   });
 
@@ -680,7 +651,7 @@ suite('dom5', () => {
       const actual = dom5.getTextContent(div);
 
       assert.equal(actual, expected);
-      assert.equal(div.childNodes!.length, 1);
+      assert.equal(div.childNodes.length, 1);
     });
 
     test('only text node ranges are merged', () => {
@@ -700,10 +671,10 @@ suite('dom5', () => {
       const actual = dom5.getTextContent(div);
 
       assert.equal(actual, expected);
-      assert.equal(div.childNodes!.length, 3);
-      assert.equal(dom5.getTextContent(div.childNodes![0]), 'foobar');
-      assert.equal(dom5.getTextContent(div.childNodes![1]), 'combobreaker');
-      assert.equal(dom5.getTextContent(div.childNodes![2]), 'quux');
+      assert.equal(div.childNodes.length, 3);
+      assert.equal(dom5.getTextContent(div.childNodes[0]), 'foobar');
+      assert.equal(dom5.getTextContent(div.childNodes[1]), 'combobreaker');
+      assert.equal(dom5.getTextContent(div.childNodes[2]), 'quux');
     });
 
     test('empty text nodes are removed', () => {
@@ -711,9 +682,9 @@ suite('dom5', () => {
       const tn = con.text('');
       dom5.append(div, tn);
 
-      assert.equal(div.childNodes!.length, 1);
+      assert.equal(div.childNodes.length, 1);
       dom5.normalize(div);
-      assert.equal(div.childNodes!.length, 0);
+      assert.equal(div.childNodes.length, 0);
     });
 
     test('elements are recursively normalized', () => {
@@ -733,14 +704,13 @@ suite('dom5', () => {
 
       dom5.normalize(div);
 
-      assert.equal(div.childNodes!.length, 2);
-      assert.equal(span.childNodes!.length, 1);
+      assert.equal(div.childNodes.length, 2);
+      assert.equal(span.childNodes.length, 1);
     });
 
     test('document can be normalized', () => {
-      const doc = parse('<!DOCTYPE html>') as Document;
-      const body =
-          (doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode;
+      const doc = parse('<!DOCTYPE html>');
+      const body = (doc.childNodes[1] as Element).childNodes[1] as Element;
       const div = con.element('div');
       const tn1 = con.text('foo');
       const space = con.text('');
@@ -758,8 +728,8 @@ suite('dom5', () => {
       dom5.normalize(doc);
       assert.equal(dom5.getTextContent(doc), 'foobarbaz');
 
-      assert.equal(div.childNodes!.length, 2);
-      assert.equal(span.childNodes!.length, 1);
+      assert.equal(div.childNodes.length, 2);
+      assert.equal(span.childNodes.length, 1);
     });
   });
 });

--- a/packages/dom5/src/test/dom5_test.ts
+++ b/packages/dom5/src/test/dom5_test.ts
@@ -37,125 +37,119 @@ suite('dom5', () => {
     let doc: Document;
 
     setup(() => {
-      doc = parse(docText);
+      doc = parse(docText) as Document;
     });
 
     suite('Node Identity', () => {
       test('isElement', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         assert(dom5.isElement(divA));
       });
 
       test('isTextNode', () => {
         const textA1 =
-            (((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes![0] as ParentNode)
-              .childNodes![0];
+            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                 .childNodes![0] as ParentNode)
+                .childNodes![0];
         assert(dom5.isTextNode(textA1));
       });
 
       test('isCommentNode', () => {
         const commentEnd =
-            ((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes!.slice(-1)[0];
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes!.slice(-1)[0];
         assert(dom5.isCommentNode(commentEnd));
       });
     });
 
     suite('getAttribute', () => {
       test('returns null for a non-set attribute', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         assert.equal(dom5.getAttribute(divA, 'foo'), null);
       });
 
       test('returns the value for a set attribute', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         assert.equal(dom5.getAttribute(divA, 'id'), 'A');
       });
 
       test('returns the first value for a doubly set attribute', () => {
         const divB =
-            (((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes![0] as ParentNode)
-              .childNodes![1];
+            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                 .childNodes![0] as ParentNode)
+                .childNodes![1];
         assert.equal(dom5.getAttribute(divB, 'bar'), 'b1');
       });
     });
 
     suite('hasAttribute', () => {
       test('returns false for a non-set attribute', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         assert.equal(dom5.hasAttribute(divA, 'foo'), false);
       });
 
       test('returns true for a set attribute', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         assert.equal(dom5.hasAttribute(divA, 'id'), true);
       });
 
       test('returns true for a doubly set attribute', () => {
         const divB =
-            (((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes![0] as ParentNode)
-              .childNodes![1];
+            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                 .childNodes![0] as ParentNode)
+                .childNodes![1];
         assert.equal(dom5.hasAttribute(divB, 'bar'), true);
       });
 
       test('returns true for attribute with no value', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         assert.equal(dom5.hasAttribute(divA, 'qux'), true);
       });
     });
 
     suite('setAttribute', () => {
       test('sets a non-set attribute', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         dom5.setAttribute(divA, 'foo', 'bar');
         assert.equal(dom5.getAttribute(divA, 'foo'), 'bar');
       });
 
       test('sets and already set attribute', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         dom5.setAttribute(divA, 'id', 'qux');
         assert.equal(dom5.getAttribute(divA, 'id'), 'qux');
       });
 
       test('sets the first value for a doubly set attribute', () => {
         const divB =
-            (((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes![0] as ParentNode)
-              .childNodes![1];
+            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                 .childNodes![0] as ParentNode)
+                .childNodes![1];
         dom5.setAttribute(divB, 'bar', 'baz');
         assert.equal(dom5.getAttribute(divB, 'bar'), 'baz');
       });
 
       test('throws when called on a text node', () => {
         const text =
-            (((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes![0] as ParentNode)
-              .childNodes![0];
+            (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                 .childNodes![0] as ParentNode)
+                .childNodes![0];
         assert.throws(() => {
           dom5.setAttribute(text, 'bar', 'baz');
         });
@@ -164,18 +158,18 @@ suite('dom5', () => {
 
     suite('removeAttribute', () => {
       test('removes a set attribute', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         dom5.removeAttribute(divA, 'foo');
         assert.equal(dom5.getAttribute(divA, 'foo'), null);
       });
 
       test(
           'does not throw when called on a node without that attribute', () => {
-            const divA = ((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes![0];
+            const divA = ((doc.childNodes![1] as ParentNode).childNodes![1] as
+                          ParentNode)
+                             .childNodes![0];
             assert.doesNotThrow(() => {
               dom5.removeAttribute(divA, 'ZZZ');
             });
@@ -186,13 +180,11 @@ suite('dom5', () => {
       let body: ParentNode;
 
       suiteSetup(() => {
-        body = (doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode;
+        body = (doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode;
       });
 
       test('text node', () => {
-        const node = (body.childNodes![0] as ParentNode)
-          .childNodes![0];
+        const node = (body.childNodes![0] as ParentNode).childNodes![0];
         const expected = 'a1';
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
@@ -206,8 +198,7 @@ suite('dom5', () => {
       });
 
       test('leaf element', () => {
-        const node = (body.childNodes![0] as ParentNode)
-          .childNodes![1];
+        const node = (body.childNodes![0] as ParentNode).childNodes![1];
         const expected = 'b1';
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
@@ -224,14 +215,12 @@ suite('dom5', () => {
       let body: ParentNode;
       const expected = 'test';
 
-      suiteSetup(() => {
-        body = (doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode
-      });
+      suiteSetup(
+          () => {body = (doc.childNodes![1] as ParentNode).childNodes![1] as
+                     ParentNode});
 
       test('text node', () => {
-        const node = (body.childNodes![0] as ParentNode)
-          .childNodes![0];
+        const node = (body.childNodes![0] as ParentNode).childNodes![0];
         dom5.setTextContent(node, expected);
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
@@ -245,8 +234,8 @@ suite('dom5', () => {
       });
 
       test('leaf element', () => {
-        const node = (body.childNodes![0] as ParentNode)
-          .childNodes![1] as ParentNode;
+        const node =
+            (body.childNodes![0] as ParentNode).childNodes![1] as ParentNode;
         dom5.setTextContent(node, expected);
         const actual = dom5.getTextContent(node);
         assert.equal(actual, expected);
@@ -263,26 +252,26 @@ suite('dom5', () => {
 
     suite('Replace node', () => {
       test('New node replaces old node', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         const newNode = dom5.constructors.element('ul');
         dom5.replace(divA, newNode);
         assert.equal((divA as ChildNode).parentNode, null);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes!.indexOf(divA), -1);
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes!.indexOf(divA),
+            -1);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes!.indexOf(newNode), 0);
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes!.indexOf(newNode),
+            0);
       });
 
       test('accepts document fragments', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0];
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0];
         const fragment = dom5.constructors.fragment();
         const span = dom5.constructors.element('span');
         const text = dom5.constructors.text('foo');
@@ -293,25 +282,25 @@ suite('dom5', () => {
 
         assert.equal((divA as ChildNode).parentNode, null);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes!.indexOf(divA), -1);
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes!.indexOf(divA),
+            -1);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes!.indexOf(span), 0);
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes!.indexOf(span),
+            0);
         assert.equal(
-            ((doc.childNodes![1] as ParentNode)
-              .childNodes![1] as ParentNode)
-              .childNodes!.indexOf(text), 1);
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes!.indexOf(text),
+            1);
       });
     });
 
     suite('Remove node', () => {
       test('node is removed from parentNode', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0] as ChildNode;
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0] as ChildNode;
         const parent = divA.parentNode!;
         dom5.remove(divA);
         assert.equal(divA.parentNode, null);
@@ -319,9 +308,9 @@ suite('dom5', () => {
       });
 
       test('removed nodes do not throw', () => {
-        const divA = ((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0] as ChildNode;
+        const divA =
+            ((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+                .childNodes![0] as ChildNode;
         dom5.remove(divA);
         dom5.remove(divA);
         assert.equal(divA.parentNode, null);
@@ -331,20 +320,19 @@ suite('dom5', () => {
     suite('Remove node, save children', () => {
       test('node is removed and children at same position', () => {
         const html = '<div><em>x</em><span><em>a</em><em>c</em></span>y</div>';
-        const ast = parseFragment(html);
-        const span = (ast.childNodes![0] as ParentNode)
-          .childNodes![1]! as Element;
+        const ast = parseFragment(html) as DocumentFragment;
+        const span =
+            (ast.childNodes![0] as ParentNode).childNodes![1]! as Element;
         dom5.removeNodeSaveChildren(span);
         assert.deepEqual(
-            serialize(ast),
-            '<div><em>x</em><em>a</em><em>c</em>y</div>');
+            serialize(ast), '<div><em>x</em><em>a</em><em>c</em>y</div>');
       });
     });
 
     suite('Remove fake root elements from tree', () => {
       test('Fake root elements will be removed', () => {
         const html = `<div>Just a div</div>`;
-        const ast = parse(html, {sourceCodeLocationInfo: true});
+        const ast = parse(html, {sourceCodeLocationInfo: true}) as Document;
         assert.deepEqual(
             serialize(ast),
             '<html><head></head><body><div>Just a div</div></body></html>');
@@ -355,7 +343,7 @@ suite('dom5', () => {
       test('Real root elements will be preserved', () => {
         const html =
             '<html><head></head><body><div>Just a div</div></body></html>';
-        const ast = parse(html, {sourceCodeLocationInfo: true});
+        const ast = parse(html, {sourceCodeLocationInfo: true}) as Document;
         assert.deepEqual(serialize(ast), html);
         dom5.removeFakeRootElements(ast);
         assert.deepEqual(serialize(ast), html);
@@ -366,7 +354,7 @@ suite('dom5', () => {
       let dom: DocumentFragment, div: Element, span: Element;
 
       setup(() => {
-        dom = parseFragment('<div>a</div><span></span>b');
+        dom = parseFragment('<div>a</div><span></span>b') as DocumentFragment;
         div = dom.childNodes![0] as Element;
         span = dom.childNodes![1] as Element;
       });
@@ -414,8 +402,9 @@ suite('dom5', () => {
       });
 
       test('append to node with no children', () => {
-        const emptyBody = parse('<head></head><body></body>');
-        const body = emptyBody.childNodes![0].childNodes![1];
+        const emptyBody = parse('<head></head><body></body>') as Document;
+        const body = (emptyBody.childNodes![0] as ParentNode).childNodes![1] as
+            ParentNode;
         const span = dom5.constructors.element('span');
         dom5.append(body, span);
 
@@ -424,11 +413,10 @@ suite('dom5', () => {
     });
 
     suite('InsertBefore', () => {
-      let dom: DocumentFragment, div: Element, span: Element,
-          text: Node;
+      let dom: DocumentFragment, div: Element, span: Element, text: Node;
 
       setup(() => {
-        dom = parseFragment('<div></div><span></span>text');
+        dom = parseFragment('<div></div><span></span>text') as DocumentFragment;
         div = dom.childNodes![0] as Element;
         span = dom.childNodes![1] as Element;
         text = dom.childNodes![2];
@@ -466,7 +454,7 @@ suite('dom5', () => {
       let text: Node;
 
       setup(() => {
-        dom = parseFragment('<div></div><span></span>text');
+        dom = parseFragment('<div></div><span></span>text') as DocumentFragment;
         [div, span, text] = dom.childNodes!;
       });
 
@@ -478,18 +466,18 @@ suite('dom5', () => {
       });
 
       test('accepts document fragments', () => {
-        const fragment = parseFragment('<span></span>foo');
+        const fragment = parseFragment('<span></span>foo') as DocumentFragment;
         dom5.insertAfter(dom, span, fragment);
         assert.equal(
-            serialize(dom),
-            '<div></div><span></span><span></span>footext');
+            serialize(dom), '<div></div><span></span><span></span>footext');
         assert.equal(fragment.childNodes!.length, 0);
       });
     });
 
     suite('cloneNode', () => {
       test('clones a node', () => {
-        const dom = parseFragment('<div><span foo="bar">a</span></div>');
+        const dom = parseFragment('<div><span foo="bar">a</span></div>') as
+            DocumentFragment;
         const div = dom.childNodes![0] as Element;
         const span = div.childNodes![0] as Element;
 
@@ -513,10 +501,11 @@ suite('dom5', () => {
   suite('Query Predicates', () => {
     const fragText =
         '<div id="a" class="b c"><!-- nametag -->Hello World</div>';
-    let frag: DocumentFragment;
+    let frag: Element;
 
     suiteSetup(() => {
-      frag = parseFragment(fragText).childNodes![0];
+      frag = (parseFragment(fragText) as DocumentFragment).childNodes![0] as
+          Element;
     });
 
     test('hasTagName', () => {
@@ -629,12 +618,14 @@ suite('dom5', () => {
     test('parentMatches', () => {
       const fragText =
           '<div class="a"><div class="b"><div class="c"></div></div></div>';
-      const frag = parseFragment(fragText);
+      const frag = parseFragment(fragText) as DocumentFragment;
       const fn = dom5.predicates.parentMatches(dom5.predicates.hasClass('a'));
-      assert.isFalse(fn(frag.childNodes![0]));                // a
-      assert.isTrue(fn(frag.childNodes![0].childNodes![0]));  // b
+      assert.isFalse(fn(frag.childNodes![0]));  // a
       assert.isTrue(
-          fn(frag.childNodes![0].childNodes![0].childNodes![0]));  // c
+          fn((frag.childNodes![0] as ParentNode).childNodes![0]));  // b
+      assert.isTrue(
+          fn(((frag.childNodes![0] as ParentNode).childNodes![0] as ParentNode)
+                 .childNodes![0]));  // c
     });
   });
 
@@ -747,8 +738,9 @@ suite('dom5', () => {
     });
 
     test('document can be normalized', () => {
-      const doc = parse('<!DOCTYPE html>');
-      const body = doc.childNodes![1].childNodes![1];
+      const doc = parse('<!DOCTYPE html>') as Document;
+      const body =
+          (doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode;
       const div = con.element('div');
       const tn1 = con.text('foo');
       const space = con.text('');

--- a/packages/dom5/src/test/dom5_test.ts
+++ b/packages/dom5/src/test/dom5_test.ts
@@ -55,20 +55,20 @@ suite('dom5', () => {
     suite('getAttribute', () => {
       test('returns null for a non-set attribute', () => {
         const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
-                         .childNodes[0];
+                         .childNodes[0] as Element;
         assert.equal(dom5.getAttribute(divA, 'foo'), null);
       });
 
       test('returns the value for a set attribute', () => {
         const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
-                         .childNodes[0];
+                         .childNodes[0] as Element;
         assert.equal(dom5.getAttribute(divA, 'id'), 'A');
       });
 
       test('returns the first value for a doubly set attribute', () => {
         const divB = (((doc.childNodes[1] as Element).childNodes[1] as Element)
                           .childNodes[0] as Element)
-                         .childNodes[1];
+                         .childNodes[1] as Element;
         assert.equal(dom5.getAttribute(divB, 'bar'), 'b1');
       });
     });
@@ -76,26 +76,26 @@ suite('dom5', () => {
     suite('hasAttribute', () => {
       test('returns false for a non-set attribute', () => {
         const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
-                         .childNodes[0];
+                         .childNodes[0] as Element;
         assert.equal(dom5.hasAttribute(divA, 'foo'), false);
       });
 
       test('returns true for a set attribute', () => {
         const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
-                         .childNodes[0];
+                         .childNodes[0] as Element;
         assert.equal(dom5.hasAttribute(divA, 'id'), true);
       });
 
       test('returns true for a doubly set attribute', () => {
         const divB = (((doc.childNodes[1] as Element).childNodes[1] as Element)
                           .childNodes[0] as Element)
-                         .childNodes[1];
+                         .childNodes[1] as Element;
         assert.equal(dom5.hasAttribute(divB, 'bar'), true);
       });
 
       test('returns true for attribute with no value', () => {
         const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
-                         .childNodes[0];
+                         .childNodes[0] as Element;
         assert.equal(dom5.hasAttribute(divA, 'qux'), true);
       });
     });
@@ -103,14 +103,14 @@ suite('dom5', () => {
     suite('setAttribute', () => {
       test('sets a non-set attribute', () => {
         const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
-                         .childNodes[0];
+                         .childNodes[0] as Element;
         dom5.setAttribute(divA, 'foo', 'bar');
         assert.equal(dom5.getAttribute(divA, 'foo'), 'bar');
       });
 
       test('sets and already set attribute', () => {
         const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
-                         .childNodes[0];
+                         .childNodes[0] as Element;
         dom5.setAttribute(divA, 'id', 'qux');
         assert.equal(dom5.getAttribute(divA, 'id'), 'qux');
       });
@@ -118,7 +118,7 @@ suite('dom5', () => {
       test('sets the first value for a doubly set attribute', () => {
         const divB = (((doc.childNodes[1] as Element).childNodes[1] as Element)
                           .childNodes[0] as Element)
-                         .childNodes[1];
+                         .childNodes[1] as Element;
         dom5.setAttribute(divB, 'bar', 'baz');
         assert.equal(dom5.getAttribute(divB, 'bar'), 'baz');
       });
@@ -126,7 +126,7 @@ suite('dom5', () => {
       test('throws when called on a text node', () => {
         const text = (((doc.childNodes[1] as Element).childNodes[1] as Element)
                           .childNodes[0] as Element)
-                         .childNodes[0];
+                         .childNodes[0] as Element;
         assert.throws(() => {
           dom5.setAttribute(text, 'bar', 'baz');
         });
@@ -136,7 +136,7 @@ suite('dom5', () => {
     suite('removeAttribute', () => {
       test('removes a set attribute', () => {
         const divA = ((doc.childNodes[1] as Element).childNodes[1] as Element)
-                         .childNodes[0];
+                         .childNodes[0] as Element;
         dom5.removeAttribute(divA, 'foo');
         assert.equal(dom5.getAttribute(divA, 'foo'), null);
       });
@@ -145,7 +145,7 @@ suite('dom5', () => {
           'does not throw when called on a node without that attribute', () => {
             const divA =
                 ((doc.childNodes[1] as Element).childNodes[1] as Element)
-                    .childNodes[0];
+                    .childNodes[0] as Element;
             assert.doesNotThrow(() => {
               dom5.removeAttribute(divA, 'ZZZ');
             });
@@ -153,7 +153,7 @@ suite('dom5', () => {
     });
 
     suite('getTextContent', () => {
-      let body: ParentNode;
+      let body: Element;
 
       suiteSetup(() => {
         body = (doc.childNodes[1] as Element).childNodes[1] as Element;
@@ -599,8 +599,6 @@ suite('dom5', () => {
                  .childNodes[0]));  // c
     });
   });
-
-
 
   suite('Constructors', () => {
     test('text node', () => {

--- a/packages/dom5/src/test/iteration_test.ts
+++ b/packages/dom5/src/test/iteration_test.ts
@@ -11,15 +11,9 @@
 
 import {assert} from 'chai';
 import * as fs from 'fs';
-import {
-  parse,
-  DefaultTreeNode as Node,
-  DefaultTreeParentNode as ParentNode,
-  DefaultTreeDocument as Document,
-  DefaultTreeTextNode as TextNode,
-  serialize
-} from 'parse5';
-import * as treeAdapter from 'parse5/lib/tree-adapters/default';
+import {Document, Element, Node, ParentNode, parse, serialize, TextNode} from 'parse5';
+
+import treeAdapter = require('parse5/lib/tree-adapters/default');
 import * as path from 'path';
 
 import * as dom5 from '../index-next';
@@ -47,16 +41,15 @@ suite('iteration', () => {
   let doc: Document;
 
   setup(() => {
-    doc = parse(docText) as Document;
+    doc = parse(docText);
   });
 
   test('ancestors', () => {
     // doc -> dom-module -> div -> a
-    const anchor =
-        ((((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-              .childNodes![0] as ParentNode)
-             .childNodes![3] as ParentNode)
-            .childNodes![1];
+    const anchor = ((((doc.childNodes[1] as Element).childNodes[1] as Element)
+                         .childNodes[0] as Element)
+                        .childNodes[3] as Element)
+                       .childNodes[1] as Element;
 
     assert(dom5.predicates.hasTagName('a')(anchor));
     const domModule = [...dom5.ancestors(anchor)].filter(
@@ -70,23 +63,23 @@ suite('iteration', () => {
   test('depthFirst can be filtered down to one node', () => {
     // doc -> body -> dom-module -> template
     const template =
-        (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-             .childNodes![0] as ParentNode)
-            .childNodes![1];
+        (((doc.childNodes[1] as Element).childNodes[1] as Element)
+             .childNodes[0] as Element)
+            .childNodes[1] as Element;
     const templateContent = treeAdapter.getTemplateContent(template);
 
     const textNode = dom5.predicates.AND(
         dom5.isTextNode, dom5.predicates.hasTextValue('\nsample element\n'));
 
     // 'sample element' text node
-    let expected = templateContent.childNodes![4];
+    let expected = templateContent.childNodes[4];
     let actual =
         [...dom5.depthFirst(doc, dom5.childNodesIncludeTemplate)].filter(
             textNode)[0];
     assert.equal(actual, expected);
 
     // <!-- comment node -->
-    expected = templateContent.childNodes![5];
+    expected = templateContent.childNodes[5];
     actual =
         [...dom5.depthFirst(template, dom5.childNodesIncludeTemplate)].filter(
             dom5.isCommentNode)[0];
@@ -98,9 +91,8 @@ suite('iteration', () => {
         dom5.predicates.hasTagName('link'),
         dom5.predicates.hasAttrValue('rel', 'import'),
         dom5.predicates.hasAttr('href'));
-    const expected =
-        ((doc.childNodes![1] as ParentNode).childNodes![0] as ParentNode)
-            .childNodes![0];
+    const expected = ((doc.childNodes[1] as Element).childNodes[0] as Element)
+                         .childNodes[0] as Element;
     const actual = dom5.query(doc, fn);
     assert.equal(actual, expected);
   });
@@ -131,15 +123,15 @@ suite('iteration', () => {
 
     // doc -> body -> dom-module -> template
     const template =
-        (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-             .childNodes![0] as ParentNode)
-            .childNodes![1];
+        (((doc.childNodes[1] as Element).childNodes[1] as Element)
+             .childNodes[0] as Element)
+            .childNodes[1] as Element;
     const templateContent = treeAdapter.getTemplateContent(template);
 
     // img
-    const expected_1 = templateContent.childNodes![1];
+    const expected_1 = templateContent.childNodes[1];
     // anchor
-    const expected_2 = templateContent.childNodes![3];
+    const expected_2 = templateContent.childNodes[3];
     const actual = [...dom5.queryAll(doc, fn, dom5.childNodesIncludeTemplate)];
 
     assert.equal(actual.length, 3);
@@ -153,7 +145,7 @@ suite('iteration', () => {
     let doc: Document;
 
     setup(() => {
-      doc = parse(docText) as Document;
+      doc = parse(docText);
     });
 
     test('prior', () => {

--- a/packages/dom5/src/test/iteration_test.ts
+++ b/packages/dom5/src/test/iteration_test.ts
@@ -47,16 +47,16 @@ suite('iteration', () => {
   let doc: Document;
 
   setup(() => {
-    doc = parse(docText);
+    doc = parse(docText) as Document;
   });
 
   test('ancestors', () => {
     // doc -> dom-module -> div -> a
-    const anchor = ((((doc.childNodes![1] as ParentNode)
-                       .childNodes![1] as ParentNode)
-                       .childNodes![0] as ParentNode)
-                       .childNodes![3] as ParentNode)
-                       .childNodes![1];
+    const anchor =
+        ((((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+              .childNodes![0] as ParentNode)
+             .childNodes![3] as ParentNode)
+            .childNodes![1];
 
     assert(dom5.predicates.hasTagName('a')(anchor));
     const domModule = [...dom5.ancestors(anchor)].filter(
@@ -70,12 +70,10 @@ suite('iteration', () => {
   test('depthFirst can be filtered down to one node', () => {
     // doc -> body -> dom-module -> template
     const template =
-        (((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0] as ParentNode)
-          .childNodes![1];
-    const templateContent =
-        treeAdapter.getTemplateContent(template);
+        (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+             .childNodes![0] as ParentNode)
+            .childNodes![1];
+    const templateContent = treeAdapter.getTemplateContent(template);
 
     const textNode = dom5.predicates.AND(
         dom5.isTextNode, dom5.predicates.hasTextValue('\nsample element\n'));
@@ -100,9 +98,9 @@ suite('iteration', () => {
         dom5.predicates.hasTagName('link'),
         dom5.predicates.hasAttrValue('rel', 'import'),
         dom5.predicates.hasAttr('href'));
-    const expected = ((doc.childNodes![1] as ParentNode)
-      .childNodes![0] as ParentNode)
-      .childNodes![0];
+    const expected =
+        ((doc.childNodes![1] as ParentNode).childNodes![0] as ParentNode)
+            .childNodes![0];
     const actual = dom5.query(doc, fn);
     assert.equal(actual, expected);
   });
@@ -133,12 +131,10 @@ suite('iteration', () => {
 
     // doc -> body -> dom-module -> template
     const template =
-        (((doc.childNodes![1] as ParentNode)
-          .childNodes![1] as ParentNode)
-          .childNodes![0] as ParentNode)
-          .childNodes![1];
-    const templateContent =
-        treeAdapter.getTemplateContent(template);
+        (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+             .childNodes![0] as ParentNode)
+            .childNodes![1];
+    const templateContent = treeAdapter.getTemplateContent(template);
 
     // img
     const expected_1 = templateContent.childNodes![1];
@@ -157,7 +153,7 @@ suite('iteration', () => {
     let doc: Document;
 
     setup(() => {
-      doc = parse5.parse(docText);
+      doc = parse(docText) as Document;
     });
 
     test('prior', () => {

--- a/packages/dom5/src/test/walking_test.ts
+++ b/packages/dom5/src/test/walking_test.ts
@@ -11,18 +11,12 @@
 
 import {assert} from 'chai';
 import * as fs from 'fs';
-import {
-  DefaultTreeNode as Node,
-  DefaultTreeTextNode as TextNode,
-  DefaultTreeParentNode as ParentNode,
-  DefaultTreeDocument as Document,
-  parse,
-  serialize
-} from 'parse5';
+import {Document, Element, Node, ParentNode, parse, serialize, TextNode} from 'parse5';
 import * as treeAdapter from 'parse5/lib/tree-adapters/default';
 import * as path from 'path';
 
 import * as dom5 from '../index';
+
 import {fixturesDir} from './utils';
 
 /// <reference path="mocha" />
@@ -52,11 +46,10 @@ suite('walking', () => {
 
   test('nodeWalkAncestors', () => {
     // doc -> dom-module -> div -> a
-    const anchor =
-        ((((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-              .childNodes![0] as ParentNode)
-             .childNodes![3] as ParentNode)
-            .childNodes![1];
+    const anchor = ((((doc.childNodes![1] as Element).childNodes![1] as Element)
+                         .childNodes![0] as Element)
+                        .childNodes![3] as Element)
+                       .childNodes![1] as Element;
 
     assert(dom5.predicates.hasTagName('a')(anchor));
     const domModule = dom5.nodeWalkAncestors(
@@ -70,9 +63,9 @@ suite('walking', () => {
   test('nodeWalk', () => {
     // doc -> body -> dom-module -> template
     const template =
-        (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-             .childNodes![0] as ParentNode)
-            .childNodes![1];
+        (((doc.childNodes![1] as Element).childNodes![1] as Element)
+             .childNodes![0] as Element)
+            .childNodes![1] as Element;
     const templateContent = treeAdapter.getTemplateContent(template);
 
     const textNode = dom5.predicates.AND(
@@ -95,9 +88,8 @@ suite('walking', () => {
         dom5.predicates.hasTagName('link'),
         dom5.predicates.hasAttrValue('rel', 'import'),
         dom5.predicates.hasAttr('href'));
-    const expected =
-        ((doc.childNodes![1] as ParentNode).childNodes![0] as ParentNode)
-            .childNodes![0];
+    const expected = ((doc.childNodes![1] as Element).childNodes![0] as Element)
+                         .childNodes![0] as Element;
     const actual = dom5.query(doc, fn);
     assert.equal(actual, expected);
   });
@@ -128,9 +120,9 @@ suite('walking', () => {
 
     // doc -> body -> dom-module -> template
     const template =
-        (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
-             .childNodes![0] as ParentNode)
-            .childNodes![1];
+        (((doc.childNodes![1] as Element).childNodes![1] as Element)
+             .childNodes![0] as Element)
+            .childNodes![1] as Element;
     const templateContent = treeAdapter.getTemplateContent(template);
 
     // img

--- a/packages/dom5/src/test/walking_test.ts
+++ b/packages/dom5/src/test/walking_test.ts
@@ -147,7 +147,7 @@ suite('walking', () => {
     test('nodeWalkAllPrior', () => {
       const domModule = dom5.nodeWalkAll(
           doc, dom5.predicates.hasAttrValue('id', 'test-element'))[0];
-      const comments = dom5.nodeWalkAllPrior(domModule, dom5.isCommentNode);
+      const comments = dom5.nodeWalkAllPrior(domModule as Element, dom5.isCommentNode);
       assert.include(dom5.getTextContent(comments[0]), 'test element');
       assert.include(
           dom5.getTextContent(comments[1]), 'hash or path based routing');

--- a/packages/dom5/src/test/walking_test.ts
+++ b/packages/dom5/src/test/walking_test.ts
@@ -11,7 +11,15 @@
 
 import {assert} from 'chai';
 import * as fs from 'fs';
-import * as parse5 from 'parse5';
+import {
+  DefaultTreeNode as Node,
+  DefaultTreeTextNode as TextNode,
+  DefaultTreeParentNode as ParentNode,
+  DefaultTreeDocument as Document,
+  parse,
+  serialize
+} from 'parse5';
+import * as treeAdapter from 'parse5/lib/tree-adapters/default';
 import * as path from 'path';
 
 import * as dom5 from '../index';
@@ -36,18 +44,18 @@ suite('walking', () => {
 </dom-module>
 <script>Polymer({is: "my-el"})</script>
 `.replace(/  /g, '');
-  let doc: parse5.ASTNode;
+  let doc: Document;
 
   setup(() => {
-    doc = parse5.parse(docText);
+    doc = parse(docText);
   });
 
   test('nodeWalkAncestors', () => {
     // doc -> dom-module -> div -> a
-    const anchor = doc.childNodes![1]
-                       .childNodes![1]
-                       .childNodes![0]
-                       .childNodes![3]
+    const anchor = ((((doc.childNodes![1] as ParentNode)
+                       .childNodes![1] as ParentNode)
+                       .childNodes![0] as ParentNode)
+                       .childNodes![3] as ParentNode)
                        .childNodes![1];
 
     assert(dom5.predicates.hasTagName('a')(anchor));
@@ -62,9 +70,12 @@ suite('walking', () => {
   test('nodeWalk', () => {
     // doc -> body -> dom-module -> template
     const template =
-        doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+      (((doc.childNodes![1] as ParentNode)
+        .childNodes![1] as ParentNode)
+        .childNodes![0] as ParentNode)
+        .childNodes![1];
     const templateContent =
-        parse5.treeAdapters.default.getTemplateContent(template);
+        treeAdapter.getTemplateContent(template);
 
     const textNode = dom5.predicates.AND(
         dom5.isTextNode, dom5.predicates.hasTextValue('\nsample element\n'));
@@ -86,18 +97,20 @@ suite('walking', () => {
         dom5.predicates.hasTagName('link'),
         dom5.predicates.hasAttrValue('rel', 'import'),
         dom5.predicates.hasAttr('href'));
-    const expected = doc.childNodes![1].childNodes![0].childNodes![0];
+    const expected = ((doc.childNodes![1] as ParentNode)
+      .childNodes![0] as ParentNode)
+      .childNodes![0];
     const actual = dom5.query(doc, fn);
     assert.equal(actual, expected);
   });
 
   test('nodeWalkAll', () => {
     const empty = dom5.predicates.AND(dom5.isTextNode, function(node) {
-      return !/\S/.test(node.value!);
+      return !/\S/.test((node as TextNode).value!);
     });
 
     // serialize to count for inserted <head> and <body>
-    const serializedDoc = parse5.serialize(doc);
+    const serializedDoc = serialize(doc);
     // subtract one to get "gap" number
     const expected = serializedDoc.split('\n').length - 1;
     // add two for normalized text node "\nsample text\n"
@@ -117,9 +130,12 @@ suite('walking', () => {
 
     // doc -> body -> dom-module -> template
     const template =
-        doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+      (((doc.childNodes![1] as ParentNode)
+        .childNodes![1] as ParentNode)
+        .childNodes![0] as ParentNode)
+        .childNodes![1];
     const templateContent =
-        parse5.treeAdapters.default.getTemplateContent(template);
+        treeAdapter.getTemplateContent(template);
 
     // img
     const expected_1 = templateContent.childNodes![1];
@@ -134,10 +150,10 @@ suite('walking', () => {
   suite('NodeWalkAllPrior', () => {
     const docText = fs.readFileSync(
         path.join(fixturesDir, 'multiple-comments.html'), 'utf8');
-    let doc: parse5.ASTNode;
+    let doc: Document;
 
     setup(() => {
-      doc = parse5.parse(docText);
+      doc = parse(docText);
     });
 
     test('nodeWalkAllPrior', () => {

--- a/packages/dom5/src/test/walking_test.ts
+++ b/packages/dom5/src/test/walking_test.ts
@@ -47,16 +47,16 @@ suite('walking', () => {
   let doc: Document;
 
   setup(() => {
-    doc = parse(docText);
+    doc = parse(docText) as Document;
   });
 
   test('nodeWalkAncestors', () => {
     // doc -> dom-module -> div -> a
-    const anchor = ((((doc.childNodes![1] as ParentNode)
-                       .childNodes![1] as ParentNode)
-                       .childNodes![0] as ParentNode)
-                       .childNodes![3] as ParentNode)
-                       .childNodes![1];
+    const anchor =
+        ((((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+              .childNodes![0] as ParentNode)
+             .childNodes![3] as ParentNode)
+            .childNodes![1];
 
     assert(dom5.predicates.hasTagName('a')(anchor));
     const domModule = dom5.nodeWalkAncestors(
@@ -70,12 +70,10 @@ suite('walking', () => {
   test('nodeWalk', () => {
     // doc -> body -> dom-module -> template
     const template =
-      (((doc.childNodes![1] as ParentNode)
-        .childNodes![1] as ParentNode)
-        .childNodes![0] as ParentNode)
-        .childNodes![1];
-    const templateContent =
-        treeAdapter.getTemplateContent(template);
+        (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+             .childNodes![0] as ParentNode)
+            .childNodes![1];
+    const templateContent = treeAdapter.getTemplateContent(template);
 
     const textNode = dom5.predicates.AND(
         dom5.isTextNode, dom5.predicates.hasTextValue('\nsample element\n'));
@@ -97,9 +95,9 @@ suite('walking', () => {
         dom5.predicates.hasTagName('link'),
         dom5.predicates.hasAttrValue('rel', 'import'),
         dom5.predicates.hasAttr('href'));
-    const expected = ((doc.childNodes![1] as ParentNode)
-      .childNodes![0] as ParentNode)
-      .childNodes![0];
+    const expected =
+        ((doc.childNodes![1] as ParentNode).childNodes![0] as ParentNode)
+            .childNodes![0];
     const actual = dom5.query(doc, fn);
     assert.equal(actual, expected);
   });
@@ -130,12 +128,10 @@ suite('walking', () => {
 
     // doc -> body -> dom-module -> template
     const template =
-      (((doc.childNodes![1] as ParentNode)
-        .childNodes![1] as ParentNode)
-        .childNodes![0] as ParentNode)
-        .childNodes![1];
-    const templateContent =
-        treeAdapter.getTemplateContent(template);
+        (((doc.childNodes![1] as ParentNode).childNodes![1] as ParentNode)
+             .childNodes![0] as ParentNode)
+            .childNodes![1];
+    const templateContent = treeAdapter.getTemplateContent(template);
 
     // img
     const expected_1 = templateContent.childNodes![1];
@@ -153,7 +149,7 @@ suite('walking', () => {
     let doc: Document;
 
     setup(() => {
-      doc = parse(docText);
+      doc = parse(docText) as Document;
     });
 
     test('nodeWalkAllPrior', () => {

--- a/packages/dom5/src/util.ts
+++ b/packages/dom5/src/util.ts
@@ -12,8 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {DefaultTreeNode as Node, DefaultTreeParentNode as ParentNode} from 'parse5';
-import * as treeAdapter from 'parse5/lib/tree-adapters/default';
+import {Element, Node, ParentNode} from 'parse5';
+
+import treeAdapter = require('parse5/lib/tree-adapters/default');
 
 import {constructors} from './modification';
 import {isCommentNode, isDocument, isDocumentFragment, isElement, isParentNode, isTextNode} from './predicates';
@@ -75,7 +76,7 @@ export function hasAttribute(element: Node, name: string): boolean {
 
 export function setAttribute(element: Node, name: string, value: string) {
   if (!isElement(element)) {
-    return;
+    throw new Error('Only elements support attributes.');
   }
   const i = getAttributeIndex(element, name);
   if (i > -1) {
@@ -176,7 +177,7 @@ export const defaultChildNodes = function defaultChildNodes(node: ParentNode) {
 export const childNodesIncludeTemplate = function childNodesIncludeTemplate(
     node: ParentNode) {
   if (node.nodeName === 'template') {
-    return treeAdapter.getTemplateContent(node).childNodes;
+    return treeAdapter.getTemplateContent(node as Element).childNodes;
   }
 
   return node.childNodes;

--- a/packages/dom5/src/util.ts
+++ b/packages/dom5/src/util.ts
@@ -16,7 +16,7 @@ import {DefaultTreeNode as Node, DefaultTreeParentNode as ParentNode} from 'pars
 import * as treeAdapter from 'parse5/lib/tree-adapters/default';
 
 import {constructors} from './modification';
-import {isParentNode, isCommentNode, isDocument, isDocumentFragment, isElement, isTextNode} from './predicates';
+import {isCommentNode, isDocument, isDocumentFragment, isElement, isParentNode, isTextNode} from './predicates';
 import {nodeWalkAll} from './walking';
 
 export {Node};

--- a/packages/dom5/src/util.ts
+++ b/packages/dom5/src/util.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Element, Node, ParentNode} from 'parse5';
+import {ChildNode, Element, Node, ParentNode} from 'parse5';
 
 import treeAdapter = require('parse5/lib/tree-adapters/default');
 
@@ -41,10 +41,7 @@ export function getTextContent(node: Node): string {
 /**
  * @returns The string value of attribute `name`, or `null`.
  */
-export function getAttribute(element: Node, name: string): string|null {
-  if (!isElement(element)) {
-    return null;
-  }
+export function getAttribute(element: Element, name: string): string|null {
   const i = getAttributeIndex(element, name);
   if (i > -1) {
     return element.attrs[i].value;
@@ -52,8 +49,8 @@ export function getAttribute(element: Node, name: string): string|null {
   return null;
 }
 
-export function getAttributeIndex(element: Node, name: string): number {
-  if (!isElement(element) || !element.attrs) {
+export function getAttributeIndex(element: Element, name: string): number {
+  if (!element.attrs) {
     return -1;
   }
   const n = name.toLowerCase();
@@ -68,16 +65,13 @@ export function getAttributeIndex(element: Node, name: string): number {
 /**
  * @returns `true` iff [element] has the attribute [name], `false` otherwise.
  */
-export function hasAttribute(element: Node, name: string): boolean {
+export function hasAttribute(element: Element, name: string): boolean {
   return getAttributeIndex(element, name) !== -1;
 }
 
 
 
-export function setAttribute(element: Node, name: string, value: string) {
-  if (!isElement(element)) {
-    throw new Error('Only elements support attributes.');
-  }
+export function setAttribute(element: Element, name: string, value: string) {
   const i = getAttributeIndex(element, name);
   if (i > -1) {
     element.attrs[i].value = value;
@@ -86,20 +80,14 @@ export function setAttribute(element: Node, name: string, value: string) {
   }
 }
 
-export function removeAttribute(element: Node, name: string) {
-  if (!isElement(element)) {
-    return;
-  }
+export function removeAttribute(element: Element, name: string) {
   const i = getAttributeIndex(element, name);
   if (i > -1) {
     element.attrs.splice(i, 1);
   }
 }
 
-function collapseTextRange(parent: Node, start: number, end: number) {
-  if (!isParentNode(parent)) {
-    return;
-  }
+function collapseTextRange(parent: ParentNode, start: number, end: number) {
   let text = '';
   for (let i = start; i <= end; i++) {
     text += getTextContent(parent.childNodes[i]);
@@ -168,19 +156,16 @@ export function setTextContent(node: Node, value: string) {
   }
 }
 
-export type GetChildNodes = ((node: Node) => Node[]|undefined);
+export type GetChildNodes = ((node: ParentNode) => ChildNode[]|undefined);
 
 export const defaultChildNodes = function defaultChildNodes(node: ParentNode) {
   return node.childNodes;
 };
 
 export const childNodesIncludeTemplate = function childNodesIncludeTemplate(
-    node: Node) {
-  if (!isParentNode(node)) {
-    return [];
-  }
-  if (node.nodeName === 'template') {
-    return treeAdapter.getTemplateContent(node as Element).childNodes;
+    node: ParentNode) {
+  if (isElement(node) && node.nodeName === 'template') {
+    return treeAdapter.getTemplateContent(node).childNodes;
   }
 
   return node.childNodes;

--- a/packages/dom5/src/util.ts
+++ b/packages/dom5/src/util.ts
@@ -97,7 +97,7 @@ export function removeAttribute(element: Node, name: string) {
 }
 
 function collapseTextRange(parent: Node, start: number, end: number) {
-  if (!isParentNode(parent) || !parent.childNodes) {
+  if (!isParentNode(parent)) {
     return;
   }
   let text = '';
@@ -175,7 +175,10 @@ export const defaultChildNodes = function defaultChildNodes(node: ParentNode) {
 };
 
 export const childNodesIncludeTemplate = function childNodesIncludeTemplate(
-    node: ParentNode) {
+    node: Node) {
+  if (!isParentNode(node)) {
+    return [];
+  }
   if (node.nodeName === 'template') {
     return treeAdapter.getTemplateContent(node as Element).childNodes;
   }

--- a/packages/dom5/src/walking.ts
+++ b/packages/dom5/src/walking.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {DefaultTreeNode as Node} from 'parse5';
+import {Node} from 'parse5';
 
 import * as iteration from './iteration';
 import {isElement, Predicate, predicates as p} from './predicates';

--- a/packages/dom5/src/walking.ts
+++ b/packages/dom5/src/walking.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Node} from 'parse5';
+import {ParentNode, ChildNode, Node} from 'parse5';
 
 import * as iteration from './iteration';
 import {isElement, Predicate, predicates as p} from './predicates';
@@ -24,7 +24,7 @@ export {Node};
  * Applies `mapfn` to `node` and the tree below `node`, returning a flattened
  * list of results.
  */
-export function treeMap<U>(node: Node, mapfn: (node: Node) => U[]): U[] {
+export function treeMap<U>(node: ParentNode, mapfn: (node: Node) => U[]): U[] {
   return Array.from(iteration.treeMap(node, mapfn));
 }
 
@@ -80,7 +80,7 @@ export function nodeWalkAll(
  * Nodes are searched in reverse document order, starting from the sibling
  * prior to `node`.
  */
-export function nodeWalkPrior(node: Node, predicate: Predicate): Node|
+export function nodeWalkPrior(node: ChildNode, predicate: Predicate): Node|
     undefined {
   const result = find(iteration.prior(node), predicate);
   if (result === null) {
@@ -89,7 +89,7 @@ export function nodeWalkPrior(node: Node, predicate: Predicate): Node|
   return result;
 }
 
-function* iteratePriorIncludingNode(node: Node) {
+function* iteratePriorIncludingNode(node: ChildNode) {
   yield node;
   yield* iteration.prior(node);
 }
@@ -101,7 +101,7 @@ function* iteratePriorIncludingNode(node: Node) {
  * Nodes are returned in reverse document order, starting from `node`.
  */
 export function nodeWalkAllPrior(
-    node: Node, predicate: Predicate, matches?: Node[]): Node[] {
+    node: ChildNode, predicate: Predicate, matches?: Node[]): Node[] {
   return filter(iteratePriorIncludingNode(node), predicate, matches);
 }
 
@@ -110,7 +110,7 @@ export function nodeWalkAllPrior(
  * the root of the tree.  Return the first ancestor that matches the given
  * predicate.
  */
-export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|
+export function nodeWalkAncestors(node: ChildNode, predicate: Predicate): Node|
     undefined {
   const result = find(iteration.ancestors(node), predicate);
   if (result === null) {
@@ -123,7 +123,7 @@ export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|
  * Equivalent to `nodeWalk`, but only matches elements
  */
 export function query(
-    node: Node,
+    node: ParentNode,
     predicate: Predicate,
     getChildNodes: GetChildNodes = defaultChildNodes): Node|null {
   const elementPredicate = p.AND(isElement, predicate);
@@ -134,7 +134,7 @@ export function query(
  * Equivalent to `nodeWalkAll`, but only matches elements
  */
 export function queryAll(
-    node: Node,
+    node: ParentNode,
     predicate: Predicate,
     matches?: Node[],
     getChildNodes: GetChildNodes = defaultChildNodes): Node[] {

--- a/packages/dom5/src/walking.ts
+++ b/packages/dom5/src/walking.ts
@@ -12,13 +12,13 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {ASTNode as Node} from 'parse5';
+import {DefaultTreeNode as Node} from 'parse5';
 
 import * as iteration from './iteration';
 import {isElement, Predicate, predicates as p} from './predicates';
 import {defaultChildNodes, GetChildNodes} from './util';
 
-export {ASTNode as Node} from 'parse5';
+export {Node};
 
 /**
  * Applies `mapfn` to `node` and the tree below `node`, returning a flattened


### PR DESCRIPTION
This is a fairly big change because parse5's types are pretty terrible. im trying to fix that in definitelytyped but it'll take time, so meanwhile i import all the default interfaces here as what they should be (e.g. `DefaultTreeNode` as `Node`).

cc @aomarks 