### PR TITLE
Use https instead of git URL

### DIFF
--- a/packages/wct-local/CHANGELOG.md
+++ b/packages/wct-local/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ## Unreleased -->
 <!-- Add unreleased changes here. -->
 
+## Unreleased
+- Use an https URL rather than a git URL for launchpad, hopefully that will be more compatible with https://github.blog/2021-09-01-improving-git-protocol-security-github/
+
 ## [v2.1.6] - 2022-01-06
 - Pin to a version of launchpad without CVE-2021-23330
 

--- a/packages/wct-local/package-lock.json
+++ b/packages/wct-local/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wct-local",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wct-local",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -17,7 +17,7 @@
         "chalk": "^2.3.0",
         "cleankill": "^2.0.0",
         "freeport": "^1.0.4",
-        "launchpad": "git://github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
+        "launchpad": "git+https://github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
         "selenium-standalone": "^6.7.0",
         "which": "^1.0.8"
       },
@@ -1645,7 +1645,7 @@
     "launchpad": {
       "version": "git+ssh://git@github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
       "integrity": "sha512-Lq9bGGzR8AG4IQPAebarL+HB9C/psd3EnhPiunkkAauI/nRPksNrnhrIqxOjOY7pr/J4oDt2nnEnL6GIcJsngg==",
-      "from": "launchpad@git://github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
+      "from": "launchpad@git+https://github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
       "requires": {
         "async": "^2.0.1",
         "browserstack": "^1.2.0",

--- a/packages/wct-local/package-lock.json
+++ b/packages/wct-local/package-lock.json
@@ -17,7 +17,7 @@
         "chalk": "^2.3.0",
         "cleankill": "^2.0.0",
         "freeport": "^1.0.4",
-        "launchpad": "git+https://github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
+        "launchpad": "git+https://github.com/web-padawan/launchpad.git#fdd994d089572e2c2152d70cc74abf497d08d5b7",
         "selenium-standalone": "^6.7.0",
         "which": "^1.0.8"
       },
@@ -621,8 +621,8 @@
     },
     "node_modules/launchpad": {
       "version": "0.7.5",
-      "resolved": "git+ssh://git@github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
-      "integrity": "sha512-Lq9bGGzR8AG4IQPAebarL+HB9C/psd3EnhPiunkkAauI/nRPksNrnhrIqxOjOY7pr/J4oDt2nnEnL6GIcJsngg==",
+      "resolved": "git+ssh://git@github.com/web-padawan/launchpad.git#fdd994d089572e2c2152d70cc74abf497d08d5b7",
+      "integrity": "sha512-urD+xY+lbnIe/TAgAhkjxqGFThMWXjnEIqG0p/Un4/vQEKc5PDrcB6S6kUONzANvnbTPktEnEIK/sJAuq2l6kw==",
       "dependencies": {
         "async": "^2.0.1",
         "browserstack": "^1.2.0",
@@ -1643,9 +1643,9 @@
       }
     },
     "launchpad": {
-      "version": "git+ssh://git@github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
-      "integrity": "sha512-Lq9bGGzR8AG4IQPAebarL+HB9C/psd3EnhPiunkkAauI/nRPksNrnhrIqxOjOY7pr/J4oDt2nnEnL6GIcJsngg==",
-      "from": "launchpad@git+https://github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
+      "version": "git+ssh://git@github.com/web-padawan/launchpad.git#fdd994d089572e2c2152d70cc74abf497d08d5b7",
+      "integrity": "sha512-urD+xY+lbnIe/TAgAhkjxqGFThMWXjnEIqG0p/Un4/vQEKc5PDrcB6S6kUONzANvnbTPktEnEIK/sJAuq2l6kw==",
+      "from": "launchpad@git+https://github.com/web-padawan/launchpad.git#fdd994d089572e2c2152d70cc74abf497d08d5b7",
       "requires": {
         "async": "^2.0.1",
         "browserstack": "^1.2.0",

--- a/packages/wct-local/package.json
+++ b/packages/wct-local/package.json
@@ -56,7 +56,7 @@
     "chalk": "^2.3.0",
     "cleankill": "^2.0.0",
     "freeport": "^1.0.4",
-    "launchpad": "git://github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
+    "launchpad": "git+https://github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
     "selenium-standalone": "^6.7.0",
     "which": "^1.0.8"
   },

--- a/packages/wct-local/package.json
+++ b/packages/wct-local/package.json
@@ -56,7 +56,7 @@
     "chalk": "^2.3.0",
     "cleankill": "^2.0.0",
     "freeport": "^1.0.4",
-    "launchpad": "git+https://github.com/418sec/launchpad.git#de5aca11dc16a8e530195281c77614bdbb08e7be",
+    "launchpad": "git+https://github.com/web-padawan/launchpad.git#fdd994d089572e2c2152d70cc74abf497d08d5b7",
     "selenium-standalone": "^6.7.0",
     "which": "^1.0.8"
   },


### PR DESCRIPTION
HTTPS should always be encrypted, while git might not be, and github no longer supports unencrypted git connections. See https://github.blog/2021-09-01-improving-git-protocol-security-github/